### PR TITLE
chore: bump @conduction/docusaurus-preset to 1.7.0 (footer identity links)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "conduction-website",
       "version": "0.0.0",
       "dependencies": {
-        "@conduction/docusaurus-preset": "^1.5.1",
+        "@conduction/docusaurus-preset": "^1.7.0",
         "@docusaurus/core": "^3.5.0",
         "@docusaurus/preset-classic": "^3.5.0",
         "@mdx-js/react": "^3.0.0",
@@ -1987,9 +1987,9 @@
       }
     },
     "node_modules/@conduction/docusaurus-preset": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-1.6.0.tgz",
-      "integrity": "sha512-y3TSYnmMWc4MgBW0kKZ7uS9gcwo5Z6InSeLKZcALsEXJUI4ev1vw4ADCACmwtnN0ibQH6mXyxmyjrgKicpUwvQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-1.7.0.tgz",
+      "integrity": "sha512-JH7aXaRGZCvkHZTLTLRh3gDWhj/2zAc8S4eBGS67hCfDIwzP5SK+Uj5BidoqbSi0FEEnekEoya2AVVLXbNv/OQ==",
       "license": "EUPL-1.2",
       "peerDependencies": {
         "@docusaurus/core": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "ci": "npm ci --legacy-peer-deps && npm run build"
   },
   "dependencies": {
-    "@conduction/docusaurus-preset": "^1.5.1",
+    "@conduction/docusaurus-preset": "^1.7.0",
     "@docusaurus/core": "^3.5.0",
     "@docusaurus/preset-classic": "^3.5.0",
     "@mdx-js/react": "^3.0.0",


### PR DESCRIPTION
Footer 'Brand book' + 'Diagram set' links now point at identity.conduction.nl (the brand kit's new home). Trivial 2-file diff: package.json + package-lock.json bump.