### PR TITLE
Partner programme: Host / Service / Certified

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "conduction-website",
       "version": "0.0.0",
       "dependencies": {
-        "@conduction/docusaurus-preset": "^1.7.0",
+        "@conduction/docusaurus-preset": "^2.0.0",
         "@docusaurus/core": "^3.5.0",
         "@docusaurus/preset-classic": "^3.5.0",
         "@mdx-js/react": "^3.0.0",
@@ -1987,9 +1987,9 @@
       }
     },
     "node_modules/@conduction/docusaurus-preset": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-1.7.0.tgz",
-      "integrity": "sha512-JH7aXaRGZCvkHZTLTLRh3gDWhj/2zAc8S4eBGS67hCfDIwzP5SK+Uj5BidoqbSi0FEEnekEoya2AVVLXbNv/OQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-2.0.0.tgz",
+      "integrity": "sha512-MMXHRE5kcqpRmvDlAG0+bwPCgMVRK6cihcLR6dxwxN3HHqRtKh9yCc9VJ795k9Es6N5ZWtYlLnXCWzp2ioJEtQ==",
       "license": "EUPL-1.2",
       "peerDependencies": {
         "@docusaurus/core": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "ci": "npm ci --legacy-peer-deps && npm run build"
   },
   "dependencies": {
-    "@conduction/docusaurus-preset": "^1.7.0",
+    "@conduction/docusaurus-preset": "^2.0.0",
     "@docusaurus/core": "^3.5.0",
     "@docusaurus/preset-classic": "^3.5.0",
     "@mdx-js/react": "^3.0.0",

--- a/src/data/partners-catalog.js
+++ b/src/data/partners-catalog.js
@@ -9,9 +9,23 @@
  * apps. Add href when a /partners/<slug> detail page exists. Add
  * logo when we have permission to display it.
  *
- * tier values: 'partner' | 'certified' | 'strategic'.
+ * Tier slugs (low → high):
+ *   - host       Hosts our open-source apps for their customers. May
+ *                resell Nextcloud-supported variants through their
+ *                own channels. No SLA with Conduction. No direct line
+ *                to our support, no input on the roadmap, not eligible
+ *                to respond to public tenders with our products.
+ *   - service    Has an SLA with Conduction. Their team can call us
+ *                directly for third-line support, named contacts,
+ *                input on bug priority and feature requests.
+ *   - certified  Trained and certified by Conduction. Joint roadmap.
+ *                Eligible to respond to public tenders alongside us.
+ *
  * apps:        free-form list of app or service names the partner
  *              ships, used as a facet on /partners.
+ * solutions:   free-form list of solution slugs (matching
+ *              /solutions/<slug>) the partner delivers, used both as
+ *              a facet on /partners and for the reverse lookup below.
  *
  * Summaries stay in Dutch when the partner's market is Dutch — the
  * audience that filters by an MKB hosting partner is the same audience
@@ -22,96 +36,107 @@
 import React from 'react';
 
 export const PARTNERS = [
+  // --------------------------------------------------------------
+  // Certified — top tier, joint roadmap, tender-eligible
+  // --------------------------------------------------------------
   {
     href: '/partners/acato',
-    tier: 'strategic',
+    tier: 'certified',
     name: 'Acato',
     logo: '/img/partners/acato.png',
-    summary: <>Nederlandse open-source specialist uit Almere. Bouwt en host <span className="next-blue">Nextcloud</span>-omgevingen voor gemeenten en zorginstellingen, met focus op AVG-compliance en NLDS. Strategisch partner op hosting, stack-implementatie en gezamenlijke roadmap.</>,
-    apps: ['OpenRegister', 'OpenCatalogi', 'DocuDesk'],
-    solutions: ['woo', 'archief', 'software-catalog'],
+    summary: <>Digital agency uit Almere. Bouwt toegankelijke websites en webapplicaties voor gemeenten en overheidsorganisaties, met focus op WCAG 2.2 AA en NLDS. Levert de Conduction Woo-solution op OpenCatalogi, OpenRegister en OpenConnector.</>,
+    apps: ['OpenCatalogi', 'OpenRegister', 'OpenConnector'],
+    solutions: ['woo'],
   },
+
+  // --------------------------------------------------------------
+  // Service — SLA with Conduction, third-line support
+  // --------------------------------------------------------------
   {
-    tier: 'certified',
+    tier: 'service',
+    name: 'Shift2',
+    logo: '/img/partners/shift2.png',
+    summary: <>Nederlandse softwarebouwer voor gemeenten, waterschappen en provincies, onderdeel van de Conxillium-groep. Levert CMS, burgerzaken en formulieren, en daarnaast de Conduction Woo-solution op OpenCatalogi, OpenRegister en OpenConnector.</>,
+    apps: ['OpenCatalogi', 'OpenRegister', 'OpenConnector'],
+    solutions: ['woo'],
+  },
+
+  // --------------------------------------------------------------
+  // Host — ships our apps, no SLA with Conduction
+  // --------------------------------------------------------------
+  {
+    tier: 'host',
     name: 'Centric',
     logo: '/img/partners/centric.png',
-    summary: <>Eén van Nederlands grootste software-leveranciers voor de publieke sector. Officieel <span className="next-blue">Nextcloud</span>-distributeur. Centric-klanten krijgen Conduction-apps geïntegreerd in hun bestaande Centric-omgeving.</>,
-    apps: ['Nextcloud', 'OpenZaak', 'OpenRegister', 'DocuDesk'],
-    solutions: ['zaakafhandeling', 'archief'],
+    summary: <>Een van Nederlands grootste IT-leveranciers voor gemeenten en de publieke sector. Werkt samen met <span className="next-blue">Nextcloud</span> aan soevereine werkplekken en host DocuDesk binnen dat traject.</>,
+    apps: ['Nextcloud', 'DocuDesk'],
+    solutions: [],
   },
   {
     href: '/partners/procolix',
-    tier: 'certified',
+    tier: 'host',
     name: 'Procolix',
     logo: '/img/partners/procolix.png',
-    summary: <>Nederlandse hoster en leverancier van proces- en zaakmanagement-software. Officieel <span className="next-blue">Nextcloud</span>-distributeur. Certified op DocuDesk en OpenConnector voor procesintegraties bij gemeenten en uitvoeringsorganisaties.</>,
-    apps: ['Nextcloud', 'DocuDesk', 'OpenConnector'],
-    solutions: ['zaakafhandeling', 'archief', 'legacy-erp'],
+    summary: <>Nederlandse managed-<span className="next-blue">Nextcloud</span>-hoster uit Dordrecht. Levert beheerde Nextcloud-omgevingen op eigen EU-infrastructuur, open-source als uitgangspunt.</>,
+    apps: ['Nextcloud'],
+    solutions: [],
   },
   {
-    tier: 'certified',
+    tier: 'host',
     name: 'The Goodcloud',
     logo: '/img/partners/goodcloud.png',
-    summary: <>Nederlandse <span className="next-blue">Nextcloud</span>-hoster voor MKB en non-profits. Officieel Nextcloud-distributeur. Levert beheerde omgevingen met Conduction-apps pre-installed, privacy-eerst hosting in NL.</>,
-    apps: ['Nextcloud', 'OpenRegister', 'MyDash'],
-    solutions: ['mkb-workspace'],
+    summary: <>Nederlandse managed-<span className="next-blue">Nextcloud</span>-hoster. Privacy-eerst, geen tracking, data in Nederland. Voor MKB, non-profits en privacybewuste organisaties.</>,
+    apps: ['Nextcloud'],
+    solutions: [],
   },
   {
-    tier: 'partner',
+    tier: 'host',
     name: 'BCT',
     logo: '/img/partners/bct.png',
-    summary: <>Nederlandse leverancier van document- en zaaksysteem-software voor de overheid. BCT-implementaties praten via OpenConnector met de Conduction-registers.</>,
-    apps: ['OpenConnector', 'DocuDesk', 'OpenZaak'],
-    solutions: ['zaakafhandeling', 'archief', 'legacy-erp'],
+    summary: <>Nederlandse leverancier van informatie- en documentmanagement-software (Corsa, Verix). Levert de Conduction Woo-solution aan organisaties die hun informatie-governance op orde willen krijgen.</>,
+    apps: ['OpenCatalogi', 'OpenRegister', 'OpenConnector'],
+    solutions: ['woo'],
   },
   {
-    tier: 'partner',
+    tier: 'host',
     name: 'Open Gemeenten',
     logo: '/img/partners/open-gemeenten.png',
-    summary: <>Coöperatieve community van gemeenten die samen open-source software ontwikkelen en delen. Levert OpenZaak-implementaties bij aangesloten gemeenten en draagt patches terug naar upstream.</>,
-    apps: ['OpenZaak', 'OpenRegister', 'OpenCatalogi'],
-    solutions: ['zaakafhandeling', 'software-catalog'],
+    summary: <>Open-source platform voor gemeentelijke websites. Bedient ruim 30 gemeenten met toegankelijke sites (WCAG, internet.nl). Levert daarnaast de Conduction Woo-solution.</>,
+    apps: ['OpenCatalogi', 'OpenRegister', 'OpenConnector'],
+    solutions: ['woo'],
   },
   {
-    tier: 'partner',
-    name: 'Exxellence',
+    tier: 'host',
+    name: 'xxllnc',
     logo: '/img/partners/exxellence.png',
-    summary: <>Nederlandse softwarebouwer gespecialiseerd in zaakafhandeling en burger-portaal-toepassingen. Reference-deploys op OpenZaak v4.x bij meerdere middelgrote gemeenten.</>,
-    apps: ['OpenZaak', 'DocuDesk'],
-    solutions: ['zaakafhandeling'],
+    summary: <>Nederlandse leverancier van zaakgericht-werken-software voor gemeenten (xxllnc Zaken, plus apps voor belastingen en het sociaal domein). Levert daarnaast de Conduction Woo-solution.</>,
+    apps: ['OpenCatalogi', 'OpenRegister', 'OpenConnector'],
+    solutions: ['woo'],
   },
   {
     href: '/partners/yard',
-    tier: 'partner',
+    tier: 'host',
     name: 'YARD',
     logo: '/img/partners/yard.png',
-    summary: <>Digital design- en development-bureau uit Utrecht. Ontwerpt en bouwt klantgerichte digitale producten op <span className="next-blue">Nextcloud</span> voor gemeenten en publieke organisaties.</>,
-    apps: ['MyDash', 'OpenCatalogi'],
-    solutions: ['software-catalog', 'mkb-workspace'],
+    summary: <>Digital agency uit Utrecht voor gemeenten, zorg en kennisorganisaties. Open-source-georiënteerd, ruim 80 projecten. Levert de Conduction Woo-solution.</>,
+    apps: ['OpenCatalogi', 'OpenRegister', 'OpenConnector'],
+    solutions: ['woo'],
   },
   {
-    tier: 'partner',
+    tier: 'host',
     name: 'iO',
     logo: '/img/partners/io.webp',
-    summary: <>Internationaal digital agency met Nederlandse vestiging in Amsterdam. Integreert Conduction-apps in bredere klantreis-trajecten voor publieke en semi-publieke organisaties.</>,
-    apps: ['OpenConnector', 'MyDash'],
-    solutions: ['legacy-erp', 'mkb-workspace'],
+    summary: <>Belgisch-Nederlands digital agency met kantoren in Amsterdam en Rotterdam. Bouwt klantgerichte digitale platforms en levert de Conduction Woo-solution aan publieke en semi-publieke organisaties.</>,
+    apps: ['OpenCatalogi', 'OpenRegister', 'OpenConnector'],
+    solutions: ['woo'],
   },
   {
-    tier: 'partner',
-    name: 'Shift2',
-    logo: '/img/partners/shift2.png',
-    summary: <>Nederlands development-bureau gespecialiseerd in <span className="next-blue">Nextcloud</span> en open source. Implementeert Conduction-stacks bij MKB-klanten en gemeenten in midden-Nederland.</>,
-    apps: ['OpenRegister', 'MyDash'],
-    solutions: ['mkb-workspace'],
-  },
-  {
-    tier: 'partner',
+    tier: 'host',
     name: 'Sendent',
     logo: '/img/partners/sendent.png',
-    summary: <>Nederlandse leverancier die Microsoft Outlook en Teams koppelt aan <span className="next-blue">Nextcloud</span>. Levert support op MyDash voor klanten die hun e-mail- en bestandsstroom binnen de eigen Nextcloud-omgeving willen houden.</>,
+    summary: <>Nederlandse leverancier die Microsoft Outlook en Teams koppelt aan <span className="next-blue">Nextcloud</span>. Levert support op MyDash voor klanten die hun mail- en bestandsstroom binnen de eigen Nextcloud-omgeving willen houden.</>,
     apps: ['MyDash'],
-    solutions: ['mkb-workspace'],
+    solutions: [],
   },
 ];
 
@@ -131,6 +156,6 @@ export const BECOME_PARTNER = {
   href: '/support#become-a-partner',
   eyebrow: 'Become a partner',
   title: 'Ship Conduction to your customers.',
-  body: 'Join as Partner, Certified, or Strategic. Conduction trains your team, you handle the rollouts. The apps stay open source, the relationship stays direct.',
+  body: 'Three tiers: Host (ship our apps), Service (SLA + third-line support), Certified (trained, joint roadmap, tender-eligible). The apps stay open source, the relationship stays direct.',
   ctaLabel: 'Apply through Support',
 };

--- a/src/pages/partners/acato.mdx
+++ b/src/pages/partners/acato.mdx
@@ -1,5 +1,5 @@
 ---
-title: Acato, Strategic partner, Conduction
+title: Acato, Certified partner, Conduction
 description: Nederlandse open-source specialist uit Almere. Bouwt en host Nextcloud-omgevingen voor gemeenten en zorginstellingen.
 hide_table_of_contents: true
 ---
@@ -13,7 +13,7 @@ export const ACATO_SOLUTIONS = solutionsBySlugs(ACATO.solutions);
 
 <DetailHero
   crumb={[{label: 'Partners', href: '/partners'}, 'Acato']}
-  status={{label: 'Strategic partner', color: 'var(--c-blue-cobalt)'}}
+  status={{label: 'Certified partner', color: 'var(--c-blue-cobalt)'}}
   version="Founded 2008"
   locales="Almere, NL · 24 employees"
   title="Acato."
@@ -103,18 +103,18 @@ export const ACATO_SOLUTIONS = solutionsBySlugs(ACATO.solutions);
     <PartnerCard
       variant="other"
       href="/partners/yard"
-      tier="partner"
+      tier="host"
       name="YARD"
       logo="/img/partners/yard.png"
-      why="Digital design + development bureau in Utrecht. Strong on MyDash and OpenCatalogi for citizen-facing surfaces."
+      why="Digital agency uit Utrecht voor gemeenten en zorg. Levert de Conduction Woo-solution."
     />
     <PartnerCard
       variant="other"
       href="/partners/procolix"
-      tier="certified"
+      tier="host"
       name="Procolix"
       logo="/img/partners/procolix.png"
-      why="Officieel Nextcloud-distributeur, certified op DocuDesk en OpenConnector. Procesintegraties bij gemeenten."
+      why="Managed Nextcloud-hosting op eigen EU-infrastructuur, open source als uitgangspunt."
     />
   </div>
 </Section>

--- a/src/pages/partners/procolix.mdx
+++ b/src/pages/partners/procolix.mdx
@@ -1,6 +1,6 @@
 ---
-title: Procolix, Certified partner, Conduction
-description: Officieel Nextcloud-distributeur. Certified op DocuDesk en OpenConnector voor procesintegraties bij gemeenten en uitvoeringsorganisaties.
+title: Procolix, Host partner, Conduction
+description: Nederlandse managed-Nextcloud-hoster uit Dordrecht. Levert beheerde Nextcloud-omgevingen op eigen EU-infrastructuur, open source als uitgangspunt.
 hide_table_of_contents: true
 ---
 
@@ -13,11 +13,11 @@ export const PROCOLIX_SOLUTIONS = solutionsBySlugs(PROCOLIX.solutions);
 
 <DetailHero
   crumb={[{label: 'Partners', href: '/partners'}, 'Procolix']}
-  status={{label: 'Certified partner', color: 'var(--c-gold-500)'}}
+  status={{label: 'Host partner', color: 'var(--c-cobalt-100)'}}
   version="Founded 2007"
   locales="Hilversum, NL · 35 employees"
   title="Procolix."
-  tagline={<>Nederlandse hoster en leverancier van proces- en zaakmanagement-software. Officieel <span className="next-blue">Nextcloud</span>-distributeur. Certified op DocuDesk en OpenConnector voor procesintegraties bij gemeenten en uitvoeringsorganisaties.</>}
+  tagline={<>Nederlandse managed-<span className="next-blue">Nextcloud</span>-hoster uit Dordrecht. Levert beheerde Nextcloud-omgevingen op eigen EU-infrastructuur, open source als uitgangspunt. Conduction-apps draaien daar bovenop voor klanten die hosting + apps bij één leverancier willen.</>}
   primaryCta={{label: 'Talk to Procolix', href: 'mailto:hello@procolix.com'}}
   secondaryCta={{label: 'Visit procolix.com', href: 'https://procolix.com'}}
   tertiaryCta={{label: 'All partners', href: '/partners'}}
@@ -101,18 +101,18 @@ export const PROCOLIX_SOLUTIONS = solutionsBySlugs(PROCOLIX.solutions);
     <PartnerCard
       variant="other"
       href="/partners/acato"
-      tier="strategic"
+      tier="certified"
       name="Acato"
       logo="/img/partners/acato.png"
-      why="Strategic partner. Technical Core implementations, gezamenlijke roadmap."
+      why="Certified partner. Joint roadmap, tender-eligible op de Conduction Woo-solution."
     />
     <PartnerCard
       variant="other"
       href="/partners/yard"
-      tier="partner"
+      tier="host"
       name="YARD"
       logo="/img/partners/yard.png"
-      why="Partner. Citizen-facing surfaces, NLDS-conforme front-end op de Conduction-stack."
+      why="Host partner. Digital agency uit Utrecht voor gemeenten en zorg, ship op de Woo-stack."
     />
   </div>
 </Section>

--- a/src/pages/partners/yard.mdx
+++ b/src/pages/partners/yard.mdx
@@ -1,5 +1,5 @@
 ---
-title: YARD, Partner, Conduction
+title: YARD, Host partner, Conduction
 description: Digital design- en development-bureau uit Utrecht. Strong on MyDash and OpenCatalogi for citizen-facing surfaces.
 hide_table_of_contents: true
 ---
@@ -13,7 +13,7 @@ export const YARD_SOLUTIONS = solutionsBySlugs(YARD.solutions);
 
 <DetailHero
   crumb={[{label: 'Partners', href: '/partners'}, 'YARD']}
-  status={{label: 'Partner', color: 'var(--c-cobalt-700)'}}
+  status={{label: 'Host partner', color: 'var(--c-cobalt-100)'}}
   version="Founded 2014"
   locales="Utrecht, NL · 12 employees"
   title="YARD."
@@ -101,18 +101,18 @@ export const YARD_SOLUTIONS = solutionsBySlugs(YARD.solutions);
     <PartnerCard
       variant="other"
       href="/partners/acato"
-      tier="strategic"
+      tier="certified"
       name="Acato"
       logo="/img/partners/acato.png"
-      why="Strategic partner. Technical Core implementations, hosting, lange-termijn beheer."
+      why="Certified partner. Joint roadmap, tender-eligible op de Conduction Woo-solution."
     />
     <PartnerCard
       variant="other"
       href="/partners/procolix"
-      tier="certified"
+      tier="host"
       name="Procolix"
       logo="/img/partners/procolix.png"
-      why="Certified partner. Officieel Nextcloud-distributeur, sterk op DocuDesk en OpenConnector."
+      why="Host partner. Managed Nextcloud-hosting op eigen EU-infrastructuur."
     />
   </div>
 </Section>

--- a/src/pages/support.mdx
+++ b/src/pages/support.mdx
@@ -8,11 +8,11 @@ import {Section, SectionHead, HowSteps, HowStep, Card, Pill, HexBullet, HexNetwo
 import {PARTNERS, BECOME_PARTNER} from '@site/src/data/partners-catalog';
 
 export const TIER_PILL = {
-  partner:   {background: 'var(--c-cobalt-50)', color: 'var(--c-cobalt-700)'},
-  certified: {background: 'var(--c-gold-500)',  color: 'var(--c-cobalt-900)'},
-  strategic: {background: 'white',              color: 'var(--c-blue-cobalt)'},
+  host:      {background: 'var(--c-cobalt-50)', color: 'var(--c-cobalt-700)'},
+  service:   {background: 'var(--c-gold-500)',  color: 'var(--c-cobalt-900)'},
+  certified: {background: 'white',              color: 'var(--c-blue-cobalt)'},
 };
-export const TIER_CARD_STRATEGIC = {
+export const TIER_CARD_CERTIFIED = {
   background: 'var(--c-blue-cobalt)',
   borderColor: 'var(--c-blue-cobalt)',
   color: 'white',
@@ -54,17 +54,17 @@ export const TIER_PILL_BASE = {
     eyebrow="How support works"
     title="Three paths, picked by what you need."
     align="stack"
-    lede="Most teams never need anything beyond the docs. When you do, find a partner. For mission-critical or regulated rollouts, ask for a strategic engagement."
+    lede="Most teams never need anything beyond the docs. When you do, find a partner. For tenders or mission-critical rollouts, work with a Certified partner."
   />
   <HowSteps>
     <HowStep title="Try it yourself.">
       Install from the app store. Read the docs. Ask in the public GitHub Issues or community Discord. Most MKB and pilot users never need anything else, and that stays free, forever.
     </HowStep>
     <HowStep title="Find a partner.">
-      Running Conduction apps in production, or planning to? A partner deploys, configures, and supports the stack for you. Hourly, retainer, or project-based, whatever your contracting team prefers.
+      Running Conduction apps in production, or planning to? A Host or Service partner deploys, configures, and supports the stack for you. Hourly, retainer, or project-based.
     </HowStep>
-    <HowStep title="Strategic engagement.">
-      Mission-critical workloads, multi-app rollouts, or government tenders go through Strategic partners, co-developing with Conduction engineers and shaping the roadmap.
+    <HowStep title="Certified engagement.">
+      Public tenders, multi-app rollouts, and joint roadmap work go through Certified partners. They are trained and audited by us, and may co-respond to tenders with our products.
     </HowStep>
   </HowSteps>
 </Section>
@@ -78,9 +78,9 @@ export const TIER_PILL_BASE = {
   />
   <div style={{display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 24}}>
     <Card padding="lg">
-      <span style={{...TIER_PILL_BASE, ...TIER_PILL.partner}}>Partner</span>
-      <h3 style={{fontSize: 22, fontWeight: 700, margin: '18px 0 12px', color: 'var(--c-cobalt-900)'}}>Implementation, on demand.</h3>
-      <div style={{fontSize: 14, color: 'var(--c-cobalt-700)', lineHeight: 1.6, margin: '0 0 20px'}}>Self-certified on the apps. Installs and configures for one or two clients in a region or sector.</div>
+      <span style={{...TIER_PILL_BASE, ...TIER_PILL.host}}>Host</span>
+      <h3 style={{fontSize: 22, fontWeight: 700, margin: '18px 0 12px', color: 'var(--c-cobalt-900)'}}>Ships our apps to their customers.</h3>
+      <div style={{fontSize: 14, color: 'var(--c-cobalt-700)', lineHeight: 1.6, margin: '0 0 20px'}}>Hosts and resells the open-source apps through their own channels. May offer Nextcloud-supported variants. No SLA with Conduction.</div>
       <ul style={{listStyle: 'none', padding: 0, margin: 0, display: 'flex', flexDirection: 'column', gap: 8, fontSize: 13, color: 'var(--c-cobalt-800)'}}>
         <li><HexBullet size="sm" color="var(--c-mint-500)" /> Public listing in the directory</li>
         <li><HexBullet size="sm" color="var(--c-mint-500)" /> Community Slack access</li>
@@ -88,25 +88,25 @@ export const TIER_PILL_BASE = {
       </ul>
     </Card>
     <Card padding="lg">
-      <span style={{...TIER_PILL_BASE, ...TIER_PILL.certified}}>Certified</span>
-      <h3 style={{fontSize: 22, fontWeight: 700, margin: '18px 0 12px', color: 'var(--c-cobalt-900)'}}>Certified on the apps you ship.</h3>
-      <div style={{fontSize: 14, color: 'var(--c-cobalt-700)', lineHeight: 1.6, margin: '0 0 20px'}}>Conduction-certified per app. Joint go-to-market on tenders. Higher SLA on shared customers.</div>
+      <span style={{...TIER_PILL_BASE, ...TIER_PILL.service}}>Service</span>
+      <h3 style={{fontSize: 22, fontWeight: 700, margin: '18px 0 12px', color: 'var(--c-cobalt-900)'}}>SLA, third-line, named contacts.</h3>
+      <div style={{fontSize: 14, color: 'var(--c-cobalt-700)', lineHeight: 1.6, margin: '0 0 20px'}}>Hosts and ships our apps with an SLA from Conduction. Third-line support from our engineers, named contacts, input on bug priority and feature requests.</div>
       <ul style={{listStyle: 'none', padding: 0, margin: 0, display: 'flex', flexDirection: 'column', gap: 8, fontSize: 13, color: 'var(--c-cobalt-800)'}}>
-        <li><HexBullet size="sm" color="var(--c-mint-500)" /> Everything in Partner</li>
-        <li><HexBullet size="sm" color="var(--c-mint-500)" /> Certified gold avatar</li>
-        <li><HexBullet size="sm" color="var(--c-mint-500)" /> Co-branded case-study slot</li>
-        <li><HexBullet size="sm" color="var(--c-mint-500)" /> Pre-release access (one minor)</li>
+        <li><HexBullet size="sm" color="var(--c-mint-500)" /> Everything in Host</li>
+        <li><HexBullet size="sm" color="var(--c-mint-500)" /> SLA contract with Conduction</li>
+        <li><HexBullet size="sm" color="var(--c-mint-500)" /> Direct line to third-line support</li>
+        <li><HexBullet size="sm" color="var(--c-mint-500)" /> Roadmap and bug-priority input</li>
       </ul>
     </Card>
-    <Card padding="lg" style={TIER_CARD_STRATEGIC}>
-      <span style={{...TIER_PILL_BASE, ...TIER_PILL.strategic}}>Strategic</span>
-      <h3 style={{fontSize: 22, fontWeight: 700, margin: '18px 0 12px', color: 'white'}}>Shared roadmap, shared release.</h3>
-      <div style={{fontSize: 14, color: 'rgba(255,255,255,0.78)', lineHeight: 1.6, margin: '0 0 20px'}}>Conduction's deepest partners. Joint roadmap commitments and shared engineering, by invitation only.</div>
+    <Card padding="lg" style={TIER_CARD_CERTIFIED}>
+      <span style={{...TIER_PILL_BASE, ...TIER_PILL.certified}}>Certified</span>
+      <h3 style={{fontSize: 22, fontWeight: 700, margin: '18px 0 12px', color: 'white'}}>Trained, audited, tender-eligible.</h3>
+      <div style={{fontSize: 14, color: 'rgba(255,255,255,0.78)', lineHeight: 1.6, margin: '0 0 20px'}}>Trained by Conduction, audited annually, on the joint roadmap. Eligible to co-respond to public tenders alongside us.</div>
       <ul style={{listStyle: 'none', padding: 0, margin: 0, display: 'flex', flexDirection: 'column', gap: 8, fontSize: 13, color: 'rgba(255,255,255,0.92)'}}>
-        <li><HexBullet size="sm" color="var(--c-orange-knvb)" /> Everything in Certified</li>
+        <li><HexBullet size="sm" color="var(--c-orange-knvb)" /> Everything in Service</li>
+        <li><HexBullet size="sm" color="var(--c-orange-knvb)" /> Trained + audited certification</li>
         <li><HexBullet size="sm" color="var(--c-orange-knvb)" /> Joint roadmap planning</li>
-        <li><HexBullet size="sm" color="var(--c-orange-knvb)" /> Engineering hours from Conduction</li>
-        <li><HexBullet size="sm" color="var(--c-orange-knvb)" /> Co-sale on government tenders</li>
+        <li><HexBullet size="sm" color="var(--c-orange-knvb)" /> Tender-eligible with our products</li>
       </ul>
     </Card>
   </div>
@@ -251,9 +251,9 @@ export const TIER_PILL_BASE = {
         <label style={{display: 'block'}}>
           <span style={{display: 'block', fontFamily: 'var(--conduction-typography-font-family-code)', fontSize: 11, letterSpacing: '0.06em', textTransform: 'uppercase', color: 'rgba(255,255,255,0.55)', marginBottom: 6}}>Tier you're applying for</span>
           <select name="tier" style={{width: '100%', boxSizing: 'border-box', fontFamily: 'inherit', fontSize: 14, padding: '11px 14px', border: '1px solid rgba(255,255,255,0.18)', borderRadius: 'var(--radius-md)', background: 'rgba(255,255,255,0.08)', color: 'white'}}>
-            <option>Partner</option>
-            <option>Certified</option>
-            <option>Strategic (by invitation)</option>
+            <option>Host</option>
+            <option>Service</option>
+            <option>Certified (by invitation)</option>
           </select>
         </label>
       </div>


### PR DESCRIPTION
## Summary

Rewrites the partner directory around a three-tier programme that mirrors how the relationship actually works:

- **Host** — ships our open-source apps, no SLA with Conduction, no direct support line, not tender-eligible.
- **Service** — SLA with Conduction, third-line support, named contacts, roadmap input.
- **Certified** — trained, audited, joint roadmap, eligible to co-respond to public tenders alongside us.

## Changes

- `package.json` / `package-lock.json` — `@conduction/docusaurus-preset` bumped to `^2.0.0` (preset ships the matching tier-slug rename, the combined `Apps and solutions` facet, and the strategic-blue-bg specificity fix).
- `src/data/partners-catalog.js` — eleven partners re-tiered + fresh, factual one-liners researched from each company's public site:
  - **Certified**: Acato
  - **Service**: Shift2
  - **Host**: Centric, Procolix, The Goodcloud, BCT, Open Gemeenten, xxllnc (formerly Exxellence), YARD, iO, Sendent
- Per-partner apps + solutions corrected: Sendent ships only MyDash; Procolix and The Goodcloud are Nextcloud hosts; Centric pairs Nextcloud with DocuDesk; the Woo-solution partners (Acato, Shift2, BCT, Open Gemeenten, xxllnc, YARD, iO) all carry OpenCatalogi + OpenRegister + OpenConnector + the `woo` solution slug.
- `src/pages/support.mdx` — tier cards rewritten around the new programme, application form tier dropdown updated.
- `src/pages/partners/{acato,procolix,yard}.mdx` — title, status badge, and adjacent-partners cards repointed at the new tier slugs.

## Test plan

- [ ] Local `npm run build` is clean (verified during prep).
- [ ] `/partners` directory renders Acato as the cobalt-fill Certified card (the bug from the screenshot).
- [ ] `/partners` sidebar facet now shows "Apps and solutions" with both apps and solution slugs (Woo, Archief, etc.) selectable.
- [ ] `/support` shows the three new tier cards (Host / Service / Certified).
- [ ] Detail pages for Acato / Procolix / YARD render with the right tier badge and the adjacent-partners block links to the correct tiers.