### PR TITLE
feat(apps): commercial page for Scholiq (LMS + LVS)

### DIFF
--- a/src/data/apps-catalog.js
+++ b/src/data/apps-catalog.js
@@ -110,6 +110,13 @@ const PRESENTATION = {
     categories: ['Processes'],
     icon: <svg viewBox="0 0 24 24"><path d="M3 12h6l3-7 3 14 3-7h3"/></svg>,
   },
+  scholiq: {
+    name: 'Scholiq',
+    tagline: 'Learning record + LMS. Cursussen, inschrijvingen, certificaten, compliance-training.',
+    href: '/apps/scholiq',
+    categories: ['Processes'],
+    icon: <svg viewBox="0 0 24 24"><path d="M3 9l9-5 9 5-9 5z"/><path d="M7 11v5c0 1 2.2 2 5 2s5-1 5-2v-5"/><path d="M21 9v6"/></svg>,
+  },
   nldesign: {
     name: 'NLDesign',
     tagline: 'Drop-in NLDS theme for Nextcloud, with the Conduction component variants on top.',

--- a/src/pages/apps/scholiq.mdx
+++ b/src/pages/apps/scholiq.mdx
@@ -1,0 +1,101 @@
+---
+title: Scholiq, Conduction
+description: Learning record + LMS on Nextcloud. Cohorts, courses, attendance, grading, certificates, compliance training.
+hide_table_of_contents: true
+---
+
+import {DetailHero, Section, SectionHead, FeatureList, FeatureItem, PairRow, PairCard, CtaBanner, AppCrossLinks} from '@conduction/docusaurus-preset/components';
+
+<DetailHero
+  appId="scholiq"
+  crumb={[{label: 'Apps', href: '/apps'}, 'Scholiq']}
+  status={{label: 'Beta', color: 'var(--c-orange-knvb)'}}
+  version="v0.x"
+  locales="NL · EN"
+  title="Scholiq"
+  tagline={<>Leerlingvolgsysteem en LMS op <span className="next-blue">Nextcloud</span>. Cursussen, inschrijvingen, aanwezigheid, nakijken, certificaten. Voor scholen, opleiders en compliance-teams die hun leerproces niet bij een externe SaaS willen parkeren.</>}
+  primaryCta={{label: 'Install from app store', href: '/install'}}
+  secondaryCta={{label: 'Read the docs', href: 'https://scholiq.conduction.nl/'}}
+  tertiaryCta={{label: 'View on GitHub', href: 'https://github.com/ConductionNL/scholiq'}}
+  iconColor="var(--c-blue-cobalt)"
+  icon={<svg viewBox="0 0 24 24"><path d="M3 9l9-5 9 5-9 5z"/><path d="M7 11v5c0 1 2.2 2 5 2s5-1 5-2v-5"/><path d="M21 9v6"/></svg>}
+/>
+
+<Section spacing="default">
+  <div style={{display: 'grid', gridTemplateColumns: 'minmax(0, 1fr) 320px', gap: 'var(--space-8)', alignItems: 'start'}}>
+    <div style={{minWidth: 0}}>
+      <SectionHead
+        eyebrow="What it does"
+        title="Eén leeromgeving voor cursussen, cohorten en certificeringen."
+        align="stack"
+        lede="Scholiq pakt het hele leerproces: cursussen opzetten, deelnemers inschrijven, aanwezigheid en voortgang volgen, opdrachten verzamelen en nakijken, certificaten uitreiken. Alles op typed registers in OpenRegister, dus de cijfers in MyDash en de rapportages voor de inspectie blijven kloppen."
+      />
+      <FeatureList>
+        <FeatureItem
+          icon={<svg viewBox="0 0 24 24"><path d="M4 6h16v12H4z"/><path d="M4 10h16M9 6v12"/></svg>}
+          title="Cursussen en inschrijvingen."
+        >
+          Bouw een cursus uit modules, koppel lesmateriaal en data, schrijf deelnemers of hele cohorten in. Voor doorlopend onderwijs én voor één-daagse trainingen.
+        </FeatureItem>
+        <FeatureItem
+          icon={<svg viewBox="0 0 24 24"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6M9 13l2 2 4-4"/></svg>}
+          title="Opdrachten en nakijken."
+        >
+          Stel een opdracht uit, deelnemers leveren in, jij geeft feedback en een cijfer. De volledige geschiedenis blijft per leerling beschikbaar in zijn dossier.
+        </FeatureItem>
+        <FeatureItem
+          icon={<svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg>}
+          title="Aanwezigheid en voortgang."
+        >
+          Wie was er, wie heeft de module afgerond, wie staat waar in zijn leerplan. Zonder losse Excel-lijsten, zonder schaduw-administratie.
+        </FeatureItem>
+        <FeatureItem
+          icon={<svg viewBox="0 0 24 24"><path d="M12 2l3 6 6 .9-4.5 4.2 1.1 6L12 16l-5.6 3.1 1.1-6L3 8.9 9 8z"/></svg>}
+          title="Certificaten en compliance-training."
+        >
+          Reik certificaten uit met geldigheid en hercertificering. Voor BHV, AVG, integriteits-trainingen of de jaarlijkse cybersecurity-cursus: het systeem herinnert je vanzelf wie weer aan de beurt is.
+        </FeatureItem>
+      </FeatureList>
+    </div>
+    <AppCrossLinks
+      variant="rail"
+      apps={['scholiq']}
+      surface="product"
+    />
+  </div>
+</Section>
+
+<Section spacing="default" background="tinted">
+  <SectionHead
+    eyebrow="Pairs well with"
+    title="De apps waarop Scholiq leunt."
+    align="stack"
+  />
+  <PairRow>
+    <PairCard
+      href="/apps/openregister"
+      icon={<svg viewBox="0 0 24 24"><ellipse cx="12" cy="6" rx="8" ry="3"/><path d="M4 6v12c0 1.7 3.6 3 8 3s8-1.3 8-3V6"/></svg>}
+      name="OpenRegister"
+      why="Deelnemers, cursussen, inschrijvingen, cijfers en certificaten als typed registers."
+    />
+    <PairCard
+      href="/apps/docudesk"
+      icon={<svg viewBox="0 0 24 24"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6"/></svg>}
+      name="DocuDesk"
+      why="Genereert certificaten, cursusverslagen en deelnemerslijsten uit sjablonen."
+    />
+    <PairCard
+      href="/apps/mydash"
+      icon={<svg viewBox="0 0 24 24"><rect x="3" y="3" width="7" height="9"/><rect x="14" y="3" width="7" height="5"/><rect x="14" y="12" width="7" height="9"/><rect x="3" y="16" width="7" height="5"/></svg>}
+      name="MyDash"
+      why="Mijn cursussen, na te kijken werk, en hercertificeringen op het dashboard."
+    />
+  </PairRow>
+</Section>
+
+<CtaBanner
+  title="Leren bij je eigen organisatie, niet bij een externe leverancier."
+  lede={<>Scholiq houdt het leerproces — van cursusinschrijving tot certificering — op je eigen Nextcloud. Open-source, op je eigen data, klaar voor inspectie en compliance.</>}
+  primaryCta={{label: 'Install from app store', href: '/install'}}
+  secondaryCta={{label: 'Talk to a partner', href: '/partners'}}
+/>


### PR DESCRIPTION
Adds the commercial page at `www.conduction.nl/apps/scholiq` for the upcoming Scholiq launch. Matches the existing fleet pattern (DetailHero + FeatureList + PairRow + CtaBanner), modelled on shillinq.mdx. Plus a `scholiq` row in `src/data/apps-catalog.js` so the app shows up in the `/apps` grid. Build verified locally (`npm run build` → SUCCESS; only pre-existing `/nl/about/#opensource`/`#team` broken-anchor warnings, unrelated). Tone follows brand/taalgebruik MKB-personal voice.

This brings the missing-commercial-page count down: deskdesk and planix are the remaining two on the 404 list.