### PR TITLE
feat(i18n): NL translations for sidecars (batch 2 of 2) (#77)

### DIFF
--- a/i18n/nl/docusaurus-plugin-content-pages/sidecars/openklant.mdx
+++ b/i18n/nl/docusaurus-plugin-content-pages/sidecars/openklant.mdx
@@ -1,0 +1,47 @@
+---
+title: OpenKlant sidecar, Conduction
+description: Nextcloud-sidecar rond het OpenKlant klantcontact-register. ZGW-compatibel, installeer je uit de app store.
+hide_table_of_contents: true
+---
+
+import {DetailHero, Section, SectionHead, CtaBanner} from '@conduction/docusaurus-preset/components';
+
+<DetailHero
+  appId="openklant"
+  crumb={[{label: 'Sidecars', href: '/sidecars'}, 'OpenKlant']}
+  status={{label: 'Sidecar', color: 'var(--c-cobalt-400)'}}
+  version="upstream"
+  locales="NL"
+  title="OpenKlant"
+  tagline={<>Een <span className="next-blue">Nextcloud</span>-sidecar rond OpenKlant. Draai het officiële klantcontact-register naast je workspace. Installeer uit de Nextcloud-app-store, zonder apart cluster.</>}
+  primaryCta={{label: 'Installeer uit de app store', href: '/install'}}
+  secondaryCta={{label: 'Lees de docs', href: 'https://docs.conduction.nl/openklant'}}
+  tertiaryCta={{label: 'Bekijk op GitHub', href: 'https://github.com/ConductionNL/openklant'}}
+  iconColor="var(--c-blue-cobalt)"
+  icon={<svg viewBox="0 0 24 24"><circle cx="12" cy="8" r="4"/><path d="M4 21a8 8 0 0 1 16 0"/></svg>}
+/>
+
+<Section spacing="default">
+  <SectionHead
+    eyebrow="Wat het is"
+    title="OpenKlant als Nextcloud-app."
+    align="stack"
+    lede="OpenKlant is het Common Ground klantcontact-register. We verpakken het als Nextcloud-installeerbare sidecar. Je installeert de app, de upstream-container draait naast Nextcloud, en de ZGW-API's zijn bereikbaar vanuit OpenConnector. Dezelfde upstream, minder DevOps."
+  />
+</Section>
+
+<Section spacing="default" background="tinted">
+  <SectionHead
+    eyebrow="Waarom een sidecar"
+    title="Een sidecar is geen fork."
+    align="stack"
+    lede="We forken OpenKlant niet. De sidecar volgt de upstream-releases. De wrapper regelt install, lifecycle en het koppelvlak naar Nextcloud. Je data blijft in de upstream-service. Conduction is verantwoordelijk voor de integratie, niet voor upstream OpenKlant."
+  />
+</Section>
+
+<CtaBanner
+  title="Draai OpenKlant binnen je Nextcloud."
+  lede={<>Installeer uit de Nextcloud-app-store. Combineer met OpenConnector om ZGW-calls te routeren. Combineer met Procest om workflows op klantcontact-events te draaien.</>}
+  primaryCta={{label: 'Installeer uit de app store', href: '/install'}}
+  secondaryCta={{label: 'Praat met een partner', href: '/partners'}}
+/>

--- a/i18n/nl/docusaurus-plugin-content-pages/sidecars/opentalk.mdx
+++ b/i18n/nl/docusaurus-plugin-content-pages/sidecars/opentalk.mdx
@@ -1,0 +1,47 @@
+---
+title: OpenTalk sidecar, Conduction
+description: Nextcloud-sidecar rond de OpenTalk video-conferencing controller. AVG-conforme meetings, end-to-end encrypted, schermdelen.
+hide_table_of_contents: true
+---
+
+import {DetailHero, Section, SectionHead, CtaBanner} from '@conduction/docusaurus-preset/components';
+
+<DetailHero
+  appId="opentalk"
+  crumb={[{label: 'Sidecars', href: '/sidecars'}, 'OpenTalk']}
+  status={{label: 'Sidecar', color: 'var(--c-cobalt-400)'}}
+  version="upstream"
+  locales="NL · EN"
+  title="OpenTalk"
+  tagline={<>Een <span className="next-blue">Nextcloud</span>-sidecar rond OpenTalk. AVG-conforme videoconferencing, end-to-end encrypted, schermdelen ingebouwd. Installeer via de AppAPI en draai als ExApp naast de workspace.</>}
+  primaryCta={{label: 'Installeer uit de app store', href: '/install'}}
+  secondaryCta={{label: 'Lees de upstream-docs', href: 'https://opentalk.eu/'}}
+  tertiaryCta={{label: 'Bekijk op GitHub', href: 'https://github.com/ConductionNL/opentalk'}}
+  iconColor="var(--c-blue-cobalt)"
+  icon={<svg viewBox="0 0 24 24"><path d="M21 11.5a8.4 8.4 0 0 1-9 8.4 8.4 8.4 0 0 1-3.4-.7L3 21l1.5-5.4A8.4 8.4 0 1 1 21 11.5z"/></svg>}
+/>
+
+<Section spacing="default">
+  <SectionHead
+    eyebrow="Wat het is"
+    title="OpenTalk als Nextcloud-ExApp."
+    align="stack"
+    lede="OpenTalk is een AVG-conforme video-conferencing controller van heinlein-group. We verpakken het als Nextcloud-installeerbare ExApp via de AppAPI. Installeer de app, de upstream-controller draait naast Nextcloud, en meeting-links verschijnen naast je Files, Mail en Calendar."
+  />
+</Section>
+
+<Section spacing="default" background="tinted">
+  <SectionHead
+    eyebrow="Waarom een sidecar"
+    title="Een sidecar is geen fork."
+    align="stack"
+    lede="We forken OpenTalk niet. De sidecar volgt de upstream-containerreleases. De wrapper regelt install, lifecycle en het koppelvlak naar Nextcloud. Meeting-data blijft in de upstream-service, gehost waar jij hem host. Conduction is verantwoordelijk voor de integratie, niet voor upstream OpenTalk."
+  />
+</Section>
+
+<CtaBanner
+  title="Draai OpenTalk-meetings binnen je Nextcloud."
+  lede={<>Installeer uit de Nextcloud-app-store. AVG-conform, end-to-end encrypted, gehost naast de workspace die je team al gebruikt.</>}
+  primaryCta={{label: 'Installeer uit de app store', href: '/install'}}
+  secondaryCta={{label: 'Praat met een partner', href: '/partners'}}
+/>

--- a/i18n/nl/docusaurus-plugin-content-pages/sidecars/openzaak.mdx
+++ b/i18n/nl/docusaurus-plugin-content-pages/sidecars/openzaak.mdx
@@ -1,0 +1,47 @@
+---
+title: OpenZaak sidecar, Conduction
+description: Nextcloud-sidecar rond de OpenZaak zaakafhandeling-API.
+hide_table_of_contents: true
+---
+
+import {DetailHero, Section, SectionHead, CtaBanner} from '@conduction/docusaurus-preset/components';
+
+<DetailHero
+  appId="openzaak"
+  crumb={[{label: 'Sidecars', href: '/sidecars'}, 'OpenZaak']}
+  status={{label: 'Sidecar', color: 'var(--c-cobalt-400)'}}
+  version="upstream"
+  locales="NL"
+  title="OpenZaak"
+  tagline={<>Een <span className="next-blue">Nextcloud</span>-sidecar rond OpenZaak. Draai de officiële Common Ground zaakafhandeling-API naast je workspace. ZGW-koppelvlakken, vanuit Nextcloud.</>}
+  primaryCta={{label: 'Installeer uit de app store', href: '/install'}}
+  secondaryCta={{label: 'Lees de docs', href: 'https://docs.conduction.nl/openzaak'}}
+  tertiaryCta={{label: 'Bekijk op GitHub', href: 'https://github.com/ConductionNL/openzaak'}}
+  iconColor="var(--c-blue-cobalt)"
+  icon={<svg viewBox="0 0 24 24"><rect x="4" y="4" width="16" height="16" rx="2"/><path d="M9 9h6v6H9z"/></svg>}
+/>
+
+<Section spacing="default">
+  <SectionHead
+    eyebrow="Wat het is"
+    title="OpenZaak als Nextcloud-app."
+    align="stack"
+    lede="OpenZaak is de Common Ground zaakafhandeling-API. We verpakken het als Nextcloud-installeerbare sidecar. Je installeert de app, de upstream-container draait naast Nextcloud, en de ZGW-endpoints zijn bereikbaar vanuit OpenConnector. Dezelfde upstream, minder DevOps."
+  />
+</Section>
+
+<Section spacing="default" background="tinted">
+  <SectionHead
+    eyebrow="Waarom een sidecar"
+    title="Een sidecar is geen fork."
+    align="stack"
+    lede="We forken OpenZaak niet. De sidecar volgt de upstream-releases. De wrapper regelt install, lifecycle en het koppelvlak naar Nextcloud. Je zaakgegevens blijven in de upstream-service. Conduction is verantwoordelijk voor de integratie, niet voor upstream OpenZaak."
+  />
+</Section>
+
+<CtaBanner
+  title="Draai OpenZaak binnen je Nextcloud."
+  lede={<>Installeer uit de Nextcloud-app-store. Route ZGW-calls via OpenConnector. Stuur zaken door Procest-workflows.</>}
+  primaryCta={{label: 'Installeer uit de app store', href: '/install'}}
+  secondaryCta={{label: 'Praat met een partner', href: '/partners'}}
+/>

--- a/i18n/nl/docusaurus-plugin-content-pages/sidecars/valtimo.mdx
+++ b/i18n/nl/docusaurus-plugin-content-pages/sidecars/valtimo.mdx
@@ -1,0 +1,47 @@
+---
+title: Valtimo sidecar, Conduction
+description: Nextcloud-sidecar rond de Valtimo BPMN-workflow-engine.
+hide_table_of_contents: true
+---
+
+import {DetailHero, Section, SectionHead, CtaBanner} from '@conduction/docusaurus-preset/components';
+
+<DetailHero
+  appId="valtimo"
+  crumb={[{label: 'Sidecars', href: '/sidecars'}, 'Valtimo']}
+  status={{label: 'Sidecar', color: 'var(--c-cobalt-400)'}}
+  version="upstream"
+  locales="NL · EN"
+  title="Valtimo"
+  tagline={<>Een <span className="next-blue">Nextcloud</span>-sidecar rond Valtimo. Draai de open-source BPMN-workflow-engine binnen je workspace. Installeer uit de app store, geen apart cluster te beheren.</>}
+  primaryCta={{label: 'Installeer uit de app store', href: '/install'}}
+  secondaryCta={{label: 'Lees de docs', href: 'https://docs.conduction.nl/valtimo'}}
+  tertiaryCta={{label: 'Bekijk op GitHub', href: 'https://github.com/ConductionNL/valtimo'}}
+  iconColor="var(--c-blue-cobalt)"
+  icon={<svg viewBox="0 0 24 24"><circle cx="6" cy="6" r="3"/><circle cx="18" cy="18" r="3"/><path d="M6 9v6a3 3 0 0 0 3 3h6"/></svg>}
+/>
+
+<Section spacing="default">
+  <SectionHead
+    eyebrow="Wat het is"
+    title="Valtimo als Nextcloud-app."
+    align="stack"
+    lede="Valtimo is een open-source BPMN-workflow-platform. We verpakken het als Nextcloud-installeerbare sidecar. Je installeert de app, de upstream-container draait naast Nextcloud, en Valtimo-processen zijn bereikbaar vanuit OpenConnector en Procest. Dezelfde upstream, minder DevOps."
+  />
+</Section>
+
+<Section spacing="default" background="tinted">
+  <SectionHead
+    eyebrow="Waarom een sidecar"
+    title="Een sidecar is geen fork."
+    align="stack"
+    lede="We forken Valtimo niet. De sidecar volgt de upstream-releases. De wrapper regelt install, lifecycle en het koppelvlak naar Nextcloud. Je processtatus blijft in de upstream-service. Conduction is verantwoordelijk voor de integratie, niet voor upstream Valtimo."
+  />
+</Section>
+
+<CtaBanner
+  title="Draai Valtimo binnen je Nextcloud."
+  lede={<>Installeer uit de Nextcloud-app-store. Trigger workflows vanuit Procest. Laat taken zien in MyDash. Route input via OpenConnector.</>}
+  primaryCta={{label: 'Installeer uit de app store', href: '/install'}}
+  secondaryCta={{label: 'Praat met een partner', href: '/partners'}}
+/>


### PR DESCRIPTION
Part of ConductionNL/.github#75 SEO epic, addresses ConductionNL/.github#77. Completes NL coverage for sidecars (openklant, opentalk, openzaak, valtimo). Sister PR covers the landing + first 4.