### PR TITLE
fix(workflow): add 'ci' npm script for centralized deploy workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "clear": "docusaurus clear",
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",
-    "write-heading-ids": "docusaurus write-heading-ids"
+    "write-heading-ids": "docusaurus write-heading-ids",
+    "ci": "npm ci --legacy-peer-deps && npm run build"
   },
   "dependencies": {
     "@conduction/docusaurus-preset": "^1.5.1",
@@ -29,8 +30,16 @@
     "@docusaurus/types": "^3.5.0"
   },
   "browserslist": {
-    "production": [">0.5%", "not dead", "not op_mini all"],
-    "development": ["last 1 chrome version", "last 1 firefox version", "last 1 safari version"]
+    "production": [
+      ">0.5%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
   },
   "engines": {
     "node": ">=18.0"


### PR DESCRIPTION
Centralized documentation workflow runs `npm run ci` (npm ci + build). Add the script. Mirrors the convention every product-page repo follows.