### PR TITLE
feat(openregister): MCP tool shelf + clickable 24-leaf grid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@conduction/docusaurus-preset": "^3.0.0",
+        "@conduction/docusaurus-preset": "^3.3.0",
         "@docusaurus/core": "^3.5.0",
         "@docusaurus/preset-classic": "^3.5.0",
         "@mdx-js/react": "^3.0.0",
@@ -1988,9 +1988,9 @@
       }
     },
     "node_modules/@conduction/docusaurus-preset": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-3.0.0.tgz",
-      "integrity": "sha512-rrmnX3AobCsiQW1rkRL/rk7mg3yoQJuccNHu3sq26ebnUfZUPbVS+VyMqLzpsZznXjHQmAaSTEE8TlLzyE/SAQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-3.3.0.tgz",
+      "integrity": "sha512-xpNp/Azxwp1TbvnGLN8egxpPk/ZlpUEzdEHfwUDxf7McfpsM4C16JdgXaQ33n6GZAMCHKWrbseKjfSwRSbrmtQ==",
       "license": "EUPL-1.2",
       "peerDependencies": {
         "@docusaurus/core": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "ci": "npm ci --legacy-peer-deps && npm run build"
   },
   "dependencies": {
-    "@conduction/docusaurus-preset": "^3.0.0",
+    "@conduction/docusaurus-preset": "^3.3.0",
     "@docusaurus/core": "^3.5.0",
     "@docusaurus/preset-classic": "^3.5.0",
     "@mdx-js/react": "^3.0.0",

--- a/src/pages/apps/decidesk.mdx
+++ b/src/pages/apps/decidesk.mdx
@@ -4,7 +4,7 @@ description: Decision-support and board management on Nextcloud. Agenda, dossier
 hide_table_of_contents: true
 ---
 
-import {DetailHero, Section, SectionHead, FeatureList, FeatureItem, PairRow, PairCard, CtaBanner, AppMock, RotatingCards, WidgetShelf, Showcase, AppCrossLinks} from '@conduction/docusaurus-preset/components';
+import {DetailHero, Section, SectionHead, FeatureList, FeatureItem, PairRow, PairCard, CtaBanner, AppMock, RotatingCards, WidgetShelf, Showcase, AgentTrace, McpToolShelf, AppCrossLinks} from '@conduction/docusaurus-preset/components';
 
 <DetailHero
   appId="decidesk"
@@ -204,6 +204,62 @@ import {DetailHero, Section, SectionHead, FeatureList, FeatureItem, PairRow, Pai
       panel: <AppMock app="docudesk" />,
     },
   ]}
+/>
+
+<McpToolShelf
+  eyebrow="AI chat tools"
+  title="What DeciDesk adds to the workspace AI."
+  lede="Install DeciDesk and the workspace chat gets five governance tools. The AI can list your open action items, browse meetings, open a dossier, start a meeting from a calendar event, or capture a follow-up, all under the caller's own role and auth."
+  tools={[
+    {
+      icon: <svg viewBox="0 0 24 24"><path d="M4 6h16M4 12h16M4 18h10"/><circle cx="20" cy="18" r="2"/></svg>,
+      name: 'List open action items',
+      id: 'decidesk.listOpenActionItems',
+      description: 'Incomplete action items assigned to the caller, or all visible items. Scope mine / all, capped at 50.',
+      status: 'stable',
+    },
+    {
+      icon: <svg viewBox="0 0 24 24"><rect x="3" y="4" width="18" height="16" rx="2"/><path d="M3 9h18M9 4v16"/></svg>,
+      name: 'List recent meetings',
+      id: 'decidesk.listRecentMeetings',
+      description: "Recent meetings for the caller, newest first. Optional status filter: scheduled, in-progress, or closed.",
+      status: 'stable',
+    },
+    {
+      icon: <svg viewBox="0 0 24 24"><path d="M5 4h14v6H5zM5 14h14v6H5zM9 4v16"/></svg>,
+      name: 'Get meeting details',
+      id: 'decidesk.getMeetingDetails',
+      description: 'Full dossier for one meeting: agenda, participants, action items, decisions, attached files.',
+      status: 'stable',
+    },
+    {
+      icon: <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><path d="M10 8l6 4-6 4z"/></svg>,
+      name: 'Start meeting',
+      id: 'decidesk.startMeeting',
+      description: 'Move a scheduled meeting into in-progress. Requires chair or admin role; logged in the audit trail.',
+      status: 'stable',
+    },
+    {
+      icon: <svg viewBox="0 0 24 24"><path d="M9 11l3 3 8-8"/><path d="M20 12v6a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h9"/></svg>,
+      name: 'Add action item',
+      id: 'decidesk.addActionItem',
+      description: 'Create a new action item under a meeting, assigned to a participant, with optional due date.',
+      status: 'stable',
+    },
+  ]}
+  showIds={false}
+  trace={<AgentTrace
+    lines={[
+      {kind: 'tool', text: 'decidesk - listOpenActionItems (MCP)(scope: "mine", limit: 20)'},
+      {kind: 'note', bullet: 'done', text: 'Returned 7 open action items across 4 meetings'},
+      {kind: 'tool', text: 'decidesk - addActionItem (MCP)(meetingId: "m-2026-118",'},
+      {kind: 'continuation', text: 'assignee: "j.devries", title: "Send draft contract", dueDate: "2026-05-24")'},
+      {kind: 'note', bullet: 'done', text: 'Action item created, participant notified'},
+      {kind: 'status', text: 'Synthesising follow-up'},
+    ]}
+    cursor
+    mode="audit log on (every call recorded)"
+  />}
 />
 
 <Section spacing="default" background="tinted">

