### PR TITLE
chore(data): refresh app-downloads.json (36,007 downloads, 26 apps)

### DIFF
--- a/data/app-downloads.json
+++ b/data/app-downloads.json
@@ -120,7 +120,7 @@
     },
     {
       "github": {
-        "downloads": 873,
+        "downloads": 891,
         "latest_release": "v0.0.33",
         "latest_release_at": "2026-03-05T10:25:31Z",
         "release_count": 39,
@@ -141,7 +141,7 @@
             "tag": "v0.0.34-unstable.3"
           },
           {
-            "downloads": 2,
+            "downloads": 3,
             "published_at": "2026-03-13T09:02:39Z",
             "tag": "v0.0.34-unstable.1"
           },
@@ -151,7 +151,7 @@
             "tag": "v0.0.34-beta.20260313155152"
           },
           {
-            "downloads": 124,
+            "downloads": 141,
             "published_at": "2026-03-05T10:25:31Z",
             "tag": "v0.0.33"
           },
@@ -330,7 +330,7 @@
     },
     {
       "github": {
-        "downloads": 1850,
+        "downloads": 1853,
         "latest_release": "v0.1.26",
         "latest_release_at": "2025-04-23T06:33:25Z",
         "release_count": 38,
@@ -341,7 +341,7 @@
             "tag": "v0.1.27-beta.20260313153748"
           },
           {
-            "downloads": 576,
+            "downloads": 579,
             "published_at": "2025-04-23T06:33:25Z",
             "tag": "v0.1.26"
           },
@@ -656,7 +656,7 @@
     },
     {
       "github": {
-        "downloads": 324,
+        "downloads": 364,
         "latest_release": "v0.1.2",
         "latest_release_at": "2026-03-05T10:23:21Z",
         "release_count": 14,
@@ -697,7 +697,7 @@
             "tag": "v0.1.3-beta.20260313150323"
           },
           {
-            "downloads": 225,
+            "downloads": 250,
             "published_at": "2026-03-05T10:23:21Z",
             "tag": "v0.1.2"
           },
@@ -712,7 +712,7 @@
             "tag": "v0.1.1-unstable.5"
           },
           {
-            "downloads": 74,
+            "downloads": 89,
             "published_at": "2026-02-06T12:41:22Z",
             "tag": "v0.1.1-unstable.2"
           },
@@ -775,11 +775,26 @@
     },
     {
       "github": {
-        "downloads": 5740,
-        "latest_release": "v0.7.12",
-        "latest_release_at": "2026-03-10T12:48:13Z",
-        "release_count": 317,
+        "downloads": 5882,
+        "latest_release": "v1.0.0",
+        "latest_release_at": "2026-05-08T13:47:17Z",
+        "release_count": 327,
         "releases": [
+          {
+            "downloads": 1,
+            "published_at": "2026-05-08T13:47:17Z",
+            "tag": "v1.0.0"
+          },
+          {
+            "downloads": 1,
+            "published_at": "2026-05-07T11:44:31Z",
+            "tag": "v0.7.13-beta.20260507114139"
+          },
+          {
+            "downloads": 3,
+            "published_at": "2026-05-05T14:42:02Z",
+            "tag": "v0.7.13-beta.20260505143910"
+          },
           {
             "downloads": 2,
             "published_at": "2026-05-01T13:50:43Z",
@@ -856,7 +871,7 @@
             "tag": "v0.7.12-beta.1"
           },
           {
-            "downloads": 146,
+            "downloads": 166,
             "published_at": "2026-03-10T12:48:13Z",
             "tag": "v0.7.12"
           },
@@ -936,7 +951,7 @@
             "tag": "v0.7.8-beta.1"
           },
           {
-            "downloads": 165,
+            "downloads": 178,
             "published_at": "2026-01-13T14:37:00Z",
             "tag": "v0.7.7"
           },
@@ -1011,7 +1026,7 @@
             "tag": "v0.7.7-beta.1"
           },
           {
-            "downloads": 261,
+            "downloads": 274,
             "published_at": "2025-10-31T13:14:10Z",
             "tag": "v0.7.6"
           },
@@ -1026,7 +1041,7 @@
             "tag": "v0.7.6-beta.1"
           },
           {
-            "downloads": 57,
+            "downloads": 70,
             "published_at": "2025-10-29T09:54:05Z",
             "tag": "v0.7.5"
           },
