### PR TITLE
fix(workflow): set source-folder=. so deploy finds Docusaurus at repo root

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -11,3 +11,9 @@ jobs:
     uses: ConductionNL/.github/.github/workflows/documentation.yml@main
     with:
       cname: www.conduction.nl
+      # The Docusaurus build for this site lives at the repo root
+      # (not under docs/ like the product-page repos), since this IS
+      # the docs build itself rather than docs alongside an app.
+      # Override the centralized workflow's `source-folder` default
+      # ("docs") to point at the repo root.
+      source-folder: .


### PR DESCRIPTION
Centralized documentation workflow defaults source-folder to 'docs', which fails on this repo (Docusaurus is at root). Pass source-folder='.' to fix. Trivial workflow-only diff.