--- a/src/pages/apps/openbuilt.mdx
+++ b/src/pages/apps/openbuilt.mdx
@@ -4,7 +4,7 @@ description: Citizen-developer app builder for Nextcloud. Compose apps from regi
 hide_table_of_contents: true
 ---
 
-import {DetailHero, Section, SectionHead, FeatureList, FeatureItem, PairRow, PairCard, CtaBanner, AppCrossLinks} from '@conduction/docusaurus-preset/components';
+import {DetailHero, Section, SectionHead, FeatureList, FeatureItem, PairRow, PairCard, CtaBanner, AgentTrace, McpToolShelf, AppCrossLinks} from '@conduction/docusaurus-preset/components';
 
 <DetailHero
   appId="openbuilt"
@@ -58,6 +58,84 @@ import {DetailHero, Section, SectionHead, FeatureList, FeatureItem, PairRow, Pai
     />
   </div>
 </Section>
+
+<McpToolShelf
+  eyebrow="AI chat tools"
+  title="Wat OpenBuilt aan de workspace-AI toevoegt."
+  lede="Installeer OpenBuilt en de chat krijgt acht tools waarmee de AI virtuele apps bouwt: een app aanmaken, een schema toevoegen, een pagina opzetten, een widget plaatsen, een versie promoveren. Elke aanroep loopt onder de eigen rol van de gebruiker en wordt geaudit."
+  tools={[
+    {
+      icon: <svg viewBox="0 0 24 24"><path d="M4 6h16M4 12h16M4 18h10"/></svg>,
+      name: 'Virtuele apps opsommen',
+      id: 'openbuilt.listApps',
+      description: 'Toon de virtuele apps in je organisatie met hun status en versie.',
+      status: 'stable',
+    },
+    {
+      icon: <svg viewBox="0 0 24 24"><path d="M5 4h14v6H5zM5 14h14v6H5zM9 4v16"/></svg>,
+      name: 'App-manifest ophalen',
+      id: 'openbuilt.getAppManifest',
+      description: 'Haal het runtime-manifest van één gepubliceerde virtuele app op via de slug.',
+      status: 'stable',
+    },
+    {
+      icon: <svg viewBox="0 0 24 24"><path d="M12 5v14M5 12h14"/></svg>,
+      name: 'Nieuwe app aanmaken',
+      id: 'openbuilt.createApp',
+      description: 'Maak een nieuwe virtuele app met een eerste draft-versie. Kies het versie-pad: single, dev-prod of dev-staging-prod.',
+      status: 'stable',
+    },
+    {
+      icon: <svg viewBox="0 0 24 24"><path d="M5 12h14M12 5l7 7-7 7"/></svg>,
+      name: 'Versie promoveren',
+      id: 'openbuilt.promoteVersion',
+      description: 'Promoveer een virtuele app van bijvoorbeeld development naar productie. Default-strategie laat de doelversie leeg.',
+      status: 'stable',
+    },
+    {
+      icon: <svg viewBox="0 0 24 24"><path d="M3 7h18M6 12h12M9 17h6"/></svg>,
+      name: 'Schema toevoegen of bijwerken',
+      id: 'openbuilt.upsertSchema',
+      description: 'Voeg een JSON Schema toe of werk het bij. De slug krijgt automatisch app- en versie-prefix.',
+      status: 'stable',
+    },
+    {
+      icon: <svg viewBox="0 0 24 24"><rect x="3" y="4" width="18" height="16" rx="2"/><path d="M3 9h18"/></svg>,
+      name: 'Pagina toevoegen of bijwerken',
+      id: 'openbuilt.upsertPage',
+      description: 'Maak of werk een pagina bij in het draft-manifest. Type is dashboard, index, detail of form.',
+      status: 'stable',
+    },
+    {
+      icon: <svg viewBox="0 0 24 24"><rect x="3" y="3" width="7" height="9"/><rect x="14" y="3" width="7" height="5"/><rect x="14" y="12" width="7" height="9"/><rect x="3" y="16" width="7" height="5"/></svg>,
+      name: 'Widget plaatsen',
+      id: 'openbuilt.addWidget',
+      description: 'Voeg een widget toe aan een pagina: stat-counter, grafiek, lijst of een ander type uit de catalogus.',
+      status: 'stable',
+    },
+    {
+      icon: <svg viewBox="0 0 24 24"><path d="M4 6h16M4 12h16M4 18h16"/></svg>,
+      name: 'Menu-item toevoegen of bijwerken',
+      id: 'openbuilt.upsertMenuItem',
+      description: 'Maak of werk een top-level menu-item bij in het draft-manifest. Route, volgorde en icoon stel je per item in.',
+      status: 'stable',
+    },
+  ]}
+  showIds={false}
+  trace={<AgentTrace
+    lines={[
+      {kind: 'tool', text: 'openbuilt - createApp (MCP)(name: "Subsidie-aanvraag",'},
+      {kind: 'continuation', text: 'preset: "dev-prod", description: "Aanvragen + behandeling")'},
+      {kind: 'note', bullet: 'done', text: 'App aangemaakt, draft v0.1 klaar'},
+      {kind: 'tool', text: 'openbuilt - upsertSchema (MCP)(appSlug: "subsidie-aanvraag",'},
+      {kind: 'continuation', text: 'slug: "aanvraag", properties: { naam, bedrag, status }, required: ["naam"])'},
+      {kind: 'note', bullet: 'done', text: 'Schema toegevoegd aan development-versie'},
+      {kind: 'status', text: 'Pagina opbouwen'},
+    ]}
+    cursor
+    mode="audit log on (elke aanroep wordt vastgelegd)"
+  />}
+/>
 
 <Section spacing="default" background="tinted">
   <SectionHead

--- a/src/pages/apps/openregister.mdx
+++ b/src/pages/apps/openregister.mdx
@@ -227,65 +227,95 @@ import {DetailHero, Section, SectionHead, FeatureList, FeatureItem, FeatureGrid,
   ]}
 />
 