@@ -1036,7 +1051,7 @@
             "tag": "v0.7.10-unstable.1"
           },
           {
-            "downloads": 70,
+            "downloads": 83,
             "published_at": "2026-03-05T16:02:21Z",
             "tag": "v0.7.9"
           },
@@ -1121,7 +1136,7 @@
             "tag": "v0.7.9-beta.1"
           },
           {
-            "downloads": 126,
+            "downloads": 139,
             "published_at": "2026-02-11T14:02:41Z",
             "tag": "v0.7.8"
           },
@@ -1421,7 +1436,7 @@
             "tag": "v0.7.5-beta.1"
           },
           {
-            "downloads": 289,
+            "downloads": 302,
             "published_at": "2025-08-06T07:32:56Z",
             "tag": "v0.7.4"
           },
@@ -1436,7 +1451,7 @@
             "tag": "v0.7.4-beta.1"
           },
           {
-            "downloads": 138,
+            "downloads": 151,
             "published_at": "2025-07-17T13:31:18Z",
             "tag": "v0.7.3"
           },
@@ -1661,12 +1676,12 @@
             "tag": "v0.7.3-beta.1"
           },
           {
-            "downloads": 133,
+            "downloads": 146,
             "published_at": "2025-06-20T15:44:19Z",
             "tag": "v0.7.2"
           },
           {
-            "downloads": 45,
+            "downloads": 58,
             "published_at": "2025-06-20T15:04:24Z",
             "tag": "v0.6.75"
           },
@@ -2306,38 +2321,38 @@
     },
     {
       "github": {
-        "downloads": 6027,
+        "downloads": 6247,
         "latest_release": "v0.2.20",
         "latest_release_at": "2026-04-23T14:44:26Z",
         "release_count": 299,
         "releases": [
           {
-            "downloads": 52,
+            "downloads": 75,
             "published_at": "2026-04-23T14:44:26Z",
             "tag": "v0.2.20"
           },
           {
-            "downloads": 72,
+            "downloads": 85,
             "published_at": "2026-04-15T08:45:47Z",
             "tag": "v0.2.19"
           },
           {
-            "downloads": 47,
+            "downloads": 60,
             "published_at": "2026-04-14T10:01:38Z",
             "tag": "v0.2.18"
           },
           {
-            "downloads": 75,
+            "downloads": 88,
             "published_at": "2026-04-02T09:16:08Z",
             "tag": "v0.2.17"
           },
           {
-            "downloads": 65,
+            "downloads": 78,
             "published_at": "2026-03-27T16:48:10Z",
             "tag": "v0.2.16"
           },
           {
-            "downloads": 42,
+            "downloads": 55,
             "published_at": "2026-03-27T08:47:00Z",
             "tag": "v0.2.15"
           },
@@ -2347,12 +2362,12 @@
             "tag": "v0.2.14"
           },
           {
-            "downloads": 43,
+            "downloads": 56,
             "published_at": "2026-03-18T15:46:17Z",
             "tag": "v0.2.13"
           },
           {
-            "downloads": 38,
+            "downloads": 51,
             "published_at": "2026-03-18T11:18:04Z",
             "tag": "v0.2.12"
           },
@@ -2362,7 +2377,7 @@
             "tag": "v0.2.10-beta.20260313155222"
           },
           {
-            "downloads": 64,
+            "downloads": 77,
             "published_at": "2026-03-05T12:34:50Z",
             "tag": "v0.2.9"
           },
@@ -2402,7 +2417,7 @@
             "tag": "v0.2.9-beta.1"
           },
           {
-            "downloads": 113,
+            "downloads": 126,
             "published_at": "2026-02-09T12:20:36Z",
             "tag": "v0.2.8"
           },
