### PR TITLE
feat(apps): fill DeskDesk/Planix/OpenTalk listings; rewrite App Versions

### DIFF
--- a/src/data/apps-catalog.js
+++ b/src/data/apps-catalog.js
@@ -147,10 +147,24 @@ const PRESENTATION = {
   },
   'app-versions': {
     name: 'App Versions',
-    tagline: 'Nextcloud app scaffold. Template repo for new apps, prefilled and CI-ready. In development.',
+    tagline: 'Pin and roll back any Nextcloud app version. Multi-source picker, audit-trailed. In development.',
     href: '/apps/app-versions',
     categories: ['Data'],
     icon: <svg viewBox="0 0 24 24"><path d="M3 6h18v4H3zM3 14h12v4H3z"/><circle cx="19" cy="16" r="2"/></svg>,
+  },
+  deskdesk: {
+    name: 'DeskDesk',
+    tagline: 'Desk and meeting-room booking. Plan, reserve, and check in from the Nextcloud workspace.',
+    href: '/apps/deskdesk',
+    categories: ['Processes'],
+    icon: <svg viewBox="0 0 24 24"><path d="M3 10h18M5 10v8M19 10v8M8 14h8M7 18v2M17 18v2"/></svg>,
+  },
+  planix: {
+    name: 'Planix',
+    tagline: 'Kanban boards on registers. Cards, lanes, swim-lanes wired directly to typed data.',
+    href: '/apps/planix',
+    categories: ['Processes'],
+    icon: <svg viewBox="0 0 24 24"><rect x="3" y="3" width="5" height="18" rx="1"/><rect x="10" y="3" width="5" height="12" rx="1"/><rect x="17" y="3" width="4" height="8" rx="1"/></svg>,
   },
 };
 

--- a/src/data/sidecars-catalog.js
+++ b/src/data/sidecars-catalog.js
@@ -67,6 +67,13 @@ const PRESENTATION = {
     categories: ['AI'],
     icon: <svg viewBox="0 0 24 24"><rect x="3" y="4" width="18" height="14" rx="2"/><path d="M7 9h2M7 13h6"/></svg>,
   },
+  opentalk: {
+    name: 'OpenTalk',
+    tagline: 'Sidecar for OpenTalk. GDPR-compliant video conferencing, end-to-end encrypted, packaged as a Nextcloud ExApp.',
+    href: '/sidecars/opentalk',
+    categories: ['Workflow'],
+    icon: <svg viewBox="0 0 24 24"><path d="M21 11.5a8.4 8.4 0 0 1-9 8.4 8.4 8.4 0 0 1-3.4-.7L3 21l1.5-5.4A8.4 8.4 0 1 1 21 11.5z"/></svg>,
+  },
 };
 
 export const SIDECAR_CATEGORIES = ['All', 'Registers', 'Workflow', 'Identity', 'AI'];

--- a/src/pages/apps/app-versions.mdx
+++ b/src/pages/apps/app-versions.mdx
@@ -1,10 +1,10 @@
 ---
 title: App Versions, Conduction
-description: Nextcloud app scaffold and version registry. In development.
+description: Pin and roll back any Nextcloud app version. Multi-source picker, audit-trailed. In development.
 hide_table_of_contents: true
 ---
 
-import {DetailHero, Section, SectionHead, CtaBanner} from '@conduction/docusaurus-preset/components';
+import {DetailHero, Section, SectionHead, FeatureList, FeatureItem, CtaBanner} from '@conduction/docusaurus-preset/components';
 
 <DetailHero
   appId="app-versions"
@@ -13,8 +13,8 @@ import {DetailHero, Section, SectionHead, CtaBanner} from '@conduction/docusauru
   version="v0.x"
   locales="NL · EN"
   title="App Versions"