+<Section id="leaves" anchor="leaves">
+  <SectionHead
+    eyebrow="The 24 workspace leaves"
+    title="One sidebar tab per Nextcloud app you already run."
+    lede="OpenRegister surfaces every linked entity from the surrounding Nextcloud workspace on the object's detail page. Six built-ins ship with the install; the other 18 light up when you enable the underlying app. Each leaf is documented end-to-end in the product docs."
+  />
+
+  <FeatureGrid
+    legend
+    items={[
+      {group: 'Core (ships with every install)'},
+      {label: 'Files', tip: 'Files attached to the object’s auto-created folder — drag-drop in Nextcloud Files, list them inline on the object detail page.', href: 'https://openregister.conduction.nl/docs/Integrations/leaf-system', status: 'stable'},
+      {label: 'Notes', tip: 'Free-form notes the team writes against the record. Markdown, signed by the author, scoped to the object.', href: 'https://openregister.conduction.nl/docs/Integrations/leaf-system', status: 'stable'},
+      {label: 'Tags', tip: 'System tags applied to the object. Same tag pool as files — cross-references the workspace taxonomy.', href: 'https://openregister.conduction.nl/docs/Integrations/leaf-system', status: 'stable'},
+      {label: 'Tasks', tip: 'CalDAV VTODO tasks linked to the record. Due dates and assignees live in the user’s own task app.', href: 'https://openregister.conduction.nl/docs/Integrations/leaf-system', status: 'stable'},
+      {label: 'Audit trail', tip: 'Every read, write, and schema change leaves a signed, citation-stable entry. WOO and BIO compliance evidence ships with the install.', href: 'https://openregister.conduction.nl/docs/Integrations/leaf-system', status: 'stable'},
+      {label: 'Shares', tip: 'Nextcloud shares created against the object’s files. Surfaces who has access, when, and why.', href: 'https://openregister.conduction.nl/docs/Integrations/leaf-system', status: 'stable'},
+
+      {group: 'Communication (lights up with NC Calendar / Contacts / Mail / Talk)'},
+      {label: 'Calendar', tip: 'CalDAV events linked to the record. Meet-about-this-case in one click, agenda stays in the user’s own calendar.', href: 'https://openregister.conduction.nl/docs/Integrations/calendar', status: 'stable'},
+      {label: 'Contacts', tip: 'CardDAV contacts associated with the record. Customer, vendor, citizen — every party lives in NC Contacts.', href: 'https://openregister.conduction.nl/docs/Integrations/contacts', status: 'stable'},
+      {label: 'Email', tip: 'Mail messages linked to the record. Subject, sender, date — click through to NC Mail to reply.', href: 'https://openregister.conduction.nl/docs/Integrations/email', status: 'stable'},
+      {label: 'Talk', tip: 'NC Talk conversations carrying the record’s discussions. Calls, chat history, screen-shares — all in NC Talk, surfaced on the record.', href: 'https://openregister.conduction.nl/docs/Integrations/talk', status: 'stable'},
+
+      {group: 'Knowledge & documents (NC Bookmarks / Collectives / Maps / Photos)'},
+      {label: 'Bookmarks', tip: 'NC Bookmarks tagged with the record. Reference URLs, regulatory sources, partner sites — one tag links them to the case.', href: 'https://openregister.conduction.nl/docs/Integrations/bookmarks', status: 'stable'},
+      {label: 'Collectives', tip: 'NC Collectives pages — the team wiki for the case. Markdown, versioned, with a marker in the slug.', href: 'https://openregister.conduction.nl/docs/Integrations/collectives', status: 'stable'},
+      {label: 'Maps', tip: 'NC Maps favorites with the record’s coordinates. Site visits, asset locations, on-the-ground evidence.', href: 'https://openregister.conduction.nl/docs/Integrations/maps', status: 'stable'},
+      {label: 'Photos', tip: 'NC Photos albums tied to the record. Photo evidence, signed timestamps, geo-tagged.', href: 'https://openregister.conduction.nl/docs/Integrations/photos', status: 'stable'},
+
+      {group: 'Workflow (NC Activity / Analytics / Cospend / Deck / Flow / Forms / Polls / TimeManager)'},
+      {label: 'Activity', tip: 'Nextcloud activity stream filtered to the record. Who touched the file, who shared what, when.', href: 'https://openregister.conduction.nl/docs/Integrations/activity', status: 'stable'},
+      {label: 'Analytics', tip: 'NC Analytics reports linked to the record. Charts and KPIs that reference the same data the case is built on.', href: 'https://openregister.conduction.nl/docs/Integrations/analytics', status: 'stable'},
+      {label: 'Cospend', tip: 'NC Cospend projects — budget and expense tracking attached to the case.', href: 'https://openregister.conduction.nl/docs/Integrations/cospend', status: 'stable'},
+      {label: 'Deck', tip: 'NC Deck cards linked to the record. Per-case kanban without leaving the case.', href: 'https://openregister.conduction.nl/docs/Integrations/deck', status: 'stable'},
+      {label: 'Flow', tip: 'NC Workflow Engine rules referencing the record’s schema. Automate notifications, retention, escalations.', href: 'https://openregister.conduction.nl/docs/Integrations/flow', status: 'stable'},
+      {label: 'Forms', tip: 'NC Forms responses linked to the record. Citizen submissions, survey results, intake forms.', href: 'https://openregister.conduction.nl/docs/Integrations/forms', status: 'stable'},
+      {label: 'Polls', tip: 'NC Polls scheduled around the record — stakeholder check-ins, decision tracking.', href: 'https://openregister.conduction.nl/docs/Integrations/polls', status: 'stable'},
+      {label: 'Time tracker', tip: 'NC TimeManager projects with hours logged against the record. Billable evidence per case.', href: 'https://openregister.conduction.nl/docs/Integrations/time-tracker', status: 'stable'},
+
+      {group: 'External (via OpenConnector)'},
+      {label: 'XWiki', tip: 'XWiki pages linked through OpenConnector. Knowledge-base articles, runbooks, procedure docs — outside Nextcloud, surfaced inside it.', href: 'https://openregister.conduction.nl/docs/Integrations/xwiki', status: 'stable'},
+      {label: 'OpenProject', tip: 'OpenProject work packages linked through OpenConnector. Project-management workflows from outside the workspace, surfaced on the record.', href: 'https://openregister.conduction.nl/docs/Integrations/openproject', status: 'stable'},
+    ]}
+  />
+
+  <p style={{textAlign: 'center', marginTop: 'var(--space-6)', color: 'var(--color-text-muted)', fontSize: '0.95em'}}>
+    All 24 leaves use the same <a href="https://openregister.conduction.nl/docs/Integrations/pluggable-integration-registry">pluggable integration registry</a>. Add your own with the leaf-scaffold script and it appears on every register the moment you install your app.
+  </p>
+</Section>
+
 <McpToolShelf
   eyebrow="AI chat tools"
   title="What OpenRegister adds to the workspace AI."