@@ -2457,7 +2472,7 @@
             "tag": "v0.2.8-beta.1"
           },
           {
-            "downloads": 113,
+            "downloads": 126,
             "published_at": "2026-01-13T14:36:27Z",
             "tag": "v0.2.7"
           },
@@ -2477,7 +2492,7 @@
             "tag": "v0.2.7-beta.7"
           },
           {
-            "downloads": 8,
+            "downloads": 9,
             "published_at": "2025-11-13T08:54:50Z",
             "tag": "v0.2.7-beta.6"
           },
@@ -2567,7 +2582,7 @@
             "tag": "v0.2.7-beta.1"
           },
           {
-            "downloads": 259,
+            "downloads": 272,
             "published_at": "2025-10-29T09:53:11Z",
             "tag": "v0.2.6"
           },
@@ -2767,7 +2782,7 @@
             "tag": "v0.2.6-beta.1"
           },
           {
-            "downloads": 380,
+            "downloads": 393,
             "published_at": "2025-08-07T12:31:24Z",
             "tag": "v0.2.5"
           },
@@ -2777,7 +2792,7 @@
             "tag": "v0.2.5-beta.1"
           },
           {
-            "downloads": 67,
+            "downloads": 80,
             "published_at": "2025-08-06T07:32:30Z",
             "tag": "v0.2.4"
           },
@@ -2882,7 +2897,7 @@
             "tag": "v0.2.4-beta.1"
           },
           {
-            "downloads": 129,
+            "downloads": 142,
             "published_at": "2025-07-16T15:42:51Z",
             "tag": "v0.2.3"
           },
@@ -2972,7 +2987,7 @@
             "tag": "v0.2.3-beta.1"
           },
           {
-            "downloads": 110,
+            "downloads": 123,
             "published_at": "2025-06-20T15:42:10Z",
             "tag": "v0.2.2"
           },
@@ -3392,7 +3407,7 @@
             "tag": "v0.1.79-beta.17"
           },
           {
-            "downloads": 9,
+            "downloads": 10,
             "published_at": "2025-04-11T14:21:30Z",
             "tag": "v0.1.79-beta.16"
           },
@@ -3836,11 +3851,26 @@
     },
     {
       "github": {
-        "downloads": 9805,
-        "latest_release": "v0.2.14",
-        "latest_release_at": "2026-04-27T20:40:06Z",
-        "release_count": 772,
+        "downloads": 9988,
+        "latest_release": "v1.0.1",
+        "latest_release_at": "2026-05-08T14:46:46Z",
+        "release_count": 787,
         "releases": [
+          {
+            "downloads": 1,
+            "published_at": "2026-05-08T14:46:46Z",
+            "tag": "v1.0.1"
+          },
+          {
+            "downloads": 2,
+            "published_at": "2026-05-07T14:44:42Z",
+            "tag": "v0.2.15-beta.20260507144237"
+          },
+          {
+            "downloads": 2,
+            "published_at": "2026-05-01T14:49:03Z",
+            "tag": "v0.2.15-beta.20260501144653"
+          },
           {
             "downloads": 3,
             "published_at": "2026-05-01T13:56:05Z",
@@ -3858,11 +3888,16 @@
           },
           {
             "downloads": 1,
+            "published_at": "2026-05-05T09:08:58Z",
+            "tag": "v0.2.14-unstable.20260505090717"
+          },
+          {
+            "downloads": 1,
             "published_at": "2026-05-01T11:09:58Z",
             "tag": "v0.2.14-unstable.20260501110742"
           },
           {
-            "downloads": 6,
+            "downloads": 7,
             "published_at": "2026-04-24T12:23:57Z",
             "tag": "v0.2.14-beta.20260424122135"
           },
@@ -3882,7 +3917,7 @@
             "tag": "v0.2.14-beta.20260422123909"
           },
           {
-            "downloads": 4,
+            "downloads": 5,
             "published_at": "2026-04-16T09:14:18Z",
             "tag": "v0.2.14-beta.20260416091216"
           },
@@ -3977,7 +4012,7 @@
             "tag": "v0.2.13-unstable.5"
           },
           {
-            "downloads": 1,
+            "downloads": 2,
             "published_at": "2026-03-11T19:00:44Z",
             "tag": "v0.2.13-unstable.48"
           },
@@ -4282,12 +4317,12 @@
             "tag": "v0.2.12-beta.1"
           },
           {
-            "downloads": 482,
+            "downloads": 524,
             "published_at": "2026-02-11T14:01:39Z",
             "tag": "v0.2.11"
           },
           {
-            "downloads": 84,
+            "downloads": 97,
             "published_at": "2026-02-09T12:20:49Z",
             "tag": "v0.2.10"
           },
