### PR TITLE
fix(seo): /contact page + redirects for legacy 404s

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -202,5 +202,28 @@ module.exports = createConfig({
     //     locales: ['en', 'nl'],
     //   },
     // ],
+    /* Reclaim SEO equity from URLs Google has in its index from the
+       pre-Docusaurus / pre-subdomain layout. The plugin emits one
+       static HTML page per `from` with a <meta http-equiv="refresh">
+       and a `<link rel="canonical">` to the `to` target, which Google
+       treats as a 301 signal. Only the URLs in this list have current
+       equivalents worth redirecting; the rest (componenten catalogue,
+       WP placeholders, retired training pages) are let to 404 naturally. */
+    [
+      '@docusaurus/plugin-client-redirects',
+      {
+        redirects: [
+          /* Old Dutch "about us" slug. The English /about/ route is
+             the canonical replacement; NL translation pass will land
+             /nl/about/ later. */
+          {from: '/over-ons', to: '/about/'},
+          /* The OpenConnector page used to live on the apex; everything
+             moved to its own subdomain in the 2026-02 split. Send the
+             two indexed entry points to the canonical app site. */
+          {from: '/openconnector', to: 'https://openconnector.conduction.nl/'},
+          {from: '/openconnector/support', to: 'https://openconnector.conduction.nl/support/'},
+        ],
+      },
+    ],
   ],
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@conduction/docusaurus-preset": "^3.6.0",
         "@docusaurus/core": "^3.5.0",
+        "@docusaurus/plugin-client-redirects": "^3.5.0",
         "@docusaurus/preset-classic": "^3.5.0",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
@@ -3598,6 +3599,30 @@
       "peerDependencies": {
         "react": "*",
         "react-dom": "*"
+      }
+    },
+    "node_modules/@docusaurus/plugin-client-redirects": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-3.10.1.tgz",
+      "integrity": "sha512-LHgd+YDvkhfOHMAE6XtUng3DQNzVM765RqVRrMJgHtzAvfopQhY6ieprqjxDVBdv21cLma6I0jHr+YCZH8fL9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/core": "3.10.1",
+        "@docusaurus/logger": "3.10.1",
+        "@docusaurus/utils": "3.10.1",
+        "@docusaurus/utils-common": "3.10.1",
+        "@docusaurus/utils-validation": "3.10.1",
+        "eta": "^2.2.0",
+        "fs-extra": "^11.1.1",
+        "lodash": "^4.17.21",
+        "tslib": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@docusaurus/plugin-content-blog": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@conduction/docusaurus-preset": "^3.6.0",
     "@docusaurus/core": "^3.5.0",
+    "@docusaurus/plugin-client-redirects": "^3.5.0",
     "@docusaurus/preset-classic": "^3.5.0",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",

