### PR TITLE
academy: real xWiki setup steps in Part 4 of the DeskDesk tutorial

### DIFF
--- a/academy/2026-05-17-deskdesk-tutorial-4-knowledge-and-ship/index.mdx
+++ b/academy/2026-05-17-deskdesk-tutorial-4-knowledge-and-ship/index.mdx
@@ -4,10 +4,10 @@ title: "Build a Nextcloud app on the Conduction stack — Part 4: Knowledge + sh
 contentType: tutorial
 authors: [conduction]
 date: 2026-05-17
-summary: Author zone-specific knowledge articles in xWiki, surface them per-desk via OpenConnector, package the app, publish to the Conduction app store.
+summary: Spin up xWiki locally, author zone-specific knowledge articles, surface them per-desk via an OpenRegister knowledge_article schema, package the app, publish to the Conduction app store.
 tags: [App development, OpenConnector, xWiki, Knowledge management, Release]
 apps: [openconnector, openregister]
-durationMinutes: 30
+durationMinutes: 35
 series: deskdesk-tutorial
 partNumber: 4
 ---
@@ -22,204 +22,352 @@ import {
   HexCard,
 } from '@conduction/docusaurus-preset/components';
 
-The final part of the four-part DeskDesk tutorial. Part 3 made bookings appear in NC Calendar with one schema annotation. Part 4 brings external knowledge — zone-specific etiquette, equipment notes, troubleshooting — from xWiki into the desk detail sidebar via OpenConnector. Then we package the app and ship it.
+The final part of the four-part DeskDesk tutorial. Part 3 made bookings appear in NC Calendar with one schema annotation. Part 4 brings external knowledge — zone-specific etiquette, equipment notes, troubleshooting — from xWiki into the desk detail sidebar via a `knowledge_article` OpenRegister schema. Then we package the app and ship it.
 
 External knowledge integration is the canonical case for OpenConnector: pull data from a system you don't own (xWiki here, but the same applies to Confluence, Notion, SharePoint, Decos, Mendix), surface it inside Nextcloud-native UI without making the user context-switch.
 
 {/* truncate */}
 
 <Outcomes title="What you'll have at the end of Part 4">
-  <Outcome>Three xWiki articles you author yourself, tagged by floor zone (<code>zone:east</code>, <code>zone:central</code>, <code>zone:west</code>) so they can be filtered.</Outcome>
-  <Outcome>A working OpenConnector source pointing at xWiki's REST API, queryable by tag.</Outcome>
-  <Outcome>A "Knowledge" tab on every desk's detail page that lists the articles whose <code>zone</code> tag matches the desk's zone — without leaving DeskDesk.</Outcome>
+  <Outcome>A running xWiki instance on <code>http://localhost:8086</code>, on the same Docker network as Nextcloud, sharing the existing Postgres.</Outcome>
+  <Outcome>Three xWiki articles you author yourself, scoped by zone (<code>DeskDeskKnowledge.East.Etiquette</code>, <code>.Central.MeetingDesks</code>, <code>.West.QuietRules</code>).</Outcome>
+  <Outcome>A new <code>knowledge_article</code> OpenRegister schema in DeskDesk, with seed data matching what xWiki holds.</Outcome>
+  <Outcome>A "Knowledge" tab on every desk's detail page that lists the articles whose <code>zone</code> matches the desk's zone, without leaving DeskDesk.</Outcome>
   <Outcome>A versioned, packaged DeskDesk release on the Conduction app store, installable from any Nextcloud's app browser.</Outcome>
 </Outcomes>
 
 <Prerequisites title="Where you should be">
   <PrerequisiteItem>Parts 1–3 done: DeskDesk shell, schemas + manifest, calendar integration all working.</PrerequisiteItem>
