### PR TITLE
fix: set Pages CNAME to www.conduction.nl

### DIFF
--- a/static/CNAME
+++ b/static/CNAME
@@ -1,1 +1,1 @@
-docs.conduction.nl
+www.conduction.nl


### PR DESCRIPTION
## Summary
- `static/CNAME` was set to `docs.conduction.nl` (the old domain). Docusaurus copies it into `build/CNAME`, which gets uploaded as the Pages artifact and overrides the repo's Pages custom-domain setting (`www.conduction.nl`).
- This blocks GitHub from provisioning a Let's Encrypt cert for `www.conduction.nl`.
- Fix: set `static/CNAME` to `www.conduction.nl`. After merge → `main`, the deploy workflow will rebuild and the cert should provision within minutes.

## Test plan
- [ ] After merge to `development`, fast-forward to `main` (or PR `development` → `main`)
- [ ] `Deploy to GitHub Pages` workflow run succeeds on `main`
- [ ] `gh api repos/ConductionNL/conduction-website/pages` shows `https_certificate.state == "approved"` for `www.conduction.nl`
- [ ] `curl https://www.conduction.nl/` returns HTTP/2 200 from `Server: GitHub.com`