### PR TITLE
Release www.conduction.nl: design-system takes over the brand

### DIFF
--- a/static/CNAME
+++ b/static/CNAME
@@ -1,1 +1,0 @@
-www.conduction.nl


### PR DESCRIPTION
## Summary

The new Conduction hub site lives in [ConductionNL/design-system](https://github.com/ConductionNL/design-system) under `sites/www/`. It is ready to serve the canonical `conduction.nl`. This PR removes the `static/CNAME` file from this repo so GitHub Pages no longer claims `www.conduction.nl` from `conduction-website`.

## What needs to happen separately at the Cloudflare layer

1. **www → apex redirect**: add a Cloudflare bulk-redirect or page rule that 301-redirects `www.conduction.nl/*` to `conduction.nl/$1`. Most visitors hit `www`; this rule keeps that working while the design-system site serves the canonical apex.
2. **Archive this repo (optional)**: Settings → Archive. History stays readable, no new pushes, custom-domain binding released.

## Merge sequence

Coordinate with the open PRs on `ConductionNL/design-system`:

1. Merge [design-system #4](https://github.com/ConductionNL/design-system/pull/4) (Phase 3 brand-strip)
2. Merge [design-system #5](https://github.com/ConductionNL/design-system/pull/5) (Phase 4 NL translations)
3. **Merge this PR** (releases the `www.conduction.nl` claim from this repo)
4. Merge design-system Phase 5 cutover PR (flips its CNAME to claim `conduction.nl` and adds the Cloudflare Worker)
5. Smoke-test, deploy the Worker per the runbook in design-system

The full sequence is documented at [`design-system/briefs/cutover-runbook.md`](https://github.com/ConductionNL/design-system/blob/phase-5-cutover/briefs/cutover-runbook.md) on the cutover branch.

## Test plan

- [ ] Confirm CI passes (no build needed for a CNAME-only delete)
- [ ] After all merges land, smoke-test:
  - `https://conduction.nl/` shows the new design-system landing
  - `https://www.conduction.nl/` 301-redirects to `https://conduction.nl/`
  - `https://connext.conduction.nl/` 301-redirects to `https://conduction.nl/connext`
  - `https://commonground.conduction.nl/` 301-redirects to `https://conduction.nl/commonground`

🤖 Generated with [Claude Code](https://claude.com/claude-code)