### PR TITLE
academy: Part 1 of the DeskDesk tutorial (Scaffold)

### DIFF
--- a/academy/2026-05-10-deskdesk-tutorial-1-scaffold/index.mdx
+++ b/academy/2026-05-10-deskdesk-tutorial-1-scaffold/index.mdx
@@ -1,0 +1,216 @@
+---
+slug: deskdesk-tutorial-1-scaffold
+title: "Build a Nextcloud app on the Conduction stack — Part 1: Scaffold"
+contentType: tutorial
+authors: [conduction]
+date: 2026-05-10
+summary: Clone the Conduction app template, rename it to DeskDesk, build, enable, and see the canonical app chassis. The first of four parts that build a working desk-booking app on the full Conduction stack.
+tags: [App development, Nextcloud, OpenRegister, nextcloud-vue, Tutorial series]
+apps: [openregister]
+durationMinutes: 20
+series: deskdesk-tutorial
+partNumber: 1
+---
+
+import {
+  Outcomes,
+  Outcome,
+  Prerequisites,
+  PrerequisiteItem,
+  AtomZones,
+  NextSteps,
+  NextStep,
+  HexCard,
+} from '@conduction/docusaurus-preset/components';
+
+This is **Part 1 of a four-part tutorial** that builds **DeskDesk**, a flexible desk-booking app for an open-office environment, on the full Conduction Nextcloud stack. The end product: pick a desk on a floor, book a slot, see your booking in your Nextcloud Calendar, and surface zone-specific knowledge articles from xWiki right next to the booking. Every piece reuses what `@conduction/nextcloud-vue` and OpenRegister already give you for free.
+
+In Part 1 you scaffold the app, rename it, build it, and see the canonical app chassis on screen. No data, no integrations yet. We get the bones right first.
+
+{/* truncate */}
+
+<Outcomes title="What you'll have at the end of Part 1">
+  <Outcome>A working <strong>DeskDesk</strong> app installed in your local Nextcloud, navigable from the app shelf.</Outcome>
+  <Outcome>A clear mental model of the canonical Conduction app <strong>chassis</strong>: topbar, left navigation, main column, page header, sidebar.</Outcome>
+  <Outcome>Confidence with the <strong>nextcloud-app-template</strong> rename ritual: <code>id</code>, namespace, the few files you have to touch, the rest you can leave for later.</Outcome>
+  <Outcome>A clean foundation for Part 2, where the chassis starts holding real data.</Outcome>
+</Outcomes>
+
+## What we're building, across all four parts
+
+| Part | Title | Adds |
+|---|---|---|
+| 1 | Scaffold (you're here) | Empty app shell, chassis visible, navigable |
+| 2 | Schemas + manifest | Desk and booking schemas, full CRUD, dashboard |
+| 3 | Schema-driven integrations | Bookings appear in NC Calendar via the OpenRegister calendar provider |
+| 4 | External knowledge + ship | xWiki source via OpenConnector, sidebar tab, package, publish |
+
+Same shape, two repos:
+
+- **App source:** [`ConductionNL/deskdesk`](https://github.com/ConductionNL/deskdesk) — the actual Nextcloud app you're forking from the template.
+- **Tutorial source:** [`ConductionNL/conduction-website`](https://github.com/ConductionNL/conduction-website) — the post you're reading right now.
+
+<Prerequisites title="What you need">
+  <PrerequisiteItem>A running Nextcloud (28+) with admin access. If you don't have one, follow <a href="/academy/nextcloud-lokaal-draaien">Nextcloud lokaal draaien met Docker</a> first.</PrerequisiteItem>
+  <PrerequisiteItem><strong>OpenRegister</strong> installed and enabled in that Nextcloud (Apps → search "OpenRegister" → Download).</PrerequisiteItem>
+  <PrerequisiteItem>Node.js 20+ and PHP 8.1+ on your host, plus Composer and the GitHub CLI (<code>gh</code>) — the template ships with PHPCS, Psalm, PHPStan, and ESLint configs ready to go.</PrerequisiteItem>
+  <PrerequisiteItem>A GitHub account so you can fork the template into your own org (or <code>ConductionNL</code> if you have access).</PrerequisiteItem>
+</Prerequisites>
+
+## Step 1: Use the template
+
+[`ConductionNL/nextcloud-app-template`](https://github.com/ConductionNL/nextcloud-app-template) is a GitHub *repository template*. The "Use this template" button gives you a fresh repo with the full starter kit: Vue 2 + Pinia frontend, PHP backend, OpenRegister wiring, quality pipeline, OpenSpec scaffolding, GitHub Actions.
+
+```bash title="Pick a name. We're calling ours deskdesk."
+gh repo create ConductionNL/deskdesk \
+  --template ConductionNL/nextcloud-app-template \
+  --public \
+  --description "Flexible desk booking for open-office environments"
+```
+
+Then clone it next to your other Nextcloud apps. Most workspaces keep them in a single `apps-extra/` directory the dev container mounts.
+
+```bash
+cd /path/to/your/nextcloud/workspace/apps-extra
+git clone https://github.com/ConductionNL/deskdesk.git
+cd deskdesk
+```
+
+You now have a directory with the full template content under the new name. Nothing inside has been renamed yet — the directory is `deskdesk/`, but every file still says `app-template`, `AppTemplate`, `OCA\AppTemplate`. Step 2 fixes that.
+
+## Step 2: Rename the app
+
+Nextcloud requires three identifiers to line up:
+
+- The directory name (`deskdesk/`) ✅ already
+- The `<id>` in `appinfo/info.xml`
+- The PHP namespace (`OCA\AppTemplate` → `OCA\DeskDesk`)
+
+Plus a handful of supporting files reference the old id. The full list is small enough to do by hand, and doing it by hand is the right move. Project memory: **never use `sed` or scripted edits on code files** — use a real editor with project-aware refactoring, or just read each file once before you change it.
+
+### 2a. The boot-critical files
+
+These are the ones that prevent Nextcloud from booting the app at all. Edit each with `Find & replace all` in your editor — `AppTemplate` → `DeskDesk` and `app-template` → `deskdesk`:
+
+| File | Replace |
+|---|---|
+| `appinfo/info.xml` | `<id>`, `<name>`, `<namespace>`, `<navigation>`, `<settings>` paths |
+| `composer.json` | `name`, `description`, the `psr-4` autoload prefix |
+| `package.json` | `name` |
+| `webpack.config.js` | the `appId` constant |
+| `templates/index.php` and `templates/settings/admin.php` | `OCA\AppTemplate` → `OCA\DeskDesk`, the `data-*` element id |
+| `lib/AppInfo/Application.php` | namespace, `APP_ID` constant, docblock |
+| Every other PHP file in `lib/` | `namespace OCA\AppTemplate\…` → `namespace OCA\DeskDesk\…`, every `use OCA\AppTemplate\…` import, every docblock |
+| `appinfo/routes.php` | docblock only |
+| Every Vue file in `src/` | the `t('app-template', '…')` translation namespace becomes `t('deskdesk', '…')` |
+| `src/router/index.js` | `generateUrl('/apps/app-template')` → `generateUrl('/apps/deskdesk')` |
+| `src/store/store.js`, `src/store/modules/settings.js` | `'/apps/app-template/api/settings'` → `'/apps/deskdesk/api/settings'`, fallback register slug |
+| `src/settings.js` | `loadTranslations('app-template', …)` and the `#app-template-settings` mount selector |
+| `lib/Settings/app_template_register.json` | rename to `lib/Settings/deskdesk_register.json` (and the `app` field inside it) |
+
+### 2b. The "you can do later" files
+
+Tests (`tests/Unit/AppTemplateTest.php`, the integration Postman collection), `phpcs.xml` / `phpmd.xml` / `REUSE.toml` headers, and the `.github/` workflow inputs. They reference the template id in metadata only; the app boots fine without them touched. Fix them when you set up CI.
+
+### 2c. One Nextcloud-version compatibility nip
+
+The template's `lib/AppInfo/Application.php` registers a repair step at runtime:
+
+```php title="Original — fails on some Nextcloud builds"
+$context->registerRepairStep(InitializeSettings::class);
+```
+
+`registerRepairStep()` is missing from `IRegistrationContext` on a few Nextcloud builds (you'll see `Call to undefined method` in `nextcloud.log`). Move it to `appinfo/info.xml` instead — same effect, more portable:
+
+```xml title="appinfo/info.xml — append after the <settings> block"
+<repair-steps>
+    <install>
+        <step>OCA\DeskDesk\Repair\InitializeSettings</step>
+    </install>
+    <post-migration>
+        <step>OCA\DeskDesk\Repair\InitializeSettings</step>
+    </post-migration>
+</repair-steps>
+```
+
+Then drop the `registerRepairStep()` line and the `use OCA\DeskDesk\Repair\InitializeSettings;` import from `lib/AppInfo/Application.php`.
+
+## Step 3: Build and enable
+
+The template ships its build output uncommitted. So the first thing to do in a fresh clone is install dependencies and build the JS bundles, otherwise the app UI is just a blank `<div id="content">`.
+
+```bash
+composer install --no-dev
+composer dump-autoload
+npm install --legacy-peer-deps
+npm run build
+```
+
+Then make sure your Nextcloud container can see the directory. In a typical Docker setup the `apps-extra/` host directory is mounted at `/var/www/html/custom_apps/` in the container; if your compose file uses one bind mount per app, add a line for `deskdesk` and restart. Otherwise:
+
+```bash title="Quick path: copy + chown for a one-shot install"
+docker cp ./deskdesk nextcloud:/var/www/html/custom_apps/
+docker exec -u root nextcloud chown -R www-data:www-data /var/www/html/custom_apps/deskdesk
+```
+
+Now enable:
+
+```bash
+docker exec nextcloud php occ app:enable deskdesk
+```
+
+You should see:
+
+```
+deskdesk 0.1.0 enabled
+```
+
+Open `http://localhost:8080/apps/deskdesk/` and log in. You see a placeholder dashboard with sample KPI cards, two empty panels, three nav items (Dashboard / Items / Documentation) and a Settings entry pinned to the bottom of the rail. That's the chassis.
+
+## The chassis: the whole point of Part 1
+
+Every Conduction app — DeskDesk, OpenRegister, OpenCatalogi, Procest, MyDash, the dozen others — looks the same way on first sight. Same five structural pieces, same place, same behaviour. That recognisability is what `@conduction/nextcloud-vue` enforces: a user who learnt one app navigates the next one without docs.
+
+The chassis is **one shape, five atoms**. Each card below focuses on one atom: the focused zone is at full opacity with a KNVB-orange outline, the rest fades to 25% so you see *where* the atom sits.
+
+<AtomZones />
+
+In Part 2, you'll learn how `manifest.json` plus a JSON schema fills these atoms with real data. The placeholder `Items` nav entry, the empty dashboard, and the "article" schema you saw on screen will all become **desks**, **bookings**, and a real occupancy dashboard — without you laying out a single atom by hand.
+
+## Troubleshooting
+
+<HexCard title="App UI is a blank rectangle">
+  The <code>js/</code> build output is not committed. Run <code>npm run build</code> before you enable the app, or after every frontend change. The blank-rectangle symptom always means "the bundle is missing".
+</HexCard>
+
+<HexCard title="`Could not download app deskdesk` when running occ app:enable">
+  Nextcloud requires the directory name to exactly match the <code>&lt;id&gt;</code> in <code>appinfo/info.xml</code>. If you cloned the repo under a different name, either rename the directory or add a relative symlink: <code>ln -s your-clone-name ../deskdesk</code>.
+</HexCard>
+
+<HexCard title="`Call to undefined method ...registerRepairStep()` in nextcloud.log">
+  Step 2c covers this. The fix is to move the repair-step registration from <code>lib/AppInfo/Application.php</code> into <code>appinfo/info.xml</code>'s <code>&lt;repair-steps&gt;</code> block.
+</HexCard>
+
+<HexCard title="`Class not found` after the rename">
+  Run <code>composer dump-autoload</code> from the app directory. PHP's classmap caches the old <code>OCA\AppTemplate</code> map until you regenerate it.
+</HexCard>
+
+## What's next
+
+<NextSteps>
+  <NextStep
+    title="Part 2 — Schemas + manifest"
+    href="/academy/deskdesk-tutorial-2-schemas-manifest"
+    description="Define the desk, booking, and floor schemas in OpenRegister. Wire them into a manifest.json that CnAppRoot reads. Watch CnIndexPage / CnDetailPage / CnDashboardPage render full CRUD with no glue code."
+  />
+  <NextStep
+    title="The component reference"
+    href="https://nextcloud-vue.conduction.nl/docs/components/"
+    description="Browse every Cn* component the library ships. Live playgrounds, prop tables, slot reference."
+  />
+  <NextStep
+    title="App design principles"
+    href="https://nextcloud-vue.conduction.nl/docs/architecture/app-design-principles/"
+    description="Read the architecture story behind the chassis and the five atoms — the same visual you saw above, with the full design rationale."
+  />
+</NextSteps>


### PR DESCRIPTION
## Summary

First post in a four-part academy series that builds DeskDesk, a desk-booking app for open-office environments, on the full Conduction Nextcloud stack. Lands at \`/academy/deskdesk-tutorial-1-scaffold/\`.

Part 1 covers the scaffold-and-rename ritual: \`gh repo create\` from the [nextcloud-app-template](https://github.com/ConductionNL/nextcloud-app-template) GitHub template, the boot-critical files to rename (with a complete table), the Nextcloud-version compatibility nip (\`registerRepairStep\` -> \`<repair-steps>\` in info.xml), build, enable, and verify the chassis.

The chassis story is told through the preset's \`<AtomZones/>\` component (preset 2.6.1+) so readers see the same five-atoms visual that nextcloud-vue.conduction.nl uses on its app-design-principles page.

## Reference repo

[ConductionNL/deskdesk](https://github.com/ConductionNL/deskdesk) — created from the template, scaffold + rename committed. Marked as 'Generated from nextcloud-app-template'.

## Test plan

- [x] \`npm run build\` in conduction-website succeeds; built HTML at \`build/academy/deskdesk-tutorial-1-scaffold/index.html\` contains all 5 AtomZones zones
- [x] DeskDesk runs locally at \`http://localhost:8080/apps/deskdesk/\` after the rename ritual; chassis verified
- [ ] post-merge: visual sanity-check on the live academy

## Series outline

| Part | Title | Status |
|---|---|---|
| 1 | Scaffold | this PR |
| 2 | Schemas + manifest | pending |
| 3 | Schema-driven integrations (NC Calendar) | pending |
| 4 | Knowledge integration (xWiki) + ship | pending |

Generated with Claude Code