### PR TITLE
chore(deps): bump @conduction/docusaurus-preset to ^3.0.0 (flat-hex brand refactor)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@conduction/docusaurus-preset": "^2.10.2",
+        "@conduction/docusaurus-preset": "^3.0.0",
         "@docusaurus/core": "^3.5.0",
         "@docusaurus/preset-classic": "^3.5.0",
         "@mdx-js/react": "^3.0.0",
@@ -1988,9 +1988,9 @@
       }
     },
     "node_modules/@conduction/docusaurus-preset": {
-      "version": "2.10.2",
-      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-2.10.2.tgz",
-      "integrity": "sha512-qbQ6htlDq8a6oVlZ7Bxo7Vhely0gSsD23FtL9KfNBJOugIScIGA1I/2ocAZP54u6zto/twzQtsnlSn5wBIXfsg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-3.0.0.tgz",
+      "integrity": "sha512-rrmnX3AobCsiQW1rkRL/rk7mg3yoQJuccNHu3sq26ebnUfZUPbVS+VyMqLzpsZznXjHQmAaSTEE8TlLzyE/SAQ==",
       "license": "EUPL-1.2",
       "peerDependencies": {
         "@docusaurus/core": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "ci": "npm ci --legacy-peer-deps && npm run build"
   },
   "dependencies": {
-    "@conduction/docusaurus-preset": "^2.10.2",
+    "@conduction/docusaurus-preset": "^3.0.0",
     "@docusaurus/core": "^3.5.0",
     "@docusaurus/preset-classic": "^3.5.0",
     "@mdx-js/react": "^3.0.0",


### PR DESCRIPTION
## Summary

Bump preset from `^2.10.2` to `^3.0.0`. Major-version bump because the design-system removed the 3D \`<cn-hex-prism>\` primitive and trimmed family token ramps from 5 stops to 2.

## What's in 3.0.0

- 3D hex-prism mechanism removed; brand is flat-hex only
- Family token scales (lavender / mint / forest / terracotta / coral / gold / gray / workspace / workspaceblue) trimmed from 50/100/300/500/700 to just 300/500
- \`colors.html\` consolidated as the single canonical color reference, folding in categorical role labels from the now-removed hex-prism page

## Why this is safe for conduction-website

conduction-website never imported \`HexPrism\` or used the dropped stops. Spot-verified locally on /connext/, /apps/, /apps/opencatalogi — no regressions, and the App Builder hex now renders KNVB orange as intended.

## Test plan

- [x] \`npx docusaurus start\` runs clean on localhost:4000
- [x] Visual sweep: /connext/ (App Builder hex orange ✓), /apps/ (catalogue), /apps/opencatalogi (DetailHero + AppMock)
- [ ] Confirm live deploy after merge