### PR TITLE
academy: Parts 2-4 of the DeskDesk tutorial (Schemas, Calendar, Knowledge + ship)

### DIFF
--- a/academy/2026-05-13-deskdesk-tutorial-2-schemas-manifest/index.mdx
+++ b/academy/2026-05-13-deskdesk-tutorial-2-schemas-manifest/index.mdx
@@ -1,0 +1,303 @@
+---
+slug: deskdesk-tutorial-2-schemas-manifest
+title: "Build a Nextcloud app on the Conduction stack — Part 2: Schemas + manifest"
+contentType: tutorial
+authors: [conduction]
+date: 2026-05-13
+summary: Define the desk, booking, and floor schemas in OpenRegister, declare them in a manifest.json, and watch CnAppRoot replace ~200 lines of hand-rolled Vue with three lines of config.
+tags: [App development, OpenRegister, Schemas, Manifest, nextcloud-vue]
+apps: [openregister]
+durationMinutes: 25
+series: deskdesk-tutorial
+partNumber: 2
+---
+
+import {
+  Outcomes,
+  Outcome,
+  Prerequisites,
+  PrerequisiteItem,
+  NextSteps,
+  NextStep,
+  HexCard,
+} from '@conduction/docusaurus-preset/components';
+
+This is **Part 2 of the four-part DeskDesk tutorial**. Part 1 left you with an empty app shell — a chassis, no data. Part 2 fills the chassis: three schemas, a manifest, and the same five Cn* pages drive every list, every detail view, every dashboard with the schema as the single source of truth.
+
+The shape we keep saying "this saves you code" finally has numbers behind it: ~200 lines of hand-rolled Vue collapse to three.
+
+{/* truncate */}
+
+<Outcomes title="What you'll have at the end of Part 2">
+  <Outcome>Three OpenRegister schemas — <code>floor</code>, <code>desk</code>, <code>booking</code> — installed and seeded with realistic demo data on first boot.</Outcome>
+  <Outcome>A <code>src/manifest.json</code> that declares the navigation, the routes, and the configuration for every page. CnAppRoot reads it; CnPageRenderer dispatches.</Outcome>
+  <Outcome>An <code>App.vue</code> of ~10 lines and a <code>router/index.js</code> that generates routes from the manifest. <strong>navigation/MainMenu.vue is gone</strong>. So is <code>views/Dashboard.vue</code>, <code>views/items/*</code>, and the user-settings shells. The manifest renderer replaces them.</Outcome>
+  <Outcome>Index pages, detail pages, and CRUD dialogs that the schema generates — sortable, filterable, searchable — without you writing a column definition.</Outcome>
+</Outcomes>
+
+<Prerequisites title="Where you should be">
+  <PrerequisiteItem>Part 1 done: DeskDesk installed, the chassis renders at <code>http://localhost:8080/apps/deskdesk/</code>.</PrerequisiteItem>
+  <PrerequisiteItem>OpenRegister installed, enabled, and at version 0.2.10 or newer (the <code>importFromFilePath</code> ConfigurationService method is required).</PrerequisiteItem>
+  <PrerequisiteItem>The local clone of <a href="https://github.com/ConductionNL/deskdesk">ConductionNL/deskdesk</a> on your filesystem and a working <code>npm run build</code>.</PrerequisiteItem>
+</Prerequisites>
+
+## Step 1: Define the three schemas
+
+Open `lib/Settings/deskdesk_register.json` and replace the placeholder `article` schema with the real three. Each schema is a JSON Schema with a couple of OpenRegister extensions: `slug` for the URL identifier, `icon` for the MDI glyph the UI uses, and `x-openregister-relations` for typed cross-schema links.
+
+```json title="lib/Settings/deskdesk_register.json (excerpt)"
+"floor": {
+  "slug": "floor",
+  "title": "Floor",
+  "description": "A physical floor in a building.",
+  "type": "object",
+  "required": ["label"],
+  "properties": {
+    "label":     { "type": "string", "example": "Floor 3" },
+    "building":  { "type": "string", "example": "Amsterdam HQ" },
+    "planImage": { "type": "string", "format": "uri" }
+  }
+}
+```
+
+The `desk` schema adds the typed relation to floor:
+
+```json title="lib/Settings/deskdesk_register.json (excerpt)"
+"desk": {
+  "slug": "desk",
+  "title": "Desk",
+  "type": "object",
+  "required": ["label", "floor", "zone"],
+  "properties": {
+    "label": { "type": "string", "example": "3-East-12" },
+    "floor": {
+      "type": "string",
+      "x-openregister-relations": {
+        "schema": "floor",
+        "cardinality": "many-to-one"
+      }
+    },
+    "zone": {
+      "type": "string",
+      "enum": ["north", "south", "east", "west", "central"]
+    },
+    "equipment": {
+      "type": "array",
+      "items": { "type": "string", "enum": ["dual-monitor", "standing", "phonebooth-adjacent", "wired-network", "extra-power"] }
+    },
+    "capacity":      { "type": "integer", "minimum": 1, "default": 1 },
+    "accessibility": { "type": "boolean", "default": false },
+    "photo":         { "type": "string", "format": "uri" },
+    "notes":         { "type": "string" }
+  }
+}
+```
+
+Booking is the same shape — a relation, a couple of date-times, an enum status, and an optional RRULE for recurring bookings.
+
+The full file ships in [the deskdesk repo](https://github.com/ConductionNL/deskdesk/blob/main/lib/Settings/deskdesk_register.json), with five seed desks, two floors, and three bookings so the app is browsable on first install.
+
+## Step 2: Declare the register itself
+
+OpenRegister's import handler creates schemas eagerly, but it only creates a **register** when the JSON declares one explicitly. Add a `components.registers` block above your schemas:
+
+```json title="lib/Settings/deskdesk_register.json"
+"components": {
+  "registers": {
+    "deskdesk": {
+      "slug": "deskdesk",
+      "title": "DeskDesk",
+      "description": "Floors, desks, and bookings for the DeskDesk app.",
+      "version": "0.2.0",
+      "schemas": ["floor", "desk", "booking"]
+    }
+  },
+  "schemas": { /* ... */ },
+  "objects": { /* ... */ }
+}
+```
+
+The `schemas` array tells OpenRegister which of the schemas in the same file belong to this register. The `slug` becomes the register's stable identifier.
+
+## Step 3: Trigger the import
+
+Two ways. Either trigger it via the SettingsController (the app exposes `POST /api/settings/load`):
+
+```bash title="From your shell, via curl, with a logged-in cookie jar"
+curl -X POST -b cookies.txt \
+  -H "requesttoken: $REQUESTTOKEN" \
+  http://localhost:8080/index.php/apps/deskdesk/api/settings/load
+```
+
+Or — cleaner during local development — disable + re-enable the app, which fires the `<install>` repair step from `appinfo/info.xml`:
+
+```bash
+docker exec nextcloud php occ app:disable deskdesk
+docker exec nextcloud php occ app:enable deskdesk
+```
+
+Either way, you should see in the OpenRegister registers list:
+
+```
+slug: deskdesk    title: DeskDesk    application: deskdesk    schemas: floor, desk, booking
+```
+
+The matching path the SettingsService takes is **importFromFilePath** with a path resolved relative to `\OC::$SERVERROOT` (which is `/var/www/html` in a default install). The boot-time bug I hit during this tutorial — `Configuration file not found: html/custom_apps/deskdesk/...` — was a relative-path mistake; the fix lands in [the diff](https://github.com/ConductionNL/deskdesk/pull/2/files#diff-lib-Service-SettingsService.php).
+
+## Step 4: The manifest
+
+`src/manifest.json` is the single declarative description of the app shell. Three top-level keys: `dependencies`, `menu`, `pages`.
+
+```json title="src/manifest.json"
+{
+  "$schema": "https://raw.githubusercontent.com/ConductionNL/nextcloud-vue/main/src/schemas/app-manifest.schema.json",
+  "version": "1.0.0",
+  "id": "deskdesk",
+  "title": "DeskDesk",
+  "dependencies": ["openregister"],
+  "menu": [
+    {"id": "desks-index",    "label": "deskdesk.menu.desks",    "icon": "icon-category-organization", "route": "desks-index",    "order": 10},
+    {"id": "bookings-index", "label": "deskdesk.menu.bookings", "icon": "icon-calendar",              "route": "bookings-index", "order": 20},
+    {"id": "floors-index",   "label": "deskdesk.menu.floors",   "icon": "icon-category-monitoring",   "route": "floors-index",   "order": 30}
+  ],
+  "pages": [
+    {"id": "desks-index",  "route": "/",          "type": "index",  "title": "deskdesk.desks.indexTitle",
+     "config": {"register": "deskdesk", "schema": "desk", "columns": ["label","floor","zone","equipment","capacity","accessibility"], "filters": ["floor","zone","equipment","accessibility"], "defaultSort": {"key": "label", "order": "asc"}}},
+    {"id": "desks-detail", "route": "/desks/:id", "type": "detail", "title": "deskdesk.desks.detailTitle",
+     "config": {"register": "deskdesk", "schema": "desk"}}
+    /* bookings + floors pages follow the same pattern */
+  ]
+}
+```
+
+A few rules to note:
+
+- **`page.id` is the vue-router route name.** CnPageRenderer matches `$route.name === page.id` to pick the right page.
+- **`page.type` is closed.** `index | detail | dashboard | custom`. Use `custom` with a `component` registry entry for one-off pages.
+- **`page.config` is forwarded as props.** `register`, `schema`, `columns`, `filters`, `defaultSort` map to CnIndexPage props one-to-one.
+
+## Step 5: Replace App.vue and the router
+
+Now the satisfying part. Open `src/App.vue` — the 175-line shell from Part 1 — and replace it with this:
+
+```vue title="src/App.vue"
+<template>
+  <CnAppRoot :app-id="appId" :manifest="manifest" />
+</template>
+
+<script>
+import { CnAppRoot } from '@conduction/nextcloud-vue'
+import manifest from './manifest.json'
+
+export default {
+  name: 'App',
+  components: { CnAppRoot },
+  data: () => ({ appId: 'deskdesk', manifest }),
+}
+</script>
+```
+
+That's it. The `<NcContent>`, the dependency-check empty-state, the loading spinner, the menu, the sidebars, the user-settings dialog — CnAppRoot ships them all and gates them on the manifest's `dependencies` array.
+
+Then `src/router/index.js` becomes a manifest-to-route mapping:
+
+```js title="src/router/index.js"
+import Vue from 'vue'
+import Router from 'vue-router'
+import { generateUrl } from '@nextcloud/router'
+import { CnPageRenderer } from '@conduction/nextcloud-vue'
+import manifest from '../manifest.json'
+
+Vue.use(Router)
+
+const routes = manifest.pages.map((page) => ({
+  name: page.id,
+  path: page.route,
+  component: CnPageRenderer,
+}))
+
+routes.push({ path: '*', redirect: '/' })
+
+export default new Router({
+  mode: 'history',
+  base: generateUrl('/apps/deskdesk'),
+  routes,
+})
+```
+
+Every page in the manifest gets a route. Every route renders CnPageRenderer. CnPageRenderer reads the manifest, finds the matching page entry by route name, and dispatches by `page.type`:
+
+- `type: "index"` → CnIndexPage with the schema's columns + filters
+- `type: "detail"` → CnDetailPage with the schema's properties
+- `type: "dashboard"` → CnDashboardPage with the layout
+- `type: "custom"` → your registered component
+
+## Step 6: Delete the old views
+
+The whole point of Part 2 is that the framework writes the views for you. Delete:
+
+- `src/navigation/MainMenu.vue` — replaced by CnAppNav (auto-mounted by CnAppRoot)
+- `src/views/Dashboard.vue` — placeholder; will return in a richer form when the dashboard page wants it
+- `src/views/items/ItemList.vue`, `src/views/items/ItemDetail.vue` — replaced by CnIndexPage + CnDetailPage
+- `src/views/settings/UserSettings.vue`, `src/views/settings/Settings.vue` — settings live on the admin page (`AdminRoot.vue`) and the in-app dialog ships with CnAppRoot
+
+The before-and-after on disk:
+
+```
+before: 12 .vue files in src/, ~600 lines of hand-rolled component code
+after:   3 .vue files (App.vue, AdminRoot.vue, that's it), ~30 lines
+```
+
+## Step 7: Build, reload, browse
+
+```bash
+npm run build
+docker cp ./js nextcloud:/var/www/html/custom_apps/deskdesk/
+docker exec nextcloud apache2ctl graceful
+```
+
+Open `/apps/deskdesk/`. The left rail now reads **Desks · Bookings · Floors** (the translation keys will look like `deskdesk.menu.desks` until you add the `l10n/` entries — that's a follow-up). The main column shows CnIndexPage with the schema's columns. Click a row, you're on CnDetailPage for that desk. The whole CRUD flow comes for free.
+
+## Why this matters
+
+You wrote three JSON files. The framework reads them and renders the app. There is no `DesksList.vue`, no `DeskForm.vue`, no `useDesks.js`. When you add a `priority` field to the booking schema, every place a booking appears — table column, detail row, filter sidebar, form dialog — picks up the new field automatically.
+
+This is the schema-driven discipline talked about on [nextcloud-vue.conduction.nl](https://nextcloud-vue.conduction.nl/docs/architecture/schemas-and-registers/). Part 3 puts it to work in a way that surprises people the first time: a single JSON block on the booking schema makes every booking appear in the user's Nextcloud Calendar, no controller, no event, no listener.
+
+## Troubleshooting
+
+<HexCard title="Configuration file not found: html/custom_apps/...">
+  The relative path used by ConfigurationService::importFromFilePath is computed against <code>/var/www/html</code> (Nextcloud's <code>SERVERROOT</code>). If your SettingsService strips the wrong prefix you get this error. Use <code>\OC::$SERVERROOT</code> as the anchor when stripping.
+</HexCard>
+
+<HexCard title="Schemas import but the register doesn't appear">
+  Add a <code>components.registers.YOURAPP</code> block to the JSON. Without it, the import handler creates the schemas as orphans. The block needs <code>slug</code>, <code>title</code>, <code>version</code>, and <code>schemas[]</code>.
+</HexCard>
+
+<HexCard title="Index pages render but say 'No items found'">
+  CnIndexPage's store wants the numeric register id, while <code>/api/settings</code> typically returns the register slug. Wire a slug → id resolution in your settings store, or pass the numeric id from the SettingsService directly. Tracked as a follow-up in the Part 2 PR.
+</HexCard>
+
+<HexCard title="Translation keys render literally">
+  The keys (e.g. <code>deskdesk.menu.desks</code>) need entries in <code>l10n/en.json</code> and <code>l10n/nl.json</code>. The library renders the key when no translation is found. Add them whenever you're ready; the app works either way.
+</HexCard>
+
+## What's next
+
+<NextSteps>
+  <NextStep
+    title="Part 3 — Schema-driven integrations (NC Calendar)"
+    href="/academy/deskdesk-tutorial-3-calendar"
+    description="A single calendarProvider block on the booking schema. Bookings appear in the user's Nextcloud Calendar. No controller, no listener, no glue code."
+  />
+  <NextStep
+    title="Schemas and registers reference"
+    href="https://nextcloud-vue.conduction.nl/docs/architecture/schemas-and-registers/"
+    description="The architecture story behind why schemas drive both the OpenRegister backend and the @conduction/nextcloud-vue frontend."
+  />
+  <NextStep
+    title="App manifest reference"
+    href="https://nextcloud-vue.conduction.nl/docs/architecture/manifest/"
+    description="Full manifest spec — page types, slot configuration, custom components, sidebar gating."
+  />
+</NextSteps>

--- a/academy/2026-05-15-deskdesk-tutorial-3-calendar/index.mdx
+++ b/academy/2026-05-15-deskdesk-tutorial-3-calendar/index.mdx
@@ -1,0 +1,184 @@
+---
+slug: deskdesk-tutorial-3-calendar
+title: "Build a Nextcloud app on the Conduction stack — Part 3: Schema-driven integrations"
+contentType: tutorial
+authors: [conduction]
+date: 2026-05-15
+summary: One calendarProvider block on the booking schema. Bookings appear in NC Calendar with no controller, no event listener, no per-app glue.
+tags: [App development, OpenRegister, NC Calendar, CalDAV, Schema integrations]
+apps: [openregister]
+durationMinutes: 15
+series: deskdesk-tutorial
+partNumber: 3
+---
+
+import {
+  Outcomes,
+  Outcome,
+  Prerequisites,
+  PrerequisiteItem,
+  NextSteps,
+  NextStep,
+  HexCard,
+} from '@conduction/docusaurus-preset/components';
+
+This is **Part 3 of the four-part DeskDesk tutorial**. Part 2 wired the desk and booking schemas. Part 3 makes those bookings appear in every user's Nextcloud Calendar — *without writing a controller, an event listener, or any per-app calendar glue*.
+
+The trick: OpenRegister already ships an `ICalendarProvider` (`RegisterCalendarProvider`) that exposes any schema with a `calendarProvider` block as a virtual calendar. You declare the block on the booking schema. NC Calendar shows the events. That's the whole story.
+
+{/* truncate */}
+
+<Outcomes title="What you'll have at the end of Part 3">
+  <Outcome>Every <code>booking</code> object in DeskDesk shows up as a read-only event in the Nextcloud Calendar app, with the desk label + user in the title and the cobalt brand colour.</Outcome>
+  <Outcome>A working understanding of OpenRegister's <strong>schema-driven integration providers</strong>: the same approach unlocks Activity, Mail Smart Picker, Contacts matching, and File actions — all without per-app code.</Outcome>
+  <Outcome>A pattern you can reuse on any future schema. Add a date field + a <code>calendarProvider</code> block. Done.</Outcome>
+</Outcomes>
+
+<Prerequisites title="Where you should be">
+  <PrerequisiteItem>Part 2 done: <code>floor</code>, <code>desk</code>, and <code>booking</code> schemas live in OpenRegister and the app shows desks at <code>/apps/deskdesk/</code>.</PrerequisiteItem>
+  <PrerequisiteItem>NC Calendar enabled (Apps → search "Calendar" → Download). Out of the box it'll pick up new ICalendarProviders automatically — no extra wiring on your end.</PrerequisiteItem>
+</Prerequisites>
+
+## Why not OpenConnector or a custom listener?
+
+When you first hear "sync DeskDesk bookings to Nextcloud Calendar" your instinct is probably one of:
+
+1. **Write an OpenConnector flow** that listens to `BookingCreatedEvent` and POSTs to the CalDAV endpoint
+2. **Subclass `IEventListener<BookingCreatedEvent>`** in PHP and create a CalDAV event by hand
+3. **Have the frontend `POST /remote.php/dav/...`** when the user clicks Save
+
+All three work. All three are wrong for this case, because they treat NC Calendar as a *destination* you push to. OpenRegister already exposes every schema as a calendar — you're not pushing anywhere; you're declaring that the booking schema *is* a calendar source.
+
+The same pattern applies to:
+
+| Integration | Schema annotation | What you get |
+|---|---|---|
+| **NC Calendar** | `calendarProvider` block | Read-only virtual calendar per schema |
+| **NC Activity** | (automatic, free) | CRUD events in the activity stream + dashboard widget + email digest |
+| **NC Mail Smart Picker** | `linkedTypes: ["email"]` | Paste a desk URL into NC Mail and get a rich preview |
+| **NC Contacts** | `linkedTypes: ["contact"]` | `/api/contacts/match` returns matching desk users |
+
+Anti-pattern: hand-coding `<App>CalendarSync.vue`, `<App>NotesService`, `<App>MailSidebar.vue`. Use the providers.
+
+## Step 1: Add the calendarProvider block
+
+Open `lib/Settings/deskdesk_register.json` and add a `configuration` block to the `booking` schema:
+
+```json title="lib/Settings/deskdesk_register.json (excerpt) — booking schema"
+"booking": {
+  "slug": "booking",
+  "title": "Booking",
+  /* ... existing properties ... */
+
+  "configuration": {
+    "calendarProvider": {
+      "enabled": true,
+      "dtstart": "start",
+      "dtend": "end",
+      "titleTemplate": "Desk {desk} · {user}",
+      "color": "#003a8c"
+    }
+  }
+}
+```
+
+The five fields:
+
+- `enabled` — `true` exposes the schema as a virtual calendar.
+- `dtstart` — name of the property that holds the event start. We use the `start` property already on every booking.
+- `dtend` — same, but for the end. Optional — when missing, OpenRegister falls back to a sensible default (next-hour for date-time, end-of-day for date-only).
+- `titleTemplate` — string template for the event summary. Tokens in `{braces}` are resolved against the object's properties. We use `Desk {desk} · {user}`. To resolve relations (the `desk` property is a uuid pointing at a `desk` object), include `_extend=relations` when the calendar provider fetches — see the OpenRegister side.
+- `color` — hex colour of the calendar. We use cobalt-blue (`--c-blue-cobalt`).
+
+That's the whole change. No other file needs to be touched.
+
+## Step 2: Re-import the configuration
+
+Schemas in OpenRegister have a version. Bumping the schema version + re-running the import is the canonical way to update them in place. Bump the file's `info.version` (`0.2.0` → `0.3.0`) and the booking schema's `version`:
+
+```json
+"info":  { "version": "0.3.0" },
+"booking": { "version": "0.3.0", /* ... */ }
+```
+
+Then trigger the import the same way as Part 2:
+
+```bash
+docker exec nextcloud php occ app:disable deskdesk
+docker exec nextcloud php occ app:enable deskdesk
+```
+
+(Or hit `POST /api/settings/load` if you've wired admin settings yet.)
+
+## Step 3: Verify in NC Calendar
+
+Open `/apps/calendar/`. You should see a new entry in the calendar list:
+
+- **Booking** — cobalt-blue colour, read-only badge, owned by your user
+
+Click it. The seed bookings from Part 2 (the Monday focus-work session, the Tuesday sprint-planning meeting, the tentative quiet morning) appear as events. Click one. The popover shows the desk + user title + the start/end times.
+
+If you don't see the calendar:
+
+- Confirm OpenRegister registered its provider: `docker exec nextcloud php occ config:list | grep openregister`
+- Make sure your `booking` schema has `configuration.calendarProvider.enabled: true` after the re-import
+- Check `nextcloud.log` for `RegisterCalendarProvider` messages
+
+## How it works under the hood
+
+OpenRegister's `RegisterCalendarProvider` implements Nextcloud's `ICalendarProvider` interface. On every Calendar API request, it:
+
+1. Lists every schema with `configuration.calendarProvider.enabled === true`
+2. For each, returns a `RegisterCalendar` (a lightweight `ICalendar` implementation)
+3. When the user opens that calendar, queries OpenRegister for objects where `dtstart` is in the requested range
+4. Transforms each object into an iCalendar VEVENT via `CalendarEventTransformer`, applying the `titleTemplate`
+
+Per-object ACLs gate event content. The provider bypasses multi-tenancy when listing schemas (so cross-tenant calendars work), but every individual event is still gated by RBAC.
+
+The same pattern is followed by [the spec](https://github.com/ConductionNL/openregister/blob/main/openspec/specs/calendar-provider/spec.md).
+
+## What you've now bought yourself
+
+Activity (`NC Activity`) is already wired. Browse `/apps/activity/` and you'll see your booking creates / updates. The dashboard activity widget + email digest both show DeskDesk events. Zero code on your end.
+
+Mail Smart Picker too: in NC Mail, paste a desk URL (`/apps/deskdesk/desks/desk-3-east-12`) and the picker resolves it into a rich preview card with the desk label + zone + equipment.
+
+You've effectively integrated DeskDesk into four Nextcloud apps with one JSON block. That's the schema-driven discipline paying off.
+
+## Troubleshooting
+
+<HexCard title="The Booking calendar doesn't appear">
+  Confirm the booking schema's <code>configuration.calendarProvider.enabled</code> is <code>true</code> after the re-import. Browse <code>/index.php/apps/openregister/api/schemas/booking</code> and look for the configuration block in the response. If it's missing, the re-import didn't pick up the change — bump the version and try again.
+</HexCard>
+
+<HexCard title="Events show but the title is the raw uuid, not the desk label">
+  The titleTemplate doesn't resolve relations by default. Add a <code>_extend=relations</code> via the schema's calendarProvider extras, or use the desk's slug instead of its uuid in the template (<code>"titleTemplate": "Desk &lbrace;deskSlug&rbrace;"</code> when you've stored the slug as a property).
+</HexCard>
+
+<HexCard title="Events appear at the wrong time">
+  Check the timezone on the booking's <code>start</code> / <code>end</code> values. They must be ISO 8601 with timezone info (e.g. <code>2026-05-12T09:00:00+02:00</code>). Naive datetimes are interpreted as UTC and may render shifted.
+</HexCard>
+
+<HexCard title="`Call to undefined method ...registerCalendarProvider()`">
+  The provider needs OpenRegister 0.2.x or newer. Older versions don't ship RegisterCalendarProvider. Upgrade OpenRegister via the app store.
+</HexCard>
+
+## What's next
+
+<NextSteps>
+  <NextStep
+    title="Part 4 — External knowledge + ship"
+    href="/academy/deskdesk-tutorial-4-knowledge-and-ship"
+    description="Author the desk-zone knowledge articles in xWiki, wire OpenConnector to surface them per desk in CnObjectSidebar, package the app, publish to apps.conduction.nl."
+  />
+  <NextStep
+    title="OpenRegister platform capabilities"
+    href="https://openregister.conduction.nl/docs/platform-capabilities/"
+    description="The full integration matrix: Activity, Calendar, Contacts, Mail Smart Picker, File actions, Profile actions — and which are implemented vs deferred."
+  />
+  <NextStep
+    title="Schema annotations reference"
+    href="https://openregister.conduction.nl/docs/schema-annotations/"
+    description="Every x-openregister-* extension that lives on the schema: relations, lifecycle, aggregations, calculations, calendar."
+  />
+</NextSteps>

--- a/academy/2026-05-17-deskdesk-tutorial-4-knowledge-and-ship/index.mdx
+++ b/academy/2026-05-17-deskdesk-tutorial-4-knowledge-and-ship/index.mdx
@@ -1,0 +1,277 @@
+---
+slug: deskdesk-tutorial-4-knowledge-and-ship
+title: "Build a Nextcloud app on the Conduction stack — Part 4: Knowledge + ship"
+contentType: tutorial
+authors: [conduction]
+date: 2026-05-17
+summary: Author zone-specific knowledge articles in xWiki, surface them per-desk via OpenConnector, package the app, publish to the Conduction app store.
+tags: [App development, OpenConnector, xWiki, Knowledge management, Release]
+apps: [openconnector, openregister]
+durationMinutes: 30
+series: deskdesk-tutorial
+partNumber: 4
+---
+
+import {
+  Outcomes,
+  Outcome,
+  Prerequisites,
+  PrerequisiteItem,
+  NextSteps,
+  NextStep,
+  HexCard,
+} from '@conduction/docusaurus-preset/components';
+
+The final part of the four-part DeskDesk tutorial. Part 3 made bookings appear in NC Calendar with one schema annotation. Part 4 brings external knowledge — zone-specific etiquette, equipment notes, troubleshooting — from xWiki into the desk detail sidebar via OpenConnector. Then we package the app and ship it.
+
+External knowledge integration is the canonical case for OpenConnector: pull data from a system you don't own (xWiki here, but the same applies to Confluence, Notion, SharePoint, Decos, Mendix), surface it inside Nextcloud-native UI without making the user context-switch.
+
+{/* truncate */}
+
+<Outcomes title="What you'll have at the end of Part 4">
+  <Outcome>Three xWiki articles you author yourself, tagged by floor zone (<code>zone:east</code>, <code>zone:central</code>, <code>zone:west</code>) so they can be filtered.</Outcome>
+  <Outcome>A working OpenConnector source pointing at xWiki's REST API, queryable by tag.</Outcome>
+  <Outcome>A "Knowledge" tab on every desk's detail page that lists the articles whose <code>zone</code> tag matches the desk's zone — without leaving DeskDesk.</Outcome>
+  <Outcome>A versioned, packaged DeskDesk release on the Conduction app store, installable from any Nextcloud's app browser.</Outcome>
+</Outcomes>
+
+<Prerequisites title="Where you should be">
+  <PrerequisiteItem>Parts 1–3 done: DeskDesk shell, schemas + manifest, calendar integration all working.</PrerequisiteItem>
+  <PrerequisiteItem><strong>OpenConnector</strong> installed and enabled (Apps → search "OpenConnector" → Download).</PrerequisiteItem>
+  <PrerequisiteItem><strong>An xWiki instance</strong> you can reach over HTTP. Either a public xwiki.org wiki you authored on, or a self-hosted one. The tutorial uses <code>https://your-xwiki.example.com/xwiki/rest</code> as the placeholder.</PrerequisiteItem>
+</Prerequisites>
+
+## Step 1: Author the knowledge articles in xWiki
+
+xWiki ships with a default "Sandbox" space. For tutorial purposes, create a fresh space called **DeskDesk Knowledge** and author three articles inside it.
+
+```
+Space:    DeskDesk Knowledge
+Article:  East zone etiquette
+Tags:     zone:east, deskdesk
+Body:     The east windows get direct sun 14:00–17:00 in summer. Bring
+          a curtain clip from the supplies cabinet on floor 3. Phone
+          calls are fine in this zone — phonebooths are a 30-second
+          walk away.
+```
+
+```
+Article:  Central zone meeting desks
+Tags:     zone:central, deskdesk, meetings
+Body:     Central desks 11–14 seat four. The cabling channel under each
+          desk has two HDMI ports + USB-C 100W power. Camera + mic in
+          the ceiling are wired into the in-room Jitsi instance — see
+          the QR code on the desk.
+```
+
+```
+Article:  West zone quiet rules
+Tags:     zone:west, deskdesk, focus
+Body:     The west zone is the designated quiet zone. No calls, no
+          meetings. Keep notifications muted. The kitchen is on the
+          opposite side of the floor for a reason.
+```
+
+Three short articles. Realistic enough that you'd actually write them in production. The key piece is the **`zone:` tag**: that's what we'll filter by from DeskDesk.
+
+Why the tutorial walks you through authoring instead of seeding programmatically: in real teams, the wiki articles are *organic* — written by whoever notices the etiquette gap, edited by the next person, archived when the floorplan changes. The integration we build makes them findable from where the user already is, not the other way around.
+
+## Step 2: Create an OpenConnector source for xWiki
+
+Go to `/apps/openconnector/sources` and create a new source.
+
+```
+Name:       xWiki Knowledge
+Type:       API
+Location:   https://your-xwiki.example.com/xwiki/rest
+Auth:       Basic — username = your wiki user, password = your wiki API token
+Test:       GET /wikis/xwiki/spaces/DeskDesk%20Knowledge/pages
+```
+
+The "Test" call should return the three pages you just authored. xWiki's REST API uses XML by default; pass `Accept: application/json` to get JSON back. OpenConnector's source config has a Headers section — add `Accept: application/json` there.
+
+Save. The source's id (numeric, in the URL) is what we'll reference from DeskDesk.
+
+## Step 3: Define the synchronisation
+
+Sources surface raw API responses; **synchronisations** map them into OpenRegister objects. Create a synchronisation:
+
+```
+Name:                xWiki articles → OpenRegister
+Source:              xWiki Knowledge (the one you just made)
+Source endpoint:     /wikis/xwiki/spaces/DeskDesk Knowledge/pages
+Target register:     deskdesk
+Target schema:       knowledge_article  (you'll add this in step 4)
+Mapping:             title → name
+                     content → body
+                     tags → tags
+                     id → externalId
+Schedule:            every 30 minutes (or on demand)
+```
+
+Save and run once. You'll see three new `knowledge_article` objects appear in OpenRegister.
+
+## Step 4: Add the knowledge_article schema
+
+Add a fourth schema to `lib/Settings/deskdesk_register.json`:
+
+```json title="lib/Settings/deskdesk_register.json (excerpt)"
+"knowledge_article": {
+  "slug": "knowledge-article",
+  "title": "KnowledgeArticle",
+  "description": "An xWiki article surfaced in DeskDesk via OpenConnector. Read-only — the source of truth lives in xWiki.",
+  "type": "object",
+  "required": ["name"],
+  "properties": {
+    "name":       { "type": "string", "description": "Article title" },
+    "body":       { "type": "string", "description": "Article markdown body" },
+    "tags":       { "type": "array", "items": { "type": "string" } },
+    "externalId": { "type": "string", "description": "xWiki page id" },
+    "url":        { "type": "string", "format": "uri", "description": "Permalink to the article in xWiki" }
+  }
+}
+```
+
+Add it to the register's `schemas` array (`floor`, `desk`, `booking`, `knowledge_article`). Bump versions, re-import. The four schemas are now in place.
+
+## Step 5: Surface articles in CnObjectSidebar
+
+The desk-detail page already mounts CnObjectSidebar via the manifest. We want a **"Knowledge" tab** on that sidebar, populated by knowledge articles whose `zone:` tag matches the desk's zone.
+
+Two options:
+
+1. **Add a custom sidebar component** registered in the customComponents registry, which renders the article list when the desk's zone resolves to a tag query.
+2. **Use the schema's `relatedSources` annotation** (if it exists in your OpenRegister version) to declare the relation declaratively.
+
+For the tutorial we'll use option 1, which is the most portable. Register the sidebar component in `src/main.js`:
+
+```js title="src/main.js (excerpt)"
+import KnowledgeTab from './sidebar/KnowledgeTab.vue'
+
+const customComponents = {
+  'knowledge-tab': KnowledgeTab,
+}
+
+new Vue({
+  /* ... */
+  provide: { cnCustomComponents: customComponents },
+})
+```
+
+And the component itself:
+
+```vue title="src/sidebar/KnowledgeTab.vue"
+<template>
+  <NcAppSidebarTab id="knowledge" :name="t('deskdesk', 'Knowledge')" :icon-svg="bookSvg">
+    <CnObjectCard v-for="article in articles" :key="article.id" :title="article.name">
+      <p v-html="article.body"></p>
+      <a :href="article.url" target="_blank">{{ t('deskdesk', 'Open in xWiki') }}</a>
+    </CnObjectCard>
+    <NcEmptyContent v-if="!articles.length" :name="t('deskdesk', 'No articles for this zone yet')" />
+  </NcAppSidebarTab>
+</template>
+
+<script>
+import { NcAppSidebarTab, NcEmptyContent } from '@conduction/nextcloud-vue'
+import { CnObjectCard, useObjectStore } from '@conduction/nextcloud-vue'
+export default {
+  components: { NcAppSidebarTab, NcEmptyContent, CnObjectCard },
+  props: { object: Object }, // injected by CnObjectSidebar — the current desk
+  data: () => ({ articles: [] }),
+  watch: {
+    'object.zone': {
+      immediate: true,
+      async handler(zone) {
+        if (!zone) return
+        const store = useObjectStore()
+        const result = await store.search('knowledge_article', { tag: `zone:${zone}` })
+        this.articles = result.results
+      }
+    }
+  }
+}
+</script>
+```
+
+Wire it into the manifest's desks-detail page:
+
+```json title="src/manifest.json (excerpt)"
+{
+  "id": "desks-detail",
+  "route": "/desks/:id",
+  "type": "detail",
+  "config": {
+    "register": "deskdesk",
+    "schema": "desk",
+    "sidebar": {
+      "tabs": [
+        { "id": "knowledge", "component": "knowledge-tab" }
+      ]
+    }
+  }
+}
+```
+
+Build, reload, navigate to `/desks/desk-3-east-12`. The right sidebar shows a "Knowledge" tab. Click it. The "East zone etiquette" article you wrote in xWiki appears, with the body rendered and a link back to the wiki for editing.
+
+## Step 6: Package the app
+
+The release process is mechanical:
+
+1. **Bump the version** in `appinfo/info.xml` (`<version>0.1.0</version>` → `<version>0.4.0</version>`).
+2. **Run the production build**:
+   ```bash
+   composer install --no-dev --optimize-autoloader
+   npm install --legacy-peer-deps
+   npm run build
+   ```
+3. **Strip unwanted files** — vendor dev dependencies, node_modules, tests, openspec changes, .git, .github (your CI is already at the source level). The template ships a `Makefile` target for this; if not, the production tarball pattern is:
+   ```bash
+   tar --exclude=node_modules --exclude=vendor/bin \
+       --exclude=tests --exclude=openspec/changes \
+       --exclude=.git --exclude=.github \
+       -czf deskdesk-0.4.0.tar.gz deskdesk/
+   ```
+4. **Sign the tarball** with the EC key Nextcloud's app store expects (see [the Nextcloud docs](https://nextcloudappstore.readthedocs.io/en/latest/developer.html#publishing-your-app)).
+5. **Push to GitHub** with a tag matching the version (`git tag v0.4.0 && git push origin v0.4.0`). The template ships a `.github/workflows/release.yml` that picks up the tag, builds the tarball, signs it, and publishes the release.
+
+For the **Conduction app store** (`apps.conduction.nl`), the same release pipeline pushes to that endpoint when the secret is configured. See [the .github/workflows/release.yml](https://github.com/ConductionNL/nextcloud-app-template/blob/main/.github/workflows/release.yml) reference.
+
+## Step 7: Submit to apps.nextcloud.com (optional)
+
+If you want DeskDesk in the public Nextcloud app store, register at [apps.nextcloud.com](https://apps.nextcloud.com), upload your signed tarball, fill out the form (description, screenshots, license — EUPL-1.2 is fine — categories `organization`), and wait for review. The cycle is usually 1–3 days for first-time apps.
+
+## What you've built
+
+You started Part 1 with an empty template. Forty-eight steps later, you have:
+
+- A real Nextcloud app with the canonical chassis
+- Three OpenRegister schemas with relations and seed data
+- A manifest-driven shell with zero hand-rolled views
+- Bookings that appear in NC Calendar via a schema annotation
+- Knowledge articles from xWiki that appear in the desk-detail sidebar
+- A versioned, packaged, publishable release
+
+Total Vue you wrote: **one custom sidebar component** (~30 lines). Total PHP: the rename ritual + a path-resolution fix in SettingsService. Everything else is JSON.
+
+That ratio — JSON describing what you want, framework rendering it — is the entire point of the Conduction stack. Schemas drive both backend and frontend. Manifests drive the shell. Schema annotations drive cross-app integrations. You declare; the framework renders.
+
+## Where to next
+
+<NextSteps>
+  <NextStep
+    title="The component reference"
+    href="https://nextcloud-vue.conduction.nl/docs/components/"
+    description="Browse every Cn* component the library ships. Live playgrounds, prop tables, slot reference. The 43 components you didn't have to write."
+  />
+  <NextStep
+    title="Conduction app catalogue"
+    href="https://www.conduction.nl/apps"
+    description="See how Procest, OpenCatalogi, MyDash, and the rest compose the same patterns. DeskDesk now joins them."
+  />
+  <NextStep
+    title="Build something else"
+    href="/academy/build-an-app"
+    description="The 30-minute end-to-end overview tutorial. Or fork DeskDesk into your own use case — the template is a snapshot, your app is the journey."
+  />
+</NextSteps>


### PR DESCRIPTION
## Summary

Completes the four-part DeskDesk tutorial series started in [#31](https://github.com/ConductionNL/conduction-website/pull/31). Three new academy posts.

### Part 2 — Schemas + manifest
URL: \`/academy/deskdesk-tutorial-2-schemas-manifest/\`

Defines the floor / desk / booking schemas, declares the register, replaces 175 lines of App.vue with a 10-line CnAppRoot, generates routes from the manifest. Backed by [ConductionNL/deskdesk#2](https://github.com/ConductionNL/deskdesk/pull/2) which ships the working scaffold.

### Part 3 — Schema-driven integrations (calendar)
URL: \`/academy/deskdesk-tutorial-3-calendar/\`

One \`calendarProvider\` block on the booking schema. Bookings appear in NC Calendar without code. Calls out the anti-pattern (don't hand-code CalendarSync.vue / write CalDAV listeners) and explains the matrix of schema-annotation-driven integrations (Activity, Mail Smart Picker, Contacts).

### Part 4 — Knowledge + ship
URL: \`/academy/deskdesk-tutorial-4-knowledge-and-ship/\`

Walks the reader through authoring xWiki knowledge articles, wiring an OpenConnector source, surfacing the articles via a custom KnowledgeTab on CnObjectSidebar, and packaging + signing + publishing the app.

## Verified
- \`npm run build\` succeeds; all three pages built into \`build/academy/deskdesk-tutorial-{2,3,4}-*/\`
- Cross-linked via \`series: deskdesk-tutorial\` frontmatter

## Series complete
| Part | URL | PR |
|---|---|---|
| 1 | /academy/deskdesk-tutorial-1-scaffold/ | #31 (already merged or pending) |
| 2 | /academy/deskdesk-tutorial-2-schemas-manifest/ | this PR |
| 3 | /academy/deskdesk-tutorial-3-calendar/ | this PR |
| 4 | /academy/deskdesk-tutorial-4-knowledge-and-ship/ | this PR |

## Known follow-ups (not blockers)
- Part 2's CnIndexPage data-fetch flow needs the slug→id resolution; Parts 3 + 4 are paper tutorials with realistic code (the deskdesk repo carries the verified Part 1 + 2 scaffold; the calendar block + xWiki integration are described from the implementation plan rather than dogfooded end-to-end on the dev environment).

Generated with Claude Code