### PR TITLE
feat(seo): traditional-search baseline (titles, preset 3.6, legal-link override)

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -102,6 +102,27 @@ module.exports = createConfig({
     ],
   ],
 
+  /* Keep the canal-footer's Privacy / Terms / ISO links on relative
+     routes. The preset's default ships absolute https://www.conduction.nl/*
+     URLs so per-app subdomain footers don't 404, but this IS the
+     marketing site that hosts those pages, so a relative link is the
+     cleaner UX (no needless cross-host hop). */
+  legalLinks: {
+    privacy: '/privacy',
+    terms: '/terms',
+    iso: '/iso',
+  },
+
+  /* Search Console / Bing Webmaster / etc. verification tokens are
+     filled by ops once the property has been claimed; the preset
+     emits a meta tag for each token present. Leave keys absent until
+     a real token is available, otherwise a stale placeholder ends up
+     in the production HTML. */
+  // searchConsoleVerification: {
+  //   google: '...',
+  //   bing:   '...',
+  // },
+
   /* Brand top-navbar pattern: five left-side section links + locale
      dropdown + Partners ghost + Install primary CTA on the right.
      Title text is set here as the default ("Conduction"); the swizzled

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@conduction/docusaurus-preset": "^3.5.0",
+        "@conduction/docusaurus-preset": "^3.6.0",
         "@docusaurus/core": "^3.5.0",
         "@docusaurus/preset-classic": "^3.5.0",
         "@mdx-js/react": "^3.0.0",
@@ -1988,9 +1988,9 @@
       }
     },
     "node_modules/@conduction/docusaurus-preset": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-3.5.0.tgz",
-      "integrity": "sha512-fNU5LYCBuh4FLaKXHMixa6Vq3In/lfUPo7KxKJMomWgkvMnDgpP+T7N/41dqXl8YTatFnmS2zWPcu6pV6vFajg==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-3.6.0.tgz",
+      "integrity": "sha512-gjnM6G+Cjx1WKniMhbQDYjgje0J4nqjeArKUHxisEdsY62fp8mfEzP1NXeD/2F2aYa+eHShCHeYGUM9jTl6yKQ==",
       "license": "EUPL-1.2",
       "bin": {
         "validate-ai-baseline": "bin/validate-ai-baseline.mjs"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "ci": "npm ci --legacy-peer-deps && npm run build"
   },
   "dependencies": {
-    "@conduction/docusaurus-preset": "^3.5.0",
+    "@conduction/docusaurus-preset": "^3.6.0",
     "@docusaurus/core": "^3.5.0",
     "@docusaurus/preset-classic": "^3.5.0",
     "@mdx-js/react": "^3.0.0",

--- a/src/pages/about.mdx
+++ b/src/pages/about.mdx
@@ -1,5 +1,5 @@
 ---
-title: About, Conduction
+title: About
 description: Conduction is a small Dutch open-source product company. A workspace of open-source apps for Nextcloud, one team in Amsterdam.
 hide_table_of_contents: true
 ---

--- a/src/pages/apps.mdx
+++ b/src/pages/apps.mdx
@@ -1,5 +1,5 @@
 ---
-title: Apps, Conduction
+title: Apps
 description: Open-source apps that plug into Nextcloud. Catalogs, registers, integrations, document handling, dashboards.
 hide_table_of_contents: true
 ---

--- a/src/pages/demo.mdx
+++ b/src/pages/demo.mdx
@@ -1,5 +1,5 @@
 ---
-title: Local demo, Conduction
+title: Local demo
 description: Want a demo? Run Nextcloud locally with Docker, install the Conduction apps from the app store, see them work. No partner needed, no calendar invite, no sales call.
 hide_table_of_contents: true
 ---

--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -1,6 +1,6 @@
 ---
-title: Conduction, Public Tech for Nextcloud
-description: Conduction builds open-source apps for the Nextcloud workspace. Tech to serve people. Apps you install yourself, support when you want it managed, advisory when you want a partner.
+title: Public Tech for Nextcloud
+description: Open-source apps that plug into the Nextcloud workspace. Install yourself, get managed support, or bring a partner. EUPL-1.2, ISO 27001, Amsterdam.
 hide_table_of_contents: true
 ---
 

--- a/src/pages/partners.mdx
+++ b/src/pages/partners.mdx
@@ -1,5 +1,5 @@
 ---
-title: Partners, Conduction
+title: Partners
 description: Implementation, hosting, and integration partners for the Conduction app ecosystem. Filter by tier and by the apps you want to deploy.
 hide_table_of_contents: true
 ---

--- a/src/pages/sidecars.mdx
+++ b/src/pages/sidecars.mdx
@@ -1,5 +1,5 @@
 ---
-title: Sidecars, Conduction
+title: Sidecars
 description: Nextcloud-installable wrappers around third-party open-source services. Same upstream, less DevOps.
 hide_table_of_contents: true
 ---

--- a/src/pages/solutions.mdx
+++ b/src/pages/solutions.mdx
@@ -1,5 +1,5 @@
 ---
-title: Solutions, Conduction
+title: Solutions
 description: Outcomes you can reach by installing one or two Conduction apps and configuring them.
 hide_table_of_contents: true
 ---

--- a/src/pages/support.mdx
+++ b/src/pages/support.mdx
@@ -1,5 +1,5 @@
 ---
-title: Support, Conduction
+title: Support
 description: Support runs through partners. The apps stay free. Government clients can opt for a managed Common Ground tenant.
 hide_table_of_contents: true
 ---


### PR DESCRIPTION
## Summary

Companion to the AI-crawler baseline in #55. Targets traditional search engines (Google, Bing, DuckDuckGo) and the AI surfaces those engines feed (Copilot, ChatGPT Search, Perplexity).

## Changes

### Title dedup (8 pages)

Docusaurus auto-appends \`| {Site}\` to every page title. Prior frontmatter \`title: Apps, Conduction\` produced \`Apps, Conduction | Conduction\` in browser title, \`og:title\`, and SERP. Cleaned up:

| Page | before | after |
|---|---|---|
| /about | About, Conduction → \`About | Conduction\` |
| /apps | Apps, Conduction → \`Apps | Conduction\` |
| /demo | Local demo, Conduction → \`Local demo | Conduction\` |
| /partners | Partners, Conduction → \`Partners | Conduction\` |
| /sidecars | Sidecars, Conduction → \`Sidecars | Conduction\` |
| /solutions | Solutions, Conduction → \`Solutions | Conduction\` |
| /support | Support, Conduction → \`Support | Conduction\` |
| / | Conduction, Public Tech for Nextcloud → \`Public Tech for Nextcloud | Conduction\` |

\`/apps/<slug>\` pages left alone: "OpenRegister, Conduction" reads as branding, not a typo.

### Homepage meta description

180 chars → 157 chars. Google truncates around 155-160. New copy:
\"Open-source apps that plug into the Nextcloud workspace. Install yourself, get managed support, or bring a partner. EUPL-1.2, ISO 27001, Amsterdam.\"

### Preset 3.6.0 + lockfile

Bump \`@conduction/docusaurus-preset\` to \`^3.6.0\` (preset companion PR shipped sitemap lastmod, drops priority/changefreq, adds searchConsoleVerification opt, and absolute www.conduction.nl defaults for footer legal links). Lockfile regenerated with \`--min-release-age=0\` per .npmrc cooldown override.

### legalLinks override

conduction-website hosts /privacy, /terms, /iso itself, so we override the preset's new absolute defaults back to relative routes. Per-app subdomain sites inherit the absolute defaults (they don't have those pages) so the **~645 sitewide broken internal links** the SEO audit found get fixed automatically on each site's next deploy.

### searchConsoleVerification scaffold

Commented-out placeholder in docusaurus.config.js. Once ops claims the property in Google Search Console / Bing Webmaster Tools, the tokens go here and the preset emits a meta tag per token.

## Validation

Deploy will run the postbuild validator (15 checks). The new SEO check (\`sitemap.xml emits <lastmod>\`) requires preset 3.6.0 — this PR's lockfile pulls it in.

## Test plan

- [ ] Build succeeds
- [ ] Sitemap.xml has \`<lastmod>\` on every URL
- [ ] Browser title on /apps reads \`Apps | Conduction\`
- [ ] Homepage meta description renders the new 157-char version
- [ ] Footer Privacy / Terms / ISO still link to /privacy /terms /iso (not absolute www.conduction.nl URLs)