-  <PrerequisiteItem><strong>OpenConnector</strong> installed and enabled (Apps → search "OpenConnector" → Download).</PrerequisiteItem>
-  <PrerequisiteItem><strong>An xWiki instance</strong> you can reach over HTTP. Either a public xwiki.org wiki you authored on, or a self-hosted one. The tutorial uses <code>https://your-xwiki.example.com/xwiki/rest</code> as the placeholder.</PrerequisiteItem>
+  <PrerequisiteItem>A local Nextcloud + OpenRegister stack you can <code>docker exec</code> into. The reference stack at <a href="/academy/nextcloud-lokaal-draaien">Nextcloud lokaal draaien met Docker</a> is what we test against; it already ships the xWiki service we'll start in Step 0.</PrerequisiteItem>
+  <PrerequisiteItem><strong>OpenConnector</strong> installed and enabled, for when you switch from seed data to a live xWiki sync later in the tutorial.</PrerequisiteItem>
 </Prerequisites>
 
-## Step 1: Author the knowledge articles in xWiki
+## Step 0: Spin up xWiki
 
-xWiki ships with a default "Sandbox" space. For tutorial purposes, create a fresh space called **DeskDesk Knowledge** and author three articles inside it.
+The Conduction dev stack already declares an xWiki service under the `xwiki` profile of `apps-extra/openregister/docker-compose.yml`:
 
-```
-Space:    DeskDesk Knowledge
-Article:  East zone etiquette
-Tags:     zone:east, deskdesk
-Body:     The east windows get direct sun 14:00–17:00 in summer. Bring
-          a curtain clip from the supplies cabinet on floor 3. Phone
-          calls are fine in this zone — phonebooths are a 30-second
-          walk away.
-```
-
-```
-Article:  Central zone meeting desks
-Tags:     zone:central, deskdesk, meetings
-Body:     Central desks 11–14 seat four. The cabling channel under each
-          desk has two HDMI ports + USB-C 100W power. Camera + mic in
-          the ceiling are wired into the in-room Jitsi instance — see
-          the QR code on the desk.
+```yaml title="openregister/docker-compose.yml (excerpt)"
+  xwiki:
+    profiles: [xwiki, integrations]
+    image: xwiki:lts-postgres-tomcat
+    container_name: openregister-xwiki
+    ports: ["8086:8080"]
+    volumes: ["xwiki-data:/usr/local/xwiki"]
+    environment:
+      DB_USER: nextcloud
+      DB_PASSWORD: "!ChangeMe!"
+      DB_HOST: db
+      DB_DATABASE: xwiki
+    depends_on: [db]
 ```
 
-```
-Article:  West zone quiet rules
-Tags:     zone:west, deskdesk, focus
-Body:     The west zone is the designated quiet zone. No calls, no
-          meetings. Keep notifications muted. The kitchen is on the
-          opposite side of the floor for a reason.
+xWiki shares the Postgres container with Nextcloud + OpenRegister, but uses a separate database called `xwiki`. Create it once:
+
+```bash
+docker exec openregister-postgres psql -U nextcloud -d postgres -c "CREATE DATABASE xwiki;"
 ```
 