-  tagline={<>A template repo and version registry for new <span className="next-blue">Nextcloud</span> apps. Prefilled scaffolds, CI-ready, conformance-checked against our app conventions. In active development.</>}
-  secondaryCta={{label: 'Follow progress', href: 'https://github.com/ConductionNL/app-versions'}}
+  tagline={<>Pin and roll back any <span className="next-blue">Nextcloud</span> app version. Multi-source picker over the app store, GitHub releases, and private registries. Audit-trailed, admin-only, a safety net for fleet upgrades.</>}
+  secondaryCta={{label: 'Read the docs', href: 'https://app-versions.conduction.nl/'}}
   tertiaryCta={{label: 'View on GitHub', href: 'https://github.com/ConductionNL/app-versions'}}
   iconColor="var(--c-blue-cobalt)"
   icon={<svg viewBox="0 0 24 24"><path d="M3 6h18v4H3zM3 14h12v4H3z"/><circle cx="19" cy="16" r="2"/></svg>}
@@ -22,11 +22,37 @@ import {DetailHero, Section, SectionHead, CtaBanner} from '@conduction/docusauru
 
 <Section spacing="default">
   <SectionHead
-    eyebrow="In development"
-    title="What we're building."
+    eyebrow="What it does"
+    title="A version picker for the apps you actually run."
     align="stack"
-    lede="App Versions is the scaffold every new Conduction app starts from. It ships an opinionated structure, the CI workflows, the lint and quality gates, and a version-pinning registry so the apps in the catalog stay in lockstep. Aimed at our own engineers first, then at integrator partners that build on the same conventions."
+    lede="Nextcloud's built-in updater jumps to the latest. App Versions adds the missing knob: pick any release, from any configured source, and pin or roll back without leaving the admin UI. The change is recorded, so when something breaks two days later you know who downgraded what."
   />