@@ -4367,7 +4402,7 @@
             "tag": "v0.2.10-beta.79"
           },
           {
-            "downloads": 9,
+            "downloads": 10,
             "published_at": "2026-01-28T10:12:08Z",
             "tag": "v0.2.10-beta.78"
           },
@@ -4632,7 +4667,7 @@
             "tag": "v0.2.10-beta.3"
           },
           {
-            "downloads": 7,
+            "downloads": 8,
             "published_at": "2026-01-20T07:16:04Z",
             "tag": "v0.2.10-beta.29"
           },
@@ -4742,7 +4777,7 @@
             "tag": "v0.2.10-beta.1"
           },
           {
-            "downloads": 230,
+            "downloads": 243,
             "published_at": "2026-01-13T15:39:29Z",
             "tag": "v0.2.9"
           },
@@ -4967,7 +5002,7 @@
             "tag": "v0.2.9-beta.1"
           },
           {
-            "downloads": 372,
+            "downloads": 385,
             "published_at": "2025-11-14T12:35:42Z",
             "tag": "v0.2.8"
           },
@@ -5102,7 +5137,7 @@
             "tag": "v0.2.8-beta.1"
           },
           {
-            "downloads": 189,
+            "downloads": 202,
             "published_at": "2025-10-29T09:53:08Z",
             "tag": "v0.2.7"
           },
@@ -5892,7 +5927,7 @@
             "tag": "v0.2.7-beta.1"
           },
           {
-            "downloads": 433,
+            "downloads": 446,
             "published_at": "2025-08-14T09:21:15Z",
             "tag": "v0.2.6"
           },
@@ -5922,7 +5957,7 @@
             "tag": "v0.2.6-beta.1"
           },
           {
-            "downloads": 122,
+            "downloads": 135,
             "published_at": "2025-08-06T07:31:53Z",
             "tag": "v0.2.5"
           },
@@ -6047,7 +6082,7 @@
             "tag": "v0.2.5-beta.1"
           },
           {
-            "downloads": 159,
+            "downloads": 172,
             "published_at": "2025-07-18T13:54:58Z",
             "tag": "v0.2.4"
           },
@@ -6057,7 +6092,7 @@
             "tag": "v0.2.4-beta.1"
           },
           {
-            "downloads": 68,
+            "downloads": 81,
             "published_at": "2025-07-17T13:30:01Z",
             "tag": "v0.2.3"
           },
@@ -6257,12 +6292,12 @@
             "tag": "v0.2.3-beta.1"
           },
           {
-            "downloads": 206,
+            "downloads": 219,
             "published_at": "2025-06-20T15:40:14Z",
             "tag": "v0.2.2"
           },
           {
-            "downloads": 45,
+            "downloads": 58,
             "published_at": "2025-06-20T14:54:54Z",
             "tag": "v0.1.80"
           },