-Three short articles. Realistic enough that you'd actually write them in production. The key piece is the **`zone:` tag**: that's what we'll filter by from DeskDesk.
+Now start xWiki with the profile:
+
+```bash
+cd apps-extra/openregister
+docker compose --profile xwiki up -d xwiki
+```
+
+The first boot takes about a minute — xWiki initialises its schema in the empty Postgres database and unpacks bundled webapps. Wait for the health check to flip to healthy:
+
+```bash
+docker ps --filter name=openregister-xwiki --format '{{.Status}}'
+# Up 22 seconds (health: starting)   <- still booting
+# Up 1 minute (healthy)              <- ready
+```
+
+Open `http://localhost:8086`. xWiki redirects to its **Distribution Wizard** because the empty database has no admin user and no flavor.
+
+## Step 0a: Walk the Distribution Wizard
+
+1. **Continue** past the welcome screen.
+2. **Step 1 - Admin user.** Fill in:
+   ```
+   First Name:  Desk
+   Last Name:   Admin
+   Username:    admin
+   Password:    admin1234     (any 8+ chars works)
+   Confirm:     admin1234
+   Email:       admin@deskdesk.local
+   ```
+   Click **Register and login**. You're now signed in as `admin`.
+3. **Step 2 - Flavor.** Click **Let the wiki be empty** (the bundled Standard Flavor is a ~150 MB download we don't need for this tutorial). Confirm.
+4. **Step 5 - Report** lists the pages created (just `Home` and `XWiki`). Click **Continue** to land on the Main page.
+
+The wiki is now bootstrapped. Sanity-check the REST endpoint:
+
+```bash
+curl -u admin:admin1234 -H 'Accept: application/json' \
+  http://localhost:8086/rest/wikis/xwiki/spaces | head -c 200
+# {"links":[],"spaces":[{"links":[...,"id":"xwiki:XWiki", ...}]}
+```
+
+Two things to note about the URL: the REST API lives at `/rest`, **not** `/xwiki/rest` (the latter is the human view path), and basic auth is the default.
+
+## Step 1: Author the knowledge articles
+
+For tutorial purposes we use a dedicated parent space **DeskDeskKnowledge** with one subspace per zone. The folder layout matches the desk's `zone` enum (`east`, `central`, `west`, `north`, `south`) so each desk maps cleanly to its zone's articles.
+
+You can author the articles via xWiki's UI (Create Page → set parent space → write content). Faster path: drive xWiki's REST API directly. The same payload shape works from cURL, OpenConnector, or any HTTP client.
+
+```bash title="Three short articles, one PUT each"
+put() {
+  curl -s -u admin:admin1234 -X PUT \
+    -H "Content-Type: application/xml" \
+    -d "<page xmlns=\"http://www.xwiki.org\"><title>$3</title><syntax>xwiki/2.1</syntax><content>$4</content></page>" \
+    "http://localhost:8086/rest/wikis/xwiki/spaces/DeskDeskKnowledge/spaces/$1/pages/$2" \
+    -o /dev/null -w "%{http_code} $1/$2\n"
+}
+put East    Etiquette     "East zone etiquette" \
+    "The east windows get direct sun 14:00 to 17:00 in summer. Bring a curtain clip from the supplies cabinet on floor 3. Phone calls are fine in this zone, phonebooths are a 30-second walk away."
+put Central MeetingDesks  "Central zone meeting desks" \
+    "Central desks 11 to 14 seat four. The cabling channel under each desk has two HDMI ports and USB-C 100W power. Camera and mic in the ceiling are wired into the in-room Jitsi instance. See the QR code on the desk."
+put West    QuietRules    "West zone quiet rules" \
+    "The west zone is the designated quiet zone. No calls, no meetings. Keep notifications muted. The kitchen is on the opposite side of the floor for a reason."
+```
+
+Each call returns `201`. Browse to `http://localhost:8086/xwiki/bin/view/DeskDeskKnowledge/East/Etiquette` to see the East article in xWiki's standard view. The same content is also fetchable via REST:
+
+```bash
+curl -u admin:admin1234 \
+  http://localhost:8086/rest/wikis/xwiki/spaces/DeskDeskKnowledge/spaces/East/pages
+```
+
+Three short articles. Realistic enough that you'd actually write them in production. The key piece is the **subspace name**: that's what we'll pivot on from DeskDesk's side.
 
 Why the tutorial walks you through authoring instead of seeding programmatically: in real teams, the wiki articles are *organic* — written by whoever notices the etiquette gap, edited by the next person, archived when the floorplan changes. The integration we build makes them findable from where the user already is, not the other way around.
 
-## Step 2: Create an OpenConnector source for xWiki
+## Step 2: Add a knowledge_article schema to DeskDesk
+
+Before we sync from xWiki, give OpenRegister a place to put the articles. Add a fourth schema to `lib/Settings/deskdesk_register.json`:
+
+```json title="lib/Settings/deskdesk_register.json (excerpt)"
+"knowledge_article": {
+  "slug": "knowledge_article",
+  "icon": "BookOpenVariantOutline",
+  "version": "0.1.0",
+  "title": "Knowledge article",
+  "description": "An external knowledge article surfaced in DeskDesk via OpenConnector. Read-only — canonical source lives in xWiki.",
+  "type": "object",
+  "required": ["name", "zone"],
+  "properties": {
+    "name":       { "type": "string" },
+    "zone":       { "type": "string", "enum": ["north", "south", "east", "west", "central"] },
+    "body":       { "type": "string" },
+    "url":        { "type": "string", "format": "uri" },
+    "externalId": { "type": "string" }
+  }
+}
+```
+
+Important: the **JSON key** and the **`slug` field must match** (`knowledge_article` on both sides). OpenRegister builds the REST endpoint from the slug, so a mismatch yields `Schema not found: 'knowledge_article'` at fetch time.
+
+While you're in there, bump the register's `info.version` to `0.3.0` so the import handler picks the new schema up on next run:
+
+```json title="lib/Settings/deskdesk_register.json (info block)"
+"info": {
+  "title": "DeskDesk Register",
+  "description": "Floors, desks, bookings, and knowledge articles.",
+  "version": "0.3.0"
+}
+```
+
+Also seed three articles matching the xWiki content. The seeds make the app demo-able before you wire the sync, and serve as a reference shape for the OpenConnector mapping you'll build in Step 3.
+
+```json title="components.objects (excerpt)"
+"knowledge-east-etiquette": {
+  "@self": { "register": "deskdesk", "schema": "knowledge_article", "slug": "knowledge-east-etiquette" },
+  "name": "East zone etiquette",
+  "zone": "east",
+  "body": "The east windows get direct sun 14:00 to 17:00 in summer...",
+  "url": "http://localhost:8086/xwiki/bin/view/DeskDeskKnowledge/East/Etiquette",
+  "externalId": "xwiki:DeskDeskKnowledge.East.Etiquette"
+}
+```
+
+Add the `knowledge_article` slug to the small list `SettingsService::SCHEMA_SLUGS` in [lib/Service/SettingsService.php](https://github.com/ConductionNL/deskdesk/blob/main/lib/Service/SettingsService.php) so `/api/settings` exposes its numeric id alongside the other schemas. Same in `src/store/store.js`:
+
+```js title="src/store/store.js"
+const SCHEMAS = ['floor', 'desk', 'booking', 'knowledge_article']
+```
+
+Reload the configuration so OpenRegister picks up the new schema + seeds:
+
+```bash
+docker exec nextcloud apache2ctl graceful
+# then from your Nextcloud session, POST /apps/deskdesk/api/settings/load
+# (the deskdesk admin page has a Reload button that does this for you)
+```
+
+## Step 3: Create an OpenConnector source for xWiki
+
+The seeds get the UI working immediately. For *live* data — when an article changes in xWiki you want to see the change in DeskDesk on the next sync — you wire OpenConnector.
 
 Go to `/apps/openconnector/sources` and create a new source.
 
 ```
 Name:       xWiki Knowledge
 Type:       API
-Location:   https://your-xwiki.example.com/xwiki/rest
-Auth:       Basic — username = your wiki user, password = your wiki API token
-Test:       GET /wikis/xwiki/spaces/DeskDesk%20Knowledge/pages
+Location:   http://openregister-xwiki:8080/rest
+            (container-to-container hostname; from the host you use http://localhost:8086/rest)
+Auth:       Basic
+Username:   admin
+Password:   admin1234
+Headers:    Accept: application/json
+Test:       GET /wikis/xwiki/spaces/DeskDeskKnowledge/spaces/East/pages
 ```
 
-The "Test" call should return the three pages you just authored. xWiki's REST API uses XML by default; pass `Accept: application/json` to get JSON back. OpenConnector's source config has a Headers section — add `Accept: application/json` there.
+The Test should return the East article. OpenConnector saves the source with a numeric id; we reference it from the synchronisation in the next step.
 
-Save. The source's id (numeric, in the URL) is what we'll reference from DeskDesk.
-
-## Step 3: Define the synchronisation
+## Step 4: Define the synchronisation
 
 Sources surface raw API responses; **synchronisations** map them into OpenRegister objects. Create a synchronisation:
 
 ```
-Name:                xWiki articles → OpenRegister
-Source:              xWiki Knowledge (the one you just made)
-Source endpoint:     /wikis/xwiki/spaces/DeskDesk Knowledge/pages
-Target register:     deskdesk
-Target schema:       knowledge_article  (you'll add this in step 4)
-Mapping:             title → name
-                     content → body
-                     tags → tags
-                     id → externalId
-Schedule:            every 30 minutes (or on demand)
+Name:             xWiki articles → OpenRegister
+Source:           xWiki Knowledge (the one you just made)
+Source endpoint:  /wikis/xwiki/spaces/DeskDeskKnowledge/spaces/{zone}/pages
+                  with zone iterated over ['East', 'Central', 'West']
+Target register:  deskdesk
+Target schema:    knowledge_article
+Mapping:
+  title           → name
+  content         → body
+  spaces.last     → zone     (lowercased)
+  id              → externalId
+  xwikiAbsoluteUrl → url
+Schedule:         every 30 minutes
 ```
 
-Save and run once. You'll see three new `knowledge_article` objects appear in OpenRegister.
-
-## Step 4: Add the knowledge_article schema
-
-Add a fourth schema to `lib/Settings/deskdesk_register.json`:
-
-```json title="lib/Settings/deskdesk_register.json (excerpt)"
-"knowledge_article": {
-  "slug": "knowledge-article",
-  "title": "KnowledgeArticle",
-  "description": "An xWiki article surfaced in DeskDesk via OpenConnector. Read-only — the source of truth lives in xWiki.",
-  "type": "object",
-  "required": ["name"],
-  "properties": {
-    "name":       { "type": "string", "description": "Article title" },
-    "body":       { "type": "string", "description": "Article markdown body" },
-    "tags":       { "type": "array", "items": { "type": "string" } },
-    "externalId": { "type": "string", "description": "xWiki page id" },
-    "url":        { "type": "string", "format": "uri", "description": "Permalink to the article in xWiki" }
-  }
-}
-```
-
-Add it to the register's `schemas` array (`floor`, `desk`, `booking`, `knowledge_article`). Bump versions, re-import. The four schemas are now in place.
+Save and run once. You'll see three `knowledge_article` objects in OpenRegister whose `externalId` field starts with `xwiki:`. Delete the seed objects you added in Step 2 — they're superseded by the synced ones.
 
 ## Step 5: Surface articles in CnObjectSidebar
 
-The desk-detail page already mounts CnObjectSidebar via the manifest. We want a **"Knowledge" tab** on that sidebar, populated by knowledge articles whose `zone:` tag matches the desk's zone.
-
-Two options:
-
-1. **Add a custom sidebar component** registered in the customComponents registry, which renders the article list when the desk's zone resolves to a tag query.
-2. **Use the schema's `relatedSources` annotation** (if it exists in your OpenRegister version) to declare the relation declaratively.
-
-For the tutorial we'll use option 1, which is the most portable. Register the sidebar component in `src/main.js`:
-
-```js title="src/main.js (excerpt)"
-import KnowledgeTab from './sidebar/KnowledgeTab.vue'
-
-const customComponents = {
-  'knowledge-tab': KnowledgeTab,
-}
-
-new Vue({
-  /* ... */
-  provide: { cnCustomComponents: customComponents },
-})
-```
-
-And the component itself:
-
-```vue title="src/sidebar/KnowledgeTab.vue"
-<template>
-  <NcAppSidebarTab id="knowledge" :name="t('deskdesk', 'Knowledge')" :icon-svg="bookSvg">
-    <CnObjectCard v-for="article in articles" :key="article.id" :title="article.name">
-      <p v-html="article.body"></p>
-      <a :href="article.url" target="_blank">{{ t('deskdesk', 'Open in xWiki') }}</a>
-    </CnObjectCard>
-    <NcEmptyContent v-if="!articles.length" :name="t('deskdesk', 'No articles for this zone yet')" />
-  </NcAppSidebarTab>
-</template>
-
-<script>
-import { NcAppSidebarTab, NcEmptyContent } from '@conduction/nextcloud-vue'
-import { CnObjectCard, useObjectStore } from '@conduction/nextcloud-vue'
-export default {
-  components: { NcAppSidebarTab, NcEmptyContent, CnObjectCard },
-  props: { object: Object }, // injected by CnObjectSidebar — the current desk
-  data: () => ({ articles: [] }),
-  watch: {
-    'object.zone': {
-      immediate: true,
-      async handler(zone) {
-        if (!zone) return
-        const store = useObjectStore()
-        const result = await store.search('knowledge_article', { tag: `zone:${zone}` })
-        this.articles = result.results
-      }
-    }
-  }
-}
-</script>
-```
-
-Wire it into the manifest's desks-detail page:
+The desk-detail page already mounts CnObjectSidebar. To add a **Knowledge tab** on it, declare a custom tab in the manifest:
 
 ```json title="src/manifest.json (excerpt)"
 {
   "id": "desks-detail",
   "route": "/desks/:id",
   "type": "detail",
+  "title": "deskdesk.desks.detailTitle",
   "config": {
     "register": "deskdesk",
     "schema": "desk",
     "sidebar": {
       "tabs": [
-        { "id": "knowledge", "component": "knowledge-tab" }
+        { "id": "data",      "label": "deskdesk.sidebar.data",      "widgets": [{ "type": "data" }] },
+        { "id": "knowledge", "label": "deskdesk.sidebar.knowledge", "component": "knowledge-tab" },
+        { "id": "metadata",  "label": "deskdesk.sidebar.metadata",  "widgets": [{ "type": "metadata" }] }
       ]
     }
   }
 }
 ```
 
-Build, reload, navigate to `/desks/desk-3-east-12`. The right sidebar shows a "Knowledge" tab. Click it. The "East zone etiquette" article you wrote in xWiki appears, with the body rendered and a link back to the wiki for editing.
+The `data` and `metadata` tabs use built-in widget types. The `knowledge` tab points at a custom component `knowledge-tab`, which the App registers via the `customComponents` map.
+
+Create the tab component itself at `src/views/KnowledgeTab.vue`:
+
+```vue title="src/views/KnowledgeTab.vue"
+<template>
+  <div class="knowledge-tab">
+    <NcLoadingIcon v-if="loading" :size="32" />
+    <NcEmptyContent
+      v-else-if="!articles.length"
+      :name="t('deskdesk', 'No articles for this zone yet')" />
+    <article v-for="article in articles" :key="article.id" class="knowledge-tab__article">
+      <header class="knowledge-tab__head">
+        <h3>{{ article.name }}</h3>
+        <a v-if="article.url" :href="article.url" target="_blank" rel="noopener noreferrer">
+          {{ t('deskdesk', 'Open in wiki') }} ↗
+        </a>
+      </header>
+      <p class="knowledge-tab__body">{{ article.body }}</p>
+    </article>
+  </div>
+</template>
+
+<script>
+import { NcEmptyContent, NcLoadingIcon } from '@nextcloud/vue'
+import { useObjectStore } from '../store/store.js'
+
+export default {
+  name: 'KnowledgeTab',
+  components: { NcEmptyContent, NcLoadingIcon },
+  props: {
+    objectId:   { type: String, required: true },
+    objectType: { type: String, default: 'desk' },
+  },
+  setup() { return { objectStore: useObjectStore() } },
+  data() { return { articles: [], loading: true } },
+  watch: {
+    objectId: {
+      immediate: true,
+      async handler() {
+        this.loading = true
+        try {
+          const desk = await this.objectStore.fetchObject(this.objectType, this.objectId)
+          if (!desk?.zone) { this.articles = []; return }
+          await this.objectStore.fetchCollection('knowledge_article', { zone: desk.zone, _limit: 25 })
+          this.articles = this.objectStore.collections.knowledge_article || []
+        } finally { this.loading = false }
+      },
+    },
+  },
+}
+</script>
+```
+
+Register the component in `src/App.vue` and pass it to `CnAppRoot` via the `:custom-components` prop:
+
+```vue title="src/App.vue (excerpt)"
+<script>
+import KnowledgeTab from './views/KnowledgeTab.vue'
+
+const customComponents = {
+  'knowledge-tab': KnowledgeTab,
+}
+
+export default {
+  /* ... */
+  data() {
+    return { customComponents, /* ... */ }
+  },
+}
+</script>
+
+<template>
+  <CnAppRoot
+    :app-id="appId"
+    :manifest="manifest"
+    :page-types="pageTypes"
+    :custom-components="customComponents">
+    <template #sidebar>
+      <CnObjectSidebar v-if="objectSidebarState.active" ... />
+    </template>
+  </CnAppRoot>
+</template>
+```
+
+(See the [reference repo](https://github.com/ConductionNL/deskdesk/blob/main/src/App.vue) for the complete file — App.vue also provides `objectSidebarState` so CnDetailPage's external-sidebar channel works.)
+
+Build, reload, navigate to a 3-East desk's detail URL. The right sidebar shows three tabs — Data, Knowledge, Metadata. Click **Knowledge**. The "East zone etiquette" article appears, with the body rendered and a link back to the wiki for editing.
+
+Navigate to a 2-West desk: same tab, different article ("West zone quiet rules"). The zone filter does the matching for free; you didn't write per-desk wiring.
 
 ## Step 6: Package the app
 
 The release process is mechanical:
 
 1. **Bump the version** in `appinfo/info.xml` (`<version>0.1.0</version>` → `<version>0.4.0</version>`).
-2. **Run the production build**:
+2. **Run the production build:**
    ```bash
    composer install --no-dev --optimize-autoloader
    npm install --legacy-peer-deps
@@ -246,15 +394,33 @@ If you want DeskDesk in the public Nextcloud app store, register at [apps.nextcl
 You started Part 1 with an empty template. Forty-eight steps later, you have:
 
 - A real Nextcloud app with the canonical chassis
-- Three OpenRegister schemas with relations and seed data
-- A manifest-driven shell with zero hand-rolled views
+- Four OpenRegister schemas with relations and seed data
+- A manifest-driven shell with two small wrappers (Index, Detail) that go away once the library wires auto-fetch into the default page types
 - Bookings that appear in NC Calendar via a schema annotation
-- Knowledge articles from xWiki that appear in the desk-detail sidebar
+- Knowledge articles from xWiki that appear in the desk-detail sidebar via OpenConnector
 - A versioned, packaged, publishable release
 
-Total Vue you wrote: **one custom sidebar component** (~30 lines). Total PHP: the rename ritual + a path-resolution fix in SettingsService. Everything else is JSON.
+Total Vue you wrote: **three small files** (`IndexPageWrapper`, `DetailPageWrapper`, `KnowledgeTab`) — about 100 lines together. Total PHP: the rename ritual + a path-resolution fix in SettingsService + the schema-slug list. Everything else is JSON.
 
 That ratio — JSON describing what you want, framework rendering it — is the entire point of the Conduction stack. Schemas drive both backend and frontend. Manifests drive the shell. Schema annotations drive cross-app integrations. You declare; the framework renders.
+
+## Troubleshooting
+
+<HexCard title='"Schema not found: knowledge_article" at fetch time'>
+  The schema's JSON key and the <code>slug</code> field must match. If you used <code>knowledge-article</code> (hyphen) for one and <code>knowledge_article</code> (underscore) for the other, OpenRegister's URL lookup fails. Pick one, use it both places.
+</HexCard>
+
+<HexCard title="Sidebar tabs render but the desk body says 'No data available'">
+  CnPageRenderer forwards <code>page.config</code> and <code>$route.params</code> as raw props. The route param is <code>id</code> but CnDetailPage's prop is <code>objectId</code>. The DetailPageWrapper bridges the names + fetches the object via the store; without the wrapper, CnDetailPage just renders the empty state.
+</HexCard>
+
+<HexCard title="xWiki Distribution Wizard wants to download Flavor and the container has no internet">
+  Pick <strong>Let the wiki be empty</strong> at Step 2. The empty flavor still supports REST + page creation, which is all the tutorial needs.
+</HexCard>
+
+<HexCard title="OpenConnector source 'Test' returns HTML instead of JSON">
+  Set <code>Accept: application/json</code> in the source's Headers section. xWiki defaults to XML for REST responses, but content-negotiates JSON when asked.
+</HexCard>
 
 ## Where to next
 
@@ -262,7 +428,7 @@ That ratio — JSON describing what you want, framework rendering it — is the 
   <NextStep
     title="The component reference"
     href="https://nextcloud-vue.conduction.nl/docs/components/"
-    description="Browse every Cn* component the library ships. Live playgrounds, prop tables, slot reference. The 43 components you didn't have to write."
+    description="Browse every Cn* component the library ships. Live playgrounds, prop tables, slot reference."
   />
   <NextStep
     title="Conduction app catalogue"


### PR DESCRIPTION
## Summary

Rewrites Part 4 of the DeskDesk tutorial from a paper walkthrough with placeholder URLs to the actual flow we ran against a local xWiki + the [ConductionNL/deskdesk#4](https://github.com/ConductionNL/deskdesk/pull/4) reference implementation that just merged.

## What's new

- **Step 0 + 0a**: actual docker-compose profile, postgres database bootstrap, Distribution Wizard walk-through ("Let the wiki be empty" path so no internet is required for the bundled flavor).
- **Step 1**: REST PUT recipe for three zone-scoped articles using a subspace-per-zone shape (DeskDeskKnowledge.East/Central/West) — replaces the original tags approach since the no-flavor wiki doesn't ship the Tags app.
- **Step 2**: explicit \`knowledge_article\` schema with the JSON-key-equals-slug trap called out (a real foot-gun we hit during dogfooding).
- **Steps 3-4**: OpenConnector source + synchronization with the right URL (container-internal \`http://openregister-xwiki:8080/rest\`) + the \`Accept: application/json\` header.
- **Step 5**: real KnowledgeTab.vue with the watch-objectId pattern + the CnAppRoot \`#sidebar\` slot wiring App.vue needs for CnDetailPage's external-sidebar channel.
- **Troubleshooting**: four real gotchas we hit while building — schema slug mismatch, DetailPageWrapper bridging, empty-flavor path, JSON header.

## Test plan

- [x] \`npm run build\` succeeds; built HTML at \`build/academy/deskdesk-tutorial-4-knowledge-and-ship/index.html\` rebuilds with the new content
- [x] The matching deskdesk PR #4 is verified live: 3-East desk shows "East zone etiquette", 2-West desk shows "West zone quiet rules"
- [ ] post-merge: visual sanity-check on the live academy

Generated with Claude Code