+  <FeatureList>
+    <FeatureItem
+      icon={<svg viewBox="0 0 24 24"><path d="M3 6h18M3 12h18M3 18h12"/><circle cx="19" cy="18" r="2"/></svg>}
+      title="Per-app version table."
+    >
+      For every installed app: current version, available versions per source, last upgrade, rollback target. One screen, no command line.
+    </FeatureItem>
+    <FeatureItem
+      icon={<svg viewBox="0 0 24 24"><path d="M10 13a5 5 0 0 0 7 0l3-3a5 5 0 0 0-7-7l-1 1"/><path d="M14 11a5 5 0 0 0-7 0l-3 3a5 5 0 0 0 7 7l1-1"/></svg>}
+      title="Multiple sources."
+    >
+      Nextcloud app store, GitHub releases, private registries. A token per source if needed; private GitHub releases work the same as public ones.
+    </FeatureItem>
+    <FeatureItem
+      icon={<svg viewBox="0 0 24 24"><path d="M3 12a9 9 0 0 1 15-6.7L21 8"/><path d="M21 4v4h-4"/><path d="M21 12a9 9 0 0 1-15 6.7L3 16"/><path d="M3 20v-4h4"/></svg>}
+      title="Rollback or pin."
+    >
+      One click to revert to a known-good release. Or pin a version so a future auto-update can't move it. Per app, not fleet-wide.
+    </FeatureItem>
+    <FeatureItem
+      icon={<svg viewBox="0 0 24 24"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6M9 13l2 2 4-4"/></svg>}
+      title="Audit trail."
+    >
+      Every version change recorded: who, when, from what to what, why. Visible to the admin team, exportable for compliance.
+    </FeatureItem>
+  </FeatureList>
 </Section>
 
 <Section spacing="default" background="tinted">
@@ -34,13 +60,13 @@ import {DetailHero, Section, SectionHead, CtaBanner} from '@conduction/docusauru
     eyebrow="Status"
     title="Where it stands today."
     align="stack"
-    lede="The scaffold is usable today as a 'Use this template' source on GitHub. The version-registry surface is being designed. The app is not yet a customer-installable Nextcloud app. Follow the repository on GitHub for releases."
+    lede="The four canonical specs — version-management, external-sources, pat-management, and import — are in place. Admin UI for the picker is in active development. Follow the repository on GitHub for releases, or read the spec-anchored docs for the design rationale."
   />
 </Section>
 
 <CtaBanner
-  title="Building a Nextcloud app on our stack?"
-  lede={<>App Versions is the entry point for partners and integrators. Reach out and we'll point you at the right starting branch.</>}
-  primaryCta={{label: 'Talk to a partner', href: '/partners'}}
+  title="A safety net for the next upgrade cycle."
+  lede={<>App Versions is the difference between 'roll forward and hope' and 'roll back if it bites'. Open-source, admin-only, no extra service to run.</>}
+  primaryCta={{label: 'Read the docs', href: 'https://app-versions.conduction.nl/'}}
   secondaryCta={{label: 'View on GitHub', href: 'https://github.com/ConductionNL/app-versions'}}
 />

--- a/src/pages/apps/deskdesk.mdx
+++ b/src/pages/apps/deskdesk.mdx
@@ -1,0 +1,101 @@
+---
+title: DeskDesk, Conduction
+description: Desk and meeting-room booking on Nextcloud. Plan the office week, reserve a desk, check in. Hybride werken zonder losse SaaS.
+hide_table_of_contents: true
+---
+
+import {DetailHero, Section, SectionHead, FeatureList, FeatureItem, PairRow, PairCard, CtaBanner, AppCrossLinks} from '@conduction/docusaurus-preset/components';
+
+<DetailHero
+  appId="deskdesk"
+  crumb={[{label: 'Apps', href: '/apps'}, 'DeskDesk']}
+  status={{label: 'Beta', color: 'var(--c-orange-knvb)'}}
+  version="v0.x"
+  locales="NL · EN"
+  title="DeskDesk"
+  tagline={<>Bureau- en vergaderzaalboeking op <span className="next-blue">Nextcloud</span>. Plan je kantoorweek, reserveer een werkplek, check in. Voor hybride teams die hun bezetting niet via een externe SaaS willen regelen.</>}
+  primaryCta={{label: 'Install from app store', href: '/install'}}
+  secondaryCta={{label: 'Read the docs', href: 'https://deskdesk.conduction.nl/'}}
+  tertiaryCta={{label: 'View on GitHub', href: 'https://github.com/ConductionNL/deskdesk'}}
+  iconColor="var(--c-blue-cobalt)"
+  icon={<svg viewBox="0 0 24 24"><path d="M3 10h18M5 10v8M19 10v8M8 14h8M7 18v2M17 18v2"/></svg>}
+/>
+
+<Section spacing="default">
+  <div style={{display: 'grid', gridTemplateColumns: 'minmax(0, 1fr) 320px', gap: 'var(--space-8)', alignItems: 'start'}}>
+    <div style={{minWidth: 0}}>
+      <SectionHead
+        eyebrow="What it does"
+        title="Eén plek voor je kantoor-bezetting."
+        align="stack"
+        lede="DeskDesk regelt het hybride werken: welke dagen komen mijn collega's, waar zit ik, welke vergaderzaal is vrij. Op een plattegrond van je vestiging, op de typed registers van OpenRegister. Geen losse boeking-app, geen extra inloggen, geen vendor-lock."
+      />
+      <FeatureList>
+        <FeatureItem
+          icon={<svg viewBox="0 0 24 24"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18M9 3v18"/></svg>}
+          title="Plattegrond per vestiging."
+        >
+          Teken je vloer in, plaats bureaus, vergaderzalen en faciliteiten. Mensen klikken op een plek om te reserveren; jij ziet de bezetting in één oogopslag.
+        </FeatureItem>
+        <FeatureItem
+          icon={<svg viewBox="0 0 24 24"><rect x="3" y="4" width="18" height="18" rx="2"/><path d="M16 2v4M8 2v4M3 10h18M8 14h2M14 14h2M8 18h2M14 18h2"/></svg>}
+          title="Plan je kantoorweek."
+        >
+          Reserveer terugkerend (elke dinsdag) of incidenteel. Zie wie er die dag is, plan teamdagen rond elkaars aanwezigheid.
+        </FeatureItem>
+        <FeatureItem
+          icon={<svg viewBox="0 0 24 24"><path d="M9 11l3 3 8-8"/><path d="M20 12v6a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h9"/></svg>}
+          title="Check-in en no-shows."
+        >
+          Wie er is, scant in (QR of NFC). Wie niet komt opdagen, geeft zijn plek vanzelf vrij. Geen reservering-spookbezetting meer.
+        </FeatureItem>
+        <FeatureItem
+          icon={<svg viewBox="0 0 24 24"><rect x="3" y="3" width="7" height="9"/><rect x="14" y="3" width="7" height="5"/><rect x="14" y="12" width="7" height="9"/><rect x="3" y="16" width="7" height="5"/></svg>}
+          title="Inzicht voor facility."
+        >
+          Bezettingsgraad per dag, per zone, per faciliteit. Stuurt je heroverwegingen over vierkante meters en koffie-automaten, niet je onderbuikgevoel.
+        </FeatureItem>
+      </FeatureList>
+    </div>
+    <AppCrossLinks
+      variant="rail"
+      apps={['deskdesk']}
+      surface="product"
+    />
+  </div>
+</Section>
+
+<Section spacing="default" background="tinted">
+  <SectionHead
+    eyebrow="Pairs well with"
+    title="De apps waarop DeskDesk leunt."
+    align="stack"
+  />
+  <PairRow>
+    <PairCard
+      href="/apps/openregister"
+      icon={<svg viewBox="0 0 24 24"><ellipse cx="12" cy="6" rx="8" ry="3"/><path d="M4 6v12c0 1.7 3.6 3 8 3s8-1.3 8-3V6"/></svg>}
+      name="OpenRegister"
+      why="Vestigingen, bureaus, reserveringen en check-ins als typed registers met audit-trail."
+    />
+    <PairCard
+      href="/apps/mydash"
+      icon={<svg viewBox="0 0 24 24"><rect x="3" y="3" width="7" height="9"/><rect x="14" y="3" width="7" height="5"/><rect x="14" y="12" width="7" height="9"/><rect x="3" y="16" width="7" height="5"/></svg>}
+      name="MyDash"
+      why="Bezettingsgrafieken, no-show-percentages en zone-trends op het dashboard."
+    />
+    <PairCard
+      href="/apps/openconnector"
+      icon={<svg viewBox="0 0 24 24"><circle cx="6" cy="12" r="3"/><circle cx="18" cy="6" r="3"/><circle cx="18" cy="18" r="3"/><path d="M9 12h9M9 12l9-6M9 12l9 6"/></svg>}
+      name="OpenConnector"
+      why="Synct met de toegangs-controle en met Nextcloud Calendar voor het terugzien van je boekingen."
+    />
+  </PairRow>
+</Section>
+
+<CtaBanner
+  title="Hybride werken zonder losse boeking-SaaS."
+  lede={<>DeskDesk pakt bureau- en zaalboeking voor je terug: in je Nextcloud, op je eigen data, met een plattegrond die je zelf onderhoudt.</>}
+  primaryCta={{label: 'Install from app store', href: '/install'}}
+  secondaryCta={{label: 'Talk to a partner', href: '/partners'}}
+/>

--- a/src/pages/apps/planix.mdx
+++ b/src/pages/apps/planix.mdx
@@ -1,0 +1,101 @@
+---
+title: Planix, Conduction
+description: Kanban-boards die op je registers staan. Cards, lanes en swim-lanes rechtstreeks op typed data, geen losse projectmanagement-SaaS.
+hide_table_of_contents: true
+---
+
+import {DetailHero, Section, SectionHead, FeatureList, FeatureItem, PairRow, PairCard, CtaBanner, AppCrossLinks} from '@conduction/docusaurus-preset/components';
+
+<DetailHero
+  appId="planix"
+  crumb={[{label: 'Apps', href: '/apps'}, 'Planix']}
+  status={{label: 'Beta', color: 'var(--c-orange-knvb)'}}
+  version="v0.x"
+  locales="NL · EN"
+  title="Planix"
+  tagline={<>Kanban-boards die op je <span className="next-blue">Nextcloud</span>-registers staan. Cards, lanes en swim-lanes rechtstreeks op typed data, niet op losse JSON-bestandjes. Voor teams die plannen niet bij Trello, Jira of Monday willen parkeren.</>}
+  primaryCta={{label: 'Install from app store', href: '/install'}}
+  secondaryCta={{label: 'Read the docs', href: 'https://planix.conduction.nl/'}}
+  tertiaryCta={{label: 'View on GitHub', href: 'https://github.com/ConductionNL/planix'}}
+  iconColor="var(--c-blue-cobalt)"
+  icon={<svg viewBox="0 0 24 24"><rect x="3" y="3" width="5" height="18" rx="1"/><rect x="10" y="3" width="5" height="12" rx="1"/><rect x="17" y="3" width="4" height="8" rx="1"/></svg>}
+/>
+
+<Section spacing="default">
+  <div style={{display: 'grid', gridTemplateColumns: 'minmax(0, 1fr) 320px', gap: 'var(--space-8)', alignItems: 'start'}}>
+    <div style={{minWidth: 0}}>
+      <SectionHead
+        eyebrow="What it does"
+        title="Plannen op je eigen data."
+        align="stack"
+        lede="Planix tekent een kanban-bord over je registers heen. Een lane per status, een card per object. Sleep een zaak van 'In behandeling' naar 'Afgerond' en het register update mee, met audit-trail. Geen export-import, geen aparte projectmanagement-database."
+      />
+      <FeatureList>
+        <FeatureItem
+          icon={<svg viewBox="0 0 24 24"><rect x="3" y="3" width="5" height="18" rx="1"/><rect x="10" y="3" width="5" height="12" rx="1"/><rect x="17" y="3" width="4" height="8" rx="1"/></svg>}
+          title="Boards over registers."
+        >
+          Kies een register, kies een veld voor de status, en je hebt een kanban. Voor zaken, opdrachten, helpdesk-tickets of je eigen aangemaakte registers.
+        </FeatureItem>
+        <FeatureItem
+          icon={<svg viewBox="0 0 24 24"><path d="M3 6h18M3 12h18M3 18h18"/></svg>}
+          title="Swim-lanes."
+        >
+          Splits het bord per project, team of toegewezen behandelaar. Of zet de swim-lane op een ander veld en bekijk hetzelfde werk vanuit een ander perspectief.
+        </FeatureItem>
+        <FeatureItem
+          icon={<svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 3"/></svg>}
+          title="Workflow op typed data."
+        >
+          Verplaats een card en de status van het object in OpenRegister verandert mee. Validaties, hooks en lifecycle-events draaien net zo hard als bij elke andere update.
+        </FeatureItem>
+        <FeatureItem
+          icon={<svg viewBox="0 0 24 24"><rect x="3" y="3" width="7" height="9"/><rect x="14" y="3" width="7" height="5"/><rect x="14" y="12" width="7" height="9"/><rect x="3" y="16" width="7" height="5"/></svg>}
+          title="Filters en gespaarde views."
+        >
+          Filter per toegewezen behandelaar, prioriteit of label. Sla de view op, deel hem met je team. Iedereen kijkt naar dezelfde data, maar met zijn eigen lens.
+        </FeatureItem>
+      </FeatureList>
+    </div>
+    <AppCrossLinks
+      variant="rail"
+      apps={['planix']}
+      surface="product"
+    />
+  </div>
+</Section>
+
+<Section spacing="default" background="tinted">
+  <SectionHead
+    eyebrow="Pairs well with"
+    title="De apps waarop Planix leunt."
+    align="stack"
+  />
+  <PairRow>
+    <PairCard
+      href="/apps/openregister"
+      icon={<svg viewBox="0 0 24 24"><ellipse cx="12" cy="6" rx="8" ry="3"/><path d="M4 6v12c0 1.7 3.6 3 8 3s8-1.3 8-3V6"/></svg>}
+      name="OpenRegister"
+      why="De typed data onder elke kanban-card; statuswijzigingen lopen door de register-hooks."
+    />
+    <PairCard
+      href="/apps/procest"
+      icon={<svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 3"/></svg>}
+      name="Procest"
+      why="Werkstroom op dezelfde objecten: workflow in Procest, dagelijks bord in Planix."
+    />
+    <PairCard
+      href="/apps/mydash"
+      icon={<svg viewBox="0 0 24 24"><rect x="3" y="3" width="7" height="9"/><rect x="14" y="3" width="7" height="5"/><rect x="14" y="12" width="7" height="9"/><rect x="3" y="16" width="7" height="5"/></svg>}
+      name="MyDash"
+      why="Doorlooptijden, lane-counts en bottleneck-zicht boven op het bord, voor de teamlead."
+    />
+  </PairRow>
+</Section>
+
+<CtaBanner
+  title="Eén bord, je eigen data, geen tussenlaag."
+  lede={<>Planix tekent kanban over typed registers, dus elke verplaatsing is een echte status-update. Open-source, op je eigen Nextcloud, klaar voor audit.</>}
+  primaryCta={{label: 'Install from app store', href: '/install'}}
+  secondaryCta={{label: 'Talk to a partner', href: '/partners'}}
+/>

--- a/src/pages/sidecars/opentalk.mdx
+++ b/src/pages/sidecars/opentalk.mdx
@@ -1,0 +1,47 @@
+---
+title: OpenTalk sidecar, Conduction
+description: Nextcloud sidecar wrapping the OpenTalk video-conferencing controller. GDPR-compliant meetings, end-to-end encryption, screen sharing.
+hide_table_of_contents: true
+---
+
+import {DetailHero, Section, SectionHead, CtaBanner} from '@conduction/docusaurus-preset/components';
+
+<DetailHero
+  appId="opentalk"
+  crumb={[{label: 'Sidecars', href: '/sidecars'}, 'OpenTalk']}
+  status={{label: 'Sidecar', color: 'var(--c-cobalt-400)'}}
+  version="upstream"
+  locales="NL · EN"
+  title="OpenTalk"
+  tagline={<>A <span className="next-blue">Nextcloud</span> sidecar that wraps OpenTalk. GDPR-compliant video conferencing, end-to-end encrypted, screen-sharing included. Installed through the AppAPI, run as an ExApp next to the workspace.</>}
+  primaryCta={{label: 'Install from app store', href: '/install'}}
+  secondaryCta={{label: 'Read the upstream docs', href: 'https://opentalk.eu/'}}
+  tertiaryCta={{label: 'View on GitHub', href: 'https://github.com/ConductionNL/opentalk'}}
+  iconColor="var(--c-blue-cobalt)"
+  icon={<svg viewBox="0 0 24 24"><path d="M21 11.5a8.4 8.4 0 0 1-9 8.4 8.4 8.4 0 0 1-3.4-.7L3 21l1.5-5.4A8.4 8.4 0 1 1 21 11.5z"/></svg>}
+/>
+
+<Section spacing="default">
+  <SectionHead
+    eyebrow="What it is"
+    title="OpenTalk as a Nextcloud ExApp."
+    align="stack"
+    lede="OpenTalk is a GDPR-compliant video-conferencing controller from heinlein-group. We package it as a Nextcloud-installable ExApp through the AppAPI. Install the app, the upstream controller runs alongside Nextcloud, and meeting links appear right next to your Files, Mail, and Calendar."
+  />
+</Section>
+
+<Section spacing="default" background="tinted">
+  <SectionHead
+    eyebrow="Why a sidecar"
+    title="A sidecar is not a fork."
+    align="stack"
+    lede="We do not fork OpenTalk. The sidecar tracks the upstream container releases. The wrapper handles install, lifecycle, and the koppelvlak to Nextcloud. Meeting data stays in the upstream service, hosted where you host it. Conduction is responsible for the integration, not for upstream OpenTalk."
+  />
+</Section>
+
+<CtaBanner
+  title="Run OpenTalk meetings inside your Nextcloud."
+  lede={<>Install from the Nextcloud app store. GDPR-compliant, end-to-end encrypted, hosted next to the workspace your team already uses.</>}
+  primaryCta={{label: 'Install from app store', href: '/install'}}
+  secondaryCta={{label: 'Talk to a partner', href: '/partners'}}
+/>


### PR DESCRIPTION
## Summary

- Add **DeskDesk** + **Planix** to `apps-catalog.js` and commercial pages at `/apps/deskdesk` and `/apps/planix`
- Rewrite **App Versions** away from the stale "scaffold/template" framing — both the apps-catalog tagline and `/apps/app-versions` MDX now describe the version-management surface (pin/rollback, multi-source picker, audit trail) so the commercial page matches the docs site standing up at app-versions.conduction.nl
- Close the **OpenTalk** sidecar listing gap: new `sidecars-catalog.js` row + `/sidecars/opentalk` MDX

## Test plan

- [x] `npx docusaurus build` clean (broken-anchor warnings are pre-existing /nl/about anchors)
- [ ] Visual check on conduction.nl after merge