@@ -7342,18 +7377,18 @@
     },
     {
       "github": {
-        "downloads": 563,
+        "downloads": 653,
         "latest_release": "v0.1.19",
         "latest_release_at": "2026-04-27T20:42:31Z",
         "release_count": 9,
         "releases": [
           {
-            "downloads": 141,
+            "downloads": 217,
             "published_at": "2026-04-27T20:42:31Z",
             "tag": "v0.1.19"
           },
           {
-            "downloads": 417,
+            "downloads": 431,
             "published_at": "2026-03-19T14:35:29Z",
             "tag": "v0.1.18"
           },
@@ -7414,13 +7449,13 @@
     },
     {
       "github": {
-        "downloads": 18,
+        "downloads": 21,
         "latest_release": null,
         "latest_release_at": null,
         "release_count": 2,
         "releases": [
           {
-            "downloads": 16,
+            "downloads": 19,
             "published_at": "2026-03-19T14:33:41Z",
             "tag": "v0.1.11-beta.20260319143225"
           },
@@ -7477,7 +7512,7 @@
     },
     {
       "github": {
-        "downloads": 7554,
+        "downloads": 8247,
         "latest_release": "v0.1.139",
         "latest_release_at": "2026-02-19T10:55:05Z",
         "release_count": 213,
@@ -7708,7 +7743,7 @@
             "tag": "v0.1.140"
           },
           {
-            "downloads": 579,
+            "downloads": 631,
             "published_at": "2026-02-19T10:55:05Z",
             "tag": "v0.1.139"
           },
@@ -7748,7 +7783,7 @@
             "tag": "v0.1.137-beta.9"
           },
           {
-            "downloads": 8,
+            "downloads": 9,
             "published_at": "2026-01-19T03:35:04Z",
             "tag": "v0.1.137-beta.8"
           },
@@ -7888,247 +7923,247 @@
             "tag": "v0.1.137-beta.1"
           },
           {
-            "downloads": 203,
+            "downloads": 216,
             "published_at": "2026-01-05T21:40:26Z",
             "tag": "v0.1.136"
           },
           {
-            "downloads": 56,
+            "downloads": 69,
             "published_at": "2026-01-05T21:36:53Z",
             "tag": "v0.1.135"
           },
           {
-            "downloads": 61,
+            "downloads": 74,
             "published_at": "2026-01-05T08:08:14Z",
             "tag": "v0.1.134"
           },
           {
-            "downloads": 80,
+            "downloads": 93,
             "published_at": "2025-12-29T10:56:57Z",
             "tag": "v0.1.133"
           },
           {
-            "downloads": 94,
+            "downloads": 107,
             "published_at": "2025-12-19T16:22:58Z",
             "tag": "v0.1.132"
           },
           {
-            "downloads": 54,
+            "downloads": 67,
             "published_at": "2025-12-19T16:15:03Z",
             "tag": "v0.1.131"
           },
           {
-            "downloads": 78,
+            "downloads": 91,
             "published_at": "2025-12-17T12:29:47Z",
             "tag": "v0.1.130"
           },
           {
-            "downloads": 56,
+            "downloads": 69,
             "published_at": "2025-12-17T12:27:25Z",
             "tag": "v0.1.129"
           },
           {
-            "downloads": 68,
+            "downloads": 81,
             "published_at": "2025-12-16T12:48:05Z",
             "tag": "v0.1.128"
           },
           {
-            "downloads": 69,
+            "downloads": 82,
             "published_at": "2025-12-15T11:20:05Z",
             "tag": "v0.1.127"
           },
           {
-            "downloads": 97,
+            "downloads": 110,
             "published_at": "2025-12-10T09:34:59Z",
             "tag": "v0.1.126"
           },
           {
-            "downloads": 73,
+            "downloads": 86,
             "published_at": "2025-12-08T14:08:55Z",
             "tag": "v0.1.125"
           },
           {
-            "downloads": 58,
+            "downloads": 71,
             "published_at": "2025-12-08T13:39:10Z",
             "tag": "v0.1.124"
           },
           {
-            "downloads": 59,
+            "downloads": 72,
             "published_at": "2025-12-08T11:14:07Z",
             "tag": "v0.1.123"
           },
           {
-            "downloads": 59,
+            "downloads": 72,
             "published_at": "2025-12-08T09:59:09Z",
             "tag": "v0.1.122"
           },
           {
-            "downloads": 76,
+            "downloads": 89,
             "published_at": "2025-12-05T15:09:02Z",
             "tag": "v0.1.121"
           },
           {
-            "downloads": 59,
+            "downloads": 73,
             "published_at": "2025-12-05T14:57:07Z",
             "tag": "v0.1.120"
           },
           {
-            "downloads": 56,
+            "downloads": 69,
             "published_at": "2025-12-05T14:51:53Z",
             "tag": "v0.1.119"
           },
           {
-            "downloads": 56,
+            "downloads": 69,
             "published_at": "2025-12-05T13:41:09Z",
             "tag": "v0.1.118"
           },
           {
-            "downloads": 57,
+            "downloads": 70,
             "published_at": "2025-12-05T13:01:59Z",
             "tag": "v0.1.117"
           },
           {
-            "downloads": 56,
+            "downloads": 69,
             "published_at": "2025-12-05T11:00:15Z",
             "tag": "v0.1.116"
           },
           {
-            "downloads": 69,
+            "downloads": 82,
             "published_at": "2025-12-04T14:08:35Z",
             "tag": "v0.1.115"
           },
           {
-            "downloads": 87,
+            "downloads": 101,
             "published_at": "2025-11-28T11:46:18Z",
             "tag": "v0.1.114"
           },
           {
-            "downloads": 59,
+            "downloads": 72,
             "published_at": "2025-11-28T08:43:36Z",
             "tag": "v0.1.113"
           },
           {
-            "downloads": 111,
+            "downloads": 124,
             "published_at": "2025-11-15T15:42:37Z",
             "tag": "v0.1.112"
           },
           {
-            "downloads": 56,
+            "downloads": 69,
             "published_at": "2025-11-15T14:33:48Z",
             "tag": "v0.1.111"
           },
           {
-            "downloads": 62,
+            "downloads": 75,
             "published_at": "2025-11-14T14:02:49Z",
             "tag": "v0.1.110"
           },
           {
-            "downloads": 99,
+            "downloads": 112,
             "published_at": "2025-11-06T15:24:53Z",
             "tag": "v0.1.109"
           },
           {
-            "downloads": 64,
+            "downloads": 77,
             "published_at": "2025-11-05T07:54:28Z",
             "tag": "v0.1.108"
           },
           {
-            "downloads": 76,
+            "downloads": 89,
             "published_at": "2025-10-30T10:22:06Z",
             "tag": "v0.1.107"
           },
           {
-            "downloads": 70,
+            "downloads": 83,
             "published_at": "2025-10-28T06:48:48Z",
             "tag": "v0.1.106"
           },
           {
-            "downloads": 61,
+            "downloads": 74,
             "published_at": "2025-10-27T15:29:56Z",
             "tag": "v0.1.105"
           },
           {
-            "downloads": 110,
+            "downloads": 123,
             "published_at": "2025-10-15T05:50:47Z",
             "tag": "v0.1.104"
           },
           {
-            "downloads": 59,
+            "downloads": 72,
             "published_at": "2025-10-14T11:05:47Z",
             "tag": "v0.1.103"
           },
           {
-            "downloads": 62,
+            "downloads": 75,
             "published_at": "2025-10-11T20:19:29Z",
             "tag": "v0.1.102"
           },
           {
-            "downloads": 63,
+            "downloads": 76,
             "published_at": "2025-10-10T13:23:58Z",
             "tag": "v0.1.101"
           },
           {
-            "downloads": 72,
+            "downloads": 85,
             "published_at": "2025-10-08T19:19:06Z",
             "tag": "v0.1.100"
           },
           {
-            "downloads": 64,
+            "downloads": 77,
             "published_at": "2025-10-08T12:56:14Z",
             "tag": "v0.1.99"
           },
           {
-            "downloads": 64,
+            "downloads": 77,
             "published_at": "2025-10-07T12:33:24Z",
             "tag": "v0.1.98"
           },
           {
-            "downloads": 62,
+            "downloads": 75,
             "published_at": "2025-10-07T05:58:55Z",
             "tag": "v0.1.97"
           },
           {
-            "downloads": 56,
+            "downloads": 69,
             "published_at": "2025-10-07T05:50:02Z",
             "tag": "v0.1.96"
           },
           {
-            "downloads": 60,
+            "downloads": 73,
             "published_at": "2025-10-06T21:05:43Z",
             "tag": "v0.1.95"
           },
           {
-            "downloads": 65,
+            "downloads": 78,
             "published_at": "2025-10-06T09:57:49Z",
             "tag": "v0.1.94"
           },
           {
-            "downloads": 56,
+            "downloads": 69,
             "published_at": "2025-10-06T09:47:33Z",
             "tag": "v0.1.93"
           },
           {
-            "downloads": 54,
+            "downloads": 67,
             "published_at": "2025-10-05T19:09:14Z",
             "tag": "v0.1.92"
           },
           {
-            "downloads": 54,
+            "downloads": 67,
             "published_at": "2025-10-05T10:10:43Z",
             "tag": "v0.1.91"
           },
           {
-            "downloads": 59,
+            "downloads": 72,
             "published_at": "2025-10-03T08:59:49Z",
             "tag": "v0.1.90"
           },
           {
-            "downloads": 50,
+            "downloads": 63,
             "published_at": "2025-10-03T08:53:06Z",
             "tag": "v0.1.89"
           },
           {
-            "downloads": 74,
+            "downloads": 87,
             "published_at": "2025-10-01T07:10:29Z",
             "tag": "v0.1.88"
           },
@@ -8388,7 +8423,7 @@
             "tag": "v0.1.37"
           },
           {
-            "downloads": 36,
+            "downloads": 37,
             "published_at": "2025-08-05T06:41:46Z",
             "tag": "v0.1.35"
           },
@@ -8582,33 +8617,33 @@
     },
     {
       "github": {
-        "downloads": 1717,
+        "downloads": 1785,
         "latest_release": "v0.1.30",
         "latest_release_at": "2026-03-05T10:25:29Z",
         "release_count": 107,
         "releases": [
           {
-            "downloads": 58,
+            "downloads": 71,
             "published_at": "2026-03-05T10:25:29Z",
             "tag": "v0.1.30"
           },
           {
-            "downloads": 100,
+            "downloads": 113,
             "published_at": "2025-10-07T09:34:43Z",
             "tag": "v0.1.29"
           },
           {
-            "downloads": 57,
+            "downloads": 70,
             "published_at": "2025-10-03T09:52:22Z",
             "tag": "v0.1.28"
           },
           {
-            "downloads": 53,
+            "downloads": 66,
             "published_at": "2025-10-02T09:14:13Z",
             "tag": "v0.1.27"
           },
           {
-            "downloads": 50,
+            "downloads": 63,
             "published_at": "2025-10-02T08:47:34Z",
             "tag": "v0.1.26"
           },
@@ -8718,7 +8753,7 @@
             "tag": "v0.1.3"
           },
           {
-            "downloads": 593,
+            "downloads": 596,
             "published_at": "2024-10-23T09:23:50Z",
             "tag": "v0.0.9"
           },
@@ -8862,7 +8897,7 @@
       }
     }
   ],
-  "generated_at": "2026-05-04T13:43:28+00:00",
+  "generated_at": "2026-05-08T21:05:11+00:00",
   "source": {
     "notes": "github.downloads counts every release-asset fetch (CI, mirrors, re-installs) \u2014 upper bound on real installs.",
     "org": "ConductionNL",
@@ -8871,6 +8906,6 @@
   "totals": {
     "apps_in_store": 12,
     "apps_total": 26,
-    "downloads": 34547
+    "downloads": 36007
   }
 }


### PR DESCRIPTION
Manual refresh of [data/app-downloads.json](data/app-downloads.json) to replace the stale data the homepage was showing as "0 downloads".

The nightly automation cannot push directly to `development` (org-wide pull-request rule blocks even `github-actions[bot]`), so this PR carries the freshly-generated file through the normal review flow.

**Totals:** 36,007 downloads · 26 apps · 12 in the Nextcloud app store.

Generated with: `GITHUB_TOKEN=$(gh auth token) python3 .github/scripts/app_downloads.py`