--- a/src/pages/contact.mdx
+++ b/src/pages/contact.mdx
@@ -1,0 +1,96 @@
+---
+title: Contact
+description: Reach Conduction directly. Email or call our team in Amsterdam, or use the route that matches your reason for reaching out.
+hide_table_of_contents: true
+---
+
+import {Section, SectionHead, TeamGrid, EmployeeCard} from '@conduction/docusaurus-preset/components';
+
+<Section spacing="default">
+  <SectionHead
+    eyebrow="Contact"
+    title={<>Talk to a person.<br/>Not a ticket queue.</>}
+    lede={<>Conduction is a small Dutch open-source product company in Amsterdam. Pick the route below that matches what you need, or email us directly. We answer within one business day.</>}
+  />
+</Section>
+
+<Section spacing="default" background="tinted" id="routes">
+  <SectionHead
+    eyebrow="Three routes"
+    title="Reach the right person."
+    align="stack"
+    lede="Every email reaches a named person on the team. No shared inboxes, no support tier triage."
+  />
+  <TeamGrid columns={3}>
+    <EmployeeCard
+      variant="photo"
+      name="Remco Damhuis"
+      role="New projects · Sales"
+      initials="RD"
+      avatarColor="var(--c-blue-cobalt)"
+      bio="Pricing, demos, procurement questions, and 'can Conduction help us with X'. For new prospects and existing customers picking up new work."
+      links={[
+        {label: 'email', href: 'mailto:remco@conduction.nl', icon: 'mail'},
+        {label: 'phone', href: 'tel:+31623007992', icon: 'phone'},
+        {label: 'LinkedIn', href: 'https://www.linkedin.com/in/remcodamhuis/', icon: 'linkedin'},
+      ]}
+    />
+    <EmployeeCard
+      variant="photo"
+      name="Ruben van der Linde"
+      role="Architecture · Technical"
+      initials="RV"
+      avatarColor="var(--c-orange-knvb)"
+      bio="Schema design, OpenRegister, federation, and integration questions. For developers, integrators, and architects evaluating the platform."
+      links={[
+        {label: 'email', href: 'mailto:ruben@conduction.nl', icon: 'mail'},
+        {label: 'phone', href: 'tel:+31645536677', icon: 'phone'},
+        {label: 'GitHub', href: 'https://github.com/rubenvdlinde', icon: 'github'},
+      ]}
+    />
+    <EmployeeCard
+      variant="photo"
+      name="Marleen Romijn"
+      role="Research · Press"
+      initials="MR"
+      avatarColor="var(--c-blue-cobalt)"
+      bio="User research, market questions, and press or partnership inquiries. For media, researchers, and ecosystem partners."
+      links={[
+        {label: 'email', href: 'mailto:marleen@conduction.nl', icon: 'mail'},
+        {label: 'phone', href: 'tel:+31641336683', icon: 'phone'},
+        {label: 'LinkedIn', href: 'https://www.linkedin.com/in/marleen-romijn-45a45054/', icon: 'linkedin'},
+      ]}
+    />
+  </TeamGrid>
+</Section>
+
+<Section spacing="default" id="office">
+  <SectionHead
+    eyebrow="Office"
+    title="Where we work."
+    align="stack"
+    lede="One office in the Jordaan, a stone's throw from Westermarkt. We're heads-down most days, so call ahead before you drop by."
+  />
+  <div style={{display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))', gap: 'var(--space-8)', maxWidth: 760, margin: '0 auto'}}>
+    <div>
+      <h3 style={{fontSize: 22, fontWeight: 700, color: 'var(--c-cobalt-900)', margin: '0 0 var(--space-3)'}}>Conduction B.V.</h3>
+      <p style={{fontSize: 16, lineHeight: 1.7, color: 'var(--c-cobalt-700)', margin: 0}}>
+        Lauriergracht 14h<br/>
+        1016 RR Amsterdam<br/>
+        Nederland
+      </p>
+      <p style={{fontSize: 16, lineHeight: 1.7, color: 'var(--c-cobalt-700)', margin: 'var(--space-3) 0 0'}}>
+        <a href="tel:+31853036840">+31 85 303 6840</a><br/>
+        <a href="mailto:info@conduction.nl">info@conduction.nl</a>
+      </p>
+    </div>
+    <div>
+      <h3 style={{fontSize: 22, fontWeight: 700, color: 'var(--c-cobalt-900)', margin: '0 0 var(--space-3)'}}>Company details</h3>
+      <p style={{fontSize: 16, lineHeight: 1.7, color: 'var(--c-cobalt-700)', margin: 0}}>
+        KvK: 76741850<br/>
+        BTW: NL860784241B01<br/>
+        IBAN: NL51 ABNA 0868951550
+      </p>
+    </div>
+  </div>
+</Section>


### PR DESCRIPTION
## What

- Adds **/contact** page (was 404 — Google Search Console flagged as Niet gevonden).
- Wires **@docusaurus/plugin-client-redirects** with three redirects for legacy URLs Google still has indexed:
  - \`/over-ons\` → \`/about/\`
  - \`/openconnector\` → \`openconnector.conduction.nl\`
  - \`/openconnector/support\` → \`openconnector.conduction.nl/support/\`

## Why

GSC \"Pagina-indexering > Niet gevonden (404)\" report had 41 URLs. Analysis: ~30 are legacy WordPress URLs (componenten catalogue, retired training pages, sample-page) with no current equivalent — let them fade naturally over 1-3 months. The remaining handful are URLs with current homes worth a 301 signal; this PR covers the conduction.nl side. A separate PR will land the docudesk legal-page redirects.

The /contact page itself fixes a business-critical 404: anyone Googling \"Conduction contact\" landed on a broken page. Now they reach a real page with named-person routes (no shared inbox, no support tier triage).

## Acceptance

After deploy:
- \`https://www.conduction.nl/contact/\` returns 200 with the contact page.
- \`https://www.conduction.nl/over-ons\` 301-redirects to \`/about/\`.
- \`https://www.conduction.nl/openconnector\` and \`/openconnector/support\` redirect to the openconnector subdomain.

The redirects plugin emits static HTML pages with meta-refresh + \`<link rel=\"canonical\">\` to the new target; Google treats this as a 301 signal.