-  lede="Install OpenRegister and the workspace chat gets five new tools. The AI can search registers, fetch a typed record, describe a schema, and read the signed audit trail, all citation-stable and all under the caller's own session."
+  lede="Install OpenRegister and the workspace chat gets three tools that cover the full register surface. The AI can read or write registers, schemas, and objects under the caller's own session, with every call validated against the schema and recorded in the signed audit log."
   tools={[
     {
-      icon: <svg viewBox="0 0 24 24"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.5-4.5"/></svg>,
-      name: 'Search registers',
-      id: 'openregister.search',
-      description: 'Plain-language search across every register the caller can read. Returns typed rows with citation IDs.',
-      status: 'stable',
-    },
-    {
-      icon: <svg viewBox="0 0 24 24"><path d="M4 6h16M4 12h16M4 18h10"/></svg>,
-      name: 'List registers',
-      id: 'openregister.listRegisters',
-      description: 'Enumerate the registers visible to the caller, with their schemas and row counts.',
+      icon: <svg viewBox="0 0 24 24"><ellipse cx="12" cy="6" rx="8" ry="3"/><path d="M4 6v12c0 1.7 3.6 3 8 3s8-1.3 8-3V6"/></svg>,
+      name: 'Manage registers',
+      id: 'openregister.registers',
+      description: 'List, fetch, create, update, or delete registers. Registers group schemas and the objects written against them.',
       status: 'stable',
     },
     {
       icon: <svg viewBox="0 0 24 24"><path d="M5 4h14v6H5zM5 14h14v6H5zM9 4v16"/></svg>,
-      name: 'Get object',
-      id: 'openregister.getObject',
-      description: 'Fetch one object by citation ID and return its full typed body.',
+      name: 'Manage schemas',
+      id: 'openregister.schemas',
+      description: 'List, fetch, create, update, or delete schemas. A schema is the JSON Schema that defines an object type inside a register.',
       status: 'stable',
     },
     {
       icon: <svg viewBox="0 0 24 24"><path d="M3 7h18M6 12h12M9 17h6"/></svg>,
-      name: 'Describe schema',
-      id: 'openregister.describeSchema',
-      description: "Return a schema's JSON Schema body so the AI can validate before suggesting a write.",
+      name: 'Manage objects',
+      id: 'openregister.objects',
+      description: 'List, fetch, create, update, or delete objects. Every write is validated against the schema and recorded in the signed audit log.',
       status: 'stable',
-    },
-    {
-      icon: <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg>,
-      name: 'Object audit history',
-      id: 'openregister.getAuditTrail',
-      description: 'Read the signed audit log for an object: who changed which field, when, from which session.',
-      status: 'beta',
-    },
-    {
-      icon: <svg viewBox="0 0 24 24"><path d="M12 5v14M5 12h14"/></svg>,
-      name: 'Create object',
-      id: 'openregister.createObject',
-      description: 'Write a new object into a register, after schema validation. Available with write-scope sessions.',
-      status: 'soon',
     },
   ]}
   showIds={false}
   trace={<AgentTrace
     lines={[
-      {kind: 'tool', text: 'openregister - search (MCP)(query: "open Woo cases'},
-      {kind: 'continuation', text: 'past their deadline in maart 2026")'},
+      {kind: 'tool', text: 'openregister - objects (MCP)(action: "list", register: "woo",'},
+      {kind: 'continuation', text: 'schema: "verzoek", filter: {status: "open", deadline_before: "2026-04-01"})'},
       {kind: 'note', bullet: 'info', text: 'Rewriting natural language to a typed query', muted: '(claude-sonnet-4-6)'},
-      {kind: 'note', bullet: 'done', text: 'Returned 14 register rows with citation IDs'},
+      {kind: 'note', bullet: 'done', text: 'Returned 14 objects with citation IDs'},
       {kind: 'status', text: 'Synthesising answer'},
     ]}
     cursor
-    mode="audit log on (every query recorded)"
+    mode="audit log on (every call recorded)"
   />}
 />
 

