### PR TITLE
Release: CNAME fix for www.conduction.nl + accumulated dev

### DIFF
--- a/static/CNAME
+++ b/static/CNAME
@@ -1,1 +1,1 @@
-docs.conduction.nl
+www.conduction.nl


### PR DESCRIPTION
## Summary
- Brings `static/CNAME` fix from #12 onto `main` so `Deploy to GitHub Pages` runs with the correct CNAME (`www.conduction.nl`).
- Also includes any accumulated commits on `development` since `main` last shipped (yesterday).

Without this merge the Pages artifact keeps shipping `CNAME=docs.conduction.nl`, which prevents Let's Encrypt cert issuance for `www.conduction.nl`.

## Test plan
- [ ] After merge, `Deploy to GitHub Pages` workflow run on `main` succeeds
- [ ] `gh api repos/ConductionNL/conduction-website/pages` shows `https_certificate.state == "approved"` for `www.conduction.nl`
- [ ] `https://www.conduction.nl/` returns 200 with valid TLS cert