### PR TITLE
fix(deps): sync package-lock.json with preset 3.5.0 (unbreaks deploy)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@conduction/docusaurus-preset": "^3.3.0",
+        "@conduction/docusaurus-preset": "^3.5.0",
         "@docusaurus/core": "^3.5.0",
         "@docusaurus/preset-classic": "^3.5.0",
         "@mdx-js/react": "^3.0.0",
@@ -1988,10 +1988,13 @@
       }
     },
     "node_modules/@conduction/docusaurus-preset": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-3.3.0.tgz",
-      "integrity": "sha512-xpNp/Azxwp1TbvnGLN8egxpPk/ZlpUEzdEHfwUDxf7McfpsM4C16JdgXaQ33n6GZAMCHKWrbseKjfSwRSbrmtQ==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-3.5.0.tgz",
+      "integrity": "sha512-fNU5LYCBuh4FLaKXHMixa6Vq3In/lfUPo7KxKJMomWgkvMnDgpP+T7N/41dqXl8YTatFnmS2zWPcu6pV6vFajg==",
       "license": "EUPL-1.2",
+      "bin": {
+        "validate-ai-baseline": "bin/validate-ai-baseline.mjs"
+      },
       "peerDependencies": {
         "@docusaurus/core": "^3.0.0",
         "@docusaurus/preset-classic": "^3.0.0",
@@ -16022,13 +16025,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
-    },
-    "node_modules/search-insights": {
-      "version": "2.17.3",
-      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.3.tgz",
-      "integrity": "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/section-matter": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "ci": "npm ci --legacy-peer-deps && npm run build"
   },
   "dependencies": {
-    "@conduction/docusaurus-preset": "^3.4.0",
+    "@conduction/docusaurus-preset": "^3.5.0",
     "@docusaurus/core": "^3.5.0",
     "@docusaurus/preset-classic": "^3.5.0",
     "@mdx-js/react": "^3.0.0",


### PR DESCRIPTION
## Summary

PR #55 bumped \`@conduction/docusaurus-preset\` to \`^3.4.0\` in \`package.json\` without regenerating \`package-lock.json\`. CI uses \`npm ci --legacy-peer-deps\` which fails if the two are out of sync. Result: every Documentation workflow run on \`development\` since #55 merged has failed at \`npm ci\`, and **the AI baseline (robots.txt, llms.txt, JSON-LD, OG card, sitemaps) never reached production on www.conduction.nl**.

## Fix

- Bumped the package.json range from \`^3.4.0\` to \`^3.5.0\` to match the latest preset (also matches what the rest of the fleet was migrated to in #59-style PRs).
- Regenerated \`package-lock.json\` against the new range using \`npm install --package-lock-only --legacy-peer-deps --min-release-age=0\` (the \`min-release-age=0\` override is documented in \`.npmrc\` as the way to pull fresh \`@conduction/*\` releases past the 24h cooldown).

## Expected after merge

The next push to \`development\` will:
1. \`npm ci --legacy-peer-deps\` succeeds (lock in sync)
2. \`docusaurus build\` runs
3. \`postbuild\` runs the AI-baseline validator (15 checks); should pass
4. \`upload-artifact\` uploads \`build/\`
5. \`deploy\` job downloads + pushes to \`gh-pages\`
6. www.conduction.nl serves robots.txt, llms.txt, JSON-LD, og-conduction.png, both sitemaps

I'll verify the live state once the deploy completes.

## Related

- #55 (AI baseline) — the work this unblocks
- ConductionNL/.github#73 (centralised workflow with build-on-PR) — the workflow that's been failing

## Test plan

- [ ] CI passes on this PR
- [ ] After merge: development deploy succeeds
- [ ] curl https://www.conduction.nl/robots.txt returns 200 with the AI-bot allow list
- [ ] curl https://www.conduction.nl/llms.txt returns 200 with the 15-app index
- [ ] view-source of www.conduction.nl shows Organization + WebSite JSON-LD blocks