--- a/src/pages/apps/openregister.mdx
+++ b/src/pages/apps/openregister.mdx
@@ -4,7 +4,7 @@ description: Schema-driven object store with audit trail. The data foundation un
 hide_table_of_contents: true
 ---
 
-import {DetailHero, Section, SectionHead, FeatureList, FeatureItem, FeatureGrid, PairRow, PairCard, CtaBanner, AppMock, RotatingCards, WidgetShelf, Showcase, AgentTrace, AppCrossLinks} from '@conduction/docusaurus-preset/components';
+import {DetailHero, Section, SectionHead, FeatureList, FeatureItem, FeatureGrid, PairRow, PairCard, CtaBanner, AppMock, RotatingCards, WidgetShelf, Showcase, AgentTrace, McpToolShelf, AppCrossLinks} from '@conduction/docusaurus-preset/components';
 
 <DetailHero
   appId="openregister"
@@ -225,6 +225,68 @@ import {DetailHero, Section, SectionHead, FeatureList, FeatureItem, FeatureGrid,
       panel: <AppMock app="docudesk" />,
     },
   ]}
+/>
+
+<McpToolShelf
+  eyebrow="AI chat tools"
+  title="What OpenRegister adds to the workspace AI."
+  lede="Install OpenRegister and the workspace chat gets five new tools. The AI can search registers, fetch a typed record, describe a schema, and read the signed audit trail, all citation-stable and all under the caller's own session."
+  tools={[
+    {
+      icon: <svg viewBox="0 0 24 24"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.5-4.5"/></svg>,
+      name: 'Search registers',
+      id: 'openregister.search',
+      description: 'Plain-language search across every register the caller can read. Returns typed rows with citation IDs.',
+      status: 'stable',
+    },
+    {
+      icon: <svg viewBox="0 0 24 24"><path d="M4 6h16M4 12h16M4 18h10"/></svg>,
+      name: 'List registers',
+      id: 'openregister.listRegisters',
+      description: 'Enumerate the registers visible to the caller, with their schemas and row counts.',
+      status: 'stable',
+    },
+    {
+      icon: <svg viewBox="0 0 24 24"><path d="M5 4h14v6H5zM5 14h14v6H5zM9 4v16"/></svg>,
+      name: 'Get object',
+      id: 'openregister.getObject',
+      description: 'Fetch one object by citation ID and return its full typed body.',
+      status: 'stable',
+    },
+    {
+      icon: <svg viewBox="0 0 24 24"><path d="M3 7h18M6 12h12M9 17h6"/></svg>,
+      name: 'Describe schema',
+      id: 'openregister.describeSchema',
+      description: "Return a schema's JSON Schema body so the AI can validate before suggesting a write.",
+      status: 'stable',
+    },
+    {
+      icon: <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg>,
+      name: 'Object audit history',
+      id: 'openregister.getAuditTrail',
+      description: 'Read the signed audit log for an object: who changed which field, when, from which session.',
+      status: 'beta',
+    },
+    {
+      icon: <svg viewBox="0 0 24 24"><path d="M12 5v14M5 12h14"/></svg>,
+      name: 'Create object',
+      id: 'openregister.createObject',
+      description: 'Write a new object into a register, after schema validation. Available with write-scope sessions.',
+      status: 'soon',
+    },
+  ]}
+  showIds={false}
+  trace={<AgentTrace
+    lines={[
+      {kind: 'tool', text: 'openregister - search (MCP)(query: "open Woo cases'},
+      {kind: 'continuation', text: 'past their deadline in maart 2026")'},
+      {kind: 'note', bullet: 'info', text: 'Rewriting natural language to a typed query', muted: '(claude-sonnet-4-6)'},
+      {kind: 'note', bullet: 'done', text: 'Returned 14 register rows with citation IDs'},
+      {kind: 'status', text: 'Synthesising answer'},
+    ]}
+    cursor
+    mode="audit log on (every query recorded)"
+  />}
 />
 
 <Section spacing="default" background="tinted">

--- a/src/pages/apps/openregister.mdx
+++ b/src/pages/apps/openregister.mdx
@@ -188,7 +188,7 @@ import {DetailHero, Section, SectionHead, FeatureList, FeatureItem, FeatureGrid,
     {
       id: 'windmill-n8n',
       title: 'Windmill and n8n',
-      summary: 'Trigger workflows on register events. New row, schema change, validation failure, archive transition — each one fires a webhook your Windmill or n8n flow can consume. Outcomes write back to the row.',
+      summary: 'Trigger workflows on register events. New row, schema change, validation failure, archive transition: each one fires a webhook your Windmill or n8n flow can consume. Outcomes write back to the row.',
       cta: {label: 'See the workflow examples', href: 'https://docs.conduction.nl/openregister/windmill-n8n'},
       panel: <AppMock app="openconnector" />,
     },
@@ -238,44 +238,44 @@ import {DetailHero, Section, SectionHead, FeatureList, FeatureItem, FeatureGrid,
     legend
     items={[
       {group: 'Core (ships with every install)'},
-      {label: 'Files', tip: 'Files attached to the object’s auto-created folder — drag-drop in Nextcloud Files, list them inline on the object detail page.', href: 'https://openregister.conduction.nl/docs/Integrations/leaf-system', status: 'stable'},
+      {label: 'Files', tip: "Files attached to the object's auto-created folder. Drag-drop in Nextcloud Files, list them inline on the object detail page.", href: 'https://openregister.conduction.nl/docs/Integrations/leaf-system', status: 'stable'},
       {label: 'Notes', tip: 'Free-form notes the team writes against the record. Markdown, signed by the author, scoped to the object.', href: 'https://openregister.conduction.nl/docs/Integrations/leaf-system', status: 'stable'},
-      {label: 'Tags', tip: 'System tags applied to the object. Same tag pool as files — cross-references the workspace taxonomy.', href: 'https://openregister.conduction.nl/docs/Integrations/leaf-system', status: 'stable'},
-      {label: 'Tasks', tip: 'CalDAV VTODO tasks linked to the record. Due dates and assignees live in the user’s own task app.', href: 'https://openregister.conduction.nl/docs/Integrations/leaf-system', status: 'stable'},
+      {label: 'Tags', tip: 'System tags applied to the object. Same tag pool as files, cross-references the workspace taxonomy.', href: 'https://openregister.conduction.nl/docs/Integrations/leaf-system', status: 'stable'},
+      {label: 'Tasks', tip: "CalDAV VTODO tasks linked to the record. Due dates and assignees live in the user's own task app.", href: 'https://openregister.conduction.nl/docs/Integrations/leaf-system', status: 'stable'},
       {label: 'Audit trail', tip: 'Every read, write, and schema change leaves a signed, citation-stable entry. WOO and BIO compliance evidence ships with the install.', href: 'https://openregister.conduction.nl/docs/Integrations/leaf-system', status: 'stable'},
-      {label: 'Shares', tip: 'Nextcloud shares created against the object’s files. Surfaces who has access, when, and why.', href: 'https://openregister.conduction.nl/docs/Integrations/leaf-system', status: 'stable'},
+      {label: 'Shares', tip: "Nextcloud shares created against the object's files. Surfaces who has access, when, and why.", href: 'https://openregister.conduction.nl/docs/Integrations/leaf-system', status: 'stable'},
 
       {group: 'Communication (lights up with NC Calendar / Contacts / Mail / Talk)'},
-      {label: 'Calendar', tip: 'CalDAV events linked to the record. Meet-about-this-case in one click, agenda stays in the user’s own calendar.', href: 'https://openregister.conduction.nl/docs/Integrations/calendar', status: 'stable'},
-      {label: 'Contacts', tip: 'CardDAV contacts associated with the record. Customer, vendor, citizen — every party lives in NC Contacts.', href: 'https://openregister.conduction.nl/docs/Integrations/contacts', status: 'stable'},
-      {label: 'Email', tip: 'Mail messages linked to the record. Subject, sender, date — click through to NC Mail to reply.', href: 'https://openregister.conduction.nl/docs/Integrations/email', status: 'stable'},
-      {label: 'Talk', tip: 'NC Talk conversations carrying the record’s discussions. Calls, chat history, screen-shares — all in NC Talk, surfaced on the record.', href: 'https://openregister.conduction.nl/docs/Integrations/talk', status: 'stable'},
+      {label: 'Calendar', tip: "CalDAV events linked to the record. Meet-about-this-case in one click, agenda stays in the user's own calendar.", href: 'https://openregister.conduction.nl/docs/Integrations/calendar', status: 'stable'},
+      {label: 'Contacts', tip: 'CardDAV contacts associated with the record. Customer, vendor, citizen, every party lives in NC Contacts.', href: 'https://openregister.conduction.nl/docs/Integrations/contacts', status: 'stable'},
+      {label: 'Email', tip: 'Mail messages linked to the record. Subject, sender, date. Click through to NC Mail to reply.', href: 'https://openregister.conduction.nl/docs/Integrations/email', status: 'stable'},
+      {label: 'Talk', tip: "NC Talk conversations carrying the record's discussions. Calls, chat history, screen-shares, all in NC Talk, surfaced on the record.", href: 'https://openregister.conduction.nl/docs/Integrations/talk', status: 'stable'},
 
       {group: 'Knowledge & documents (NC Bookmarks / Collectives / Maps / Photos)'},
-      {label: 'Bookmarks', tip: 'NC Bookmarks tagged with the record. Reference URLs, regulatory sources, partner sites — one tag links them to the case.', href: 'https://openregister.conduction.nl/docs/Integrations/bookmarks', status: 'stable'},
-      {label: 'Collectives', tip: 'NC Collectives pages — the team wiki for the case. Markdown, versioned, with a marker in the slug.', href: 'https://openregister.conduction.nl/docs/Integrations/collectives', status: 'stable'},
-      {label: 'Maps', tip: 'NC Maps favorites with the record’s coordinates. Site visits, asset locations, on-the-ground evidence.', href: 'https://openregister.conduction.nl/docs/Integrations/maps', status: 'stable'},
+      {label: 'Bookmarks', tip: 'NC Bookmarks tagged with the record. Reference URLs, regulatory sources, partner sites, all one tag away from the case.', href: 'https://openregister.conduction.nl/docs/Integrations/bookmarks', status: 'stable'},
+      {label: 'Collectives', tip: 'NC Collectives pages, the team wiki for the case. Markdown, versioned, with a marker in the slug.', href: 'https://openregister.conduction.nl/docs/Integrations/collectives', status: 'stable'},
+      {label: 'Maps', tip: "NC Maps favorites with the record's coordinates. Site visits, asset locations, on-the-ground evidence.", href: 'https://openregister.conduction.nl/docs/Integrations/maps', status: 'stable'},
       {label: 'Photos', tip: 'NC Photos albums tied to the record. Photo evidence, signed timestamps, geo-tagged.', href: 'https://openregister.conduction.nl/docs/Integrations/photos', status: 'stable'},
 
       {group: 'Workflow (NC Activity / Analytics / Cospend / Deck / Flow / Forms / Polls / TimeManager)'},
       {label: 'Activity', tip: 'Nextcloud activity stream filtered to the record. Who touched the file, who shared what, when.', href: 'https://openregister.conduction.nl/docs/Integrations/activity', status: 'stable'},
       {label: 'Analytics', tip: 'NC Analytics reports linked to the record. Charts and KPIs that reference the same data the case is built on.', href: 'https://openregister.conduction.nl/docs/Integrations/analytics', status: 'stable'},
-      {label: 'Cospend', tip: 'NC Cospend projects — budget and expense tracking attached to the case.', href: 'https://openregister.conduction.nl/docs/Integrations/cospend', status: 'stable'},
+      {label: 'Cospend', tip: 'NC Cospend projects, budget and expense tracking attached to the case.', href: 'https://openregister.conduction.nl/docs/Integrations/cospend', status: 'stable'},
       {label: 'Deck', tip: 'NC Deck cards linked to the record. Per-case kanban without leaving the case.', href: 'https://openregister.conduction.nl/docs/Integrations/deck', status: 'stable'},
-      {label: 'Flow', tip: 'NC Workflow Engine rules referencing the record’s schema. Automate notifications, retention, escalations.', href: 'https://openregister.conduction.nl/docs/Integrations/flow', status: 'stable'},
+      {label: 'Flow', tip: "NC Workflow Engine rules referencing the record's schema. Automate notifications, retention, escalations.", href: 'https://openregister.conduction.nl/docs/Integrations/flow', status: 'stable'},
       {label: 'Forms', tip: 'NC Forms responses linked to the record. Citizen submissions, survey results, intake forms.', href: 'https://openregister.conduction.nl/docs/Integrations/forms', status: 'stable'},
-      {label: 'Polls', tip: 'NC Polls scheduled around the record — stakeholder check-ins, decision tracking.', href: 'https://openregister.conduction.nl/docs/Integrations/polls', status: 'stable'},
+      {label: 'Polls', tip: 'NC Polls scheduled around the record. Stakeholder check-ins, decision tracking.', href: 'https://openregister.conduction.nl/docs/Integrations/polls', status: 'stable'},
       {label: 'Time tracker', tip: 'NC TimeManager projects with hours logged against the record. Billable evidence per case.', href: 'https://openregister.conduction.nl/docs/Integrations/time-tracker', status: 'stable'},
 
       {group: 'External (via OpenConnector)'},
-      {label: 'XWiki', tip: 'XWiki pages linked through OpenConnector. Knowledge-base articles, runbooks, procedure docs — outside Nextcloud, surfaced inside it.', href: 'https://openregister.conduction.nl/docs/Integrations/xwiki', status: 'stable'},
+      {label: 'XWiki', tip: 'XWiki pages linked through OpenConnector. Knowledge-base articles, runbooks, procedure docs from outside Nextcloud, surfaced inside it.', href: 'https://openregister.conduction.nl/docs/Integrations/xwiki', status: 'stable'},
       {label: 'OpenProject', tip: 'OpenProject work packages linked through OpenConnector. Project-management workflows from outside the workspace, surfaced on the record.', href: 'https://openregister.conduction.nl/docs/Integrations/openproject', status: 'stable'},
     ]}
   />
 
-  <p style={{textAlign: 'center', marginTop: 'var(--space-6)', color: 'var(--color-text-muted)', fontSize: '0.95em'}}>
+  <div style={{textAlign: 'center', marginTop: 'var(--space-6)', color: 'var(--color-text-muted)', fontSize: '0.95em'}}>
     All 24 leaves use the same <a href="https://openregister.conduction.nl/docs/Integrations/pluggable-integration-registry">pluggable integration registry</a>. Add your own with the leaf-scaffold script and it appears on every register the moment you install your app.
-  </p>
+  </div>
 </Section>
 
 <McpToolShelf


### PR DESCRIPTION
## Summary

- Wire `<McpToolShelf>` into openregister, decidesk, and openbuilt product pages
- Add the 24-leaf workspace grid to /apps/openregister/, with each leaf clickable into its product-doc page on openregister.conduction.nl
- Bump `@conduction/docusaurus-preset` to ^3.3.0 (adds `href` prop on `FeatureItem`)
- Sweep em-dashes and curly apostrophes from leaf tips (brand rule), fix `<p>` inside `<p>` nesting warning on the closing footnote

## Test plan

- [x] Local dev server renders /apps/openregister/#leaves with 24 linked items grouped in 5 categories
- [x] All 24 hrefs point to https://openregister.conduction.nl/docs/Integrations/{leaf}
- [x] No console errors after the `<p>` → `<div>` fix
- [x] Visual layout matches kit specimen (preview/components/feature-grid.html on design-system)