### PR TITLE
feat(i18n): NL translations for sidecars (batch 1 of 2) (#77)

### DIFF
--- a/i18n/nl/docusaurus-plugin-content-pages/sidecars.mdx
+++ b/i18n/nl/docusaurus-plugin-content-pages/sidecars.mdx
@@ -1,0 +1,80 @@
+---
+title: Sidecars
+description: Nextcloud-installeerbare wrappers rond bewezen open-source services. Dezelfde upstream, minder DevOps.
+hide_table_of_contents: true
+---
+
+import React, {useState, useMemo} from 'react';
+import {Section, SectionHead, FacetedFilters, AppCard} from '@conduction/docusaurus-preset/components';
+import {getSidecars, SIDECAR_CATEGORIES} from '@site/src/data/sidecars-catalog';
+
+export const sidecars = getSidecars();
+
+export const STATUS_LABELS = {STABLE: 'Stable', BETA: 'Beta', 'COMING SOON': 'Binnenkort'};
+
+export function FilterableSidecars() {
+  const [selected, setSelected] = useState({});
+
+  const facets = useMemo(() => {
+    const cats = SIDECAR_CATEGORIES.filter(c => c !== 'All');
+    return [
+      {key: 'category', label: 'Categorie', items: cats.map(c => ({
+        value: c, label: c,
+        count: sidecars.filter(a => Array.isArray(a.categories) && a.categories.includes(c)).length,
+      })).filter(item => item.count > 0)},
+      {key: 'status', label: 'Status', items: ['STABLE', 'BETA', 'COMING SOON'].map(s => ({
+        value: s, label: STATUS_LABELS[s],
+        count: sidecars.filter(a => a.status === s).length,
+      })).filter(item => item.count > 0)},
+    ];
+  }, []);
+
+  const filtered = useMemo(() => {
+    return sidecars.filter(a => {
+      for (const [key, values] of Object.entries(selected)) {
+        if (!values || values.length === 0) continue;
+        if (key === 'category') {
+          const cats = a.categories || [];
+          if (!values.some(v => cats.includes(v))) return false;
+        } else if (key === 'status') {
+          if (!values.includes(a.status)) return false;
+        }
+      }
+      return true;
+    });
+  }, [selected]);
+
+  const totalSelected = Object.values(selected).reduce(
+    (n, v) => n + (Array.isArray(v) ? v.length : 0), 0
+  );
+
+  return (
+    <div style={{display: 'grid', gridTemplateColumns: '240px 1fr', gap: 56, alignItems: 'start'}}>
+      <FacetedFilters facets={facets} selected={selected} onChange={setSelected} />
+      <div>
+        <div style={{display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 24, paddingBottom: 16, borderBottom: '1px solid var(--c-cobalt-100)', fontSize: 14, color: 'var(--c-cobalt-700)'}}>
+          <div>
+            <strong style={{color: 'var(--c-cobalt-900)'}}>{filtered.length}</strong> van {sidecars.length} sidecars
+            {totalSelected > 0 && <span style={{color: 'var(--c-cobalt-400)'}}> · {sidecars.length - filtered.length} verborgen door filters</span>}
+          </div>
+        </div>
+        <div style={{display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))', gap: 24}}>
+          {filtered.map((app, i) => <AppCard key={i} app={app} />)}
+        </div>
+        {filtered.length === 0 && (
+          <p style={{textAlign: 'center', color: 'var(--c-cobalt-500)', padding: 'var(--space-8) 0'}}>Geen sidecars passen bij dit filter.</p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+<Section spacing="default">
+  <SectionHead
+    eyebrow="Sidecars"
+    title={<>Externe services, geïnstalleerd als een app.</>}
+    lede={<>Sidecars zijn <span className="next-blue">Nextcloud</span>-installeerbare wrappers rond bewezen open-source services. n8n, Keycloak, OpenZaak, Ollama en meer, verpakt zodat je ze uit de app store installeert in plaats van een apart cluster te draaien. We forken de upstream niet. De sidecar volgt de releases en regelt het koppelvlak met Nextcloud.</>}
+  />
+
+  <FilterableSidecars />
+</Section>

--- a/i18n/nl/docusaurus-plugin-content-pages/sidecars/keycloak.mdx
+++ b/i18n/nl/docusaurus-plugin-content-pages/sidecars/keycloak.mdx
@@ -1,0 +1,47 @@
+---
+title: Keycloak-sidecar, Conduction
+description: Nextcloud-sidecar rond Keycloak voor self-hosted identity en SSO.
+hide_table_of_contents: true
+---
+
+import {DetailHero, Section, SectionHead, CtaBanner} from '@conduction/docusaurus-preset/components';
+
+<DetailHero
+  appId="keycloak"
+  crumb={[{label: 'Sidecars', href: '/sidecars'}, 'Keycloak']}
+  status={{label: 'Sidecar', color: 'var(--c-cobalt-400)'}}
+  version="upstream"
+  locales="NL · EN"
+  title="Keycloak"
+  tagline={<>Een <span className="next-blue">Nextcloud</span>-sidecar rond Keycloak. Draai de open-source identity broker in je workspace, geïnstalleerd uit de app store, met SSO over al je apps vanaf dag één.</>}
+  primaryCta={{label: 'Installeer uit de app store', href: '/install'}}
+  secondaryCta={{label: 'Lees de docs', href: 'https://docs.conduction.nl/keycloak'}}
+  tertiaryCta={{label: 'Bekijk op GitHub', href: 'https://github.com/ConductionNL/keycloak-nextcloud'}}
+  iconColor="var(--c-blue-cobalt)"
+  icon={<svg viewBox="0 0 24 24"><circle cx="9" cy="12" r="4"/><path d="M13 12h8M17 12v4M21 12v3"/></svg>}
+/>
+
+<Section spacing="default">
+  <SectionHead
+    eyebrow="Wat het is"
+    title="Keycloak als Nextcloud-app."
+    align="stack"
+    lede="Keycloak is het open-source identity-and-access-platform van Red Hat. Wij verpakken het als Nextcloud-installeerbare sidecar. Je installeert de app, de upstream-container draait naast Nextcloud, en de SAML-, OIDC- en OAuth-flows zijn bereikbaar vanuit elke andere app in de workspace. Dezelfde upstream, minder DevOps."
+  />
+</Section>
+
+<Section spacing="default" background="tinted">
+  <SectionHead
+    eyebrow="Waarom een sidecar"
+    title="Een sidecar is geen fork."
+    align="stack"
+    lede="We forken Keycloak niet. De sidecar volgt de upstream-releases. De wrapper regelt install, lifecycle en het SSO-koppelvlak met Nextcloud. Je identity-records blijven in de upstream-service staan. Conduction is verantwoordelijk voor de integratie, niet voor upstream Keycloak."
+  />
+</Section>
+
+<CtaBanner
+  title="Draai Keycloak in je eigen Nextcloud."
+  lede={<>Installeer uit de Nextcloud-app-store. Configureer SSO voor elke Conduction-app en elke externe sidecar op één plek.</>}
+  primaryCta={{label: 'Installeer uit de app store', href: '/install'}}
+  secondaryCta={{label: 'Praat met een partner', href: '/partners'}}
+/>

--- a/i18n/nl/docusaurus-plugin-content-pages/sidecars/n8n.mdx
+++ b/i18n/nl/docusaurus-plugin-content-pages/sidecars/n8n.mdx
@@ -1,0 +1,47 @@
+---
+title: n8n-sidecar, Conduction
+description: Nextcloud-sidecar rond n8n voor workflow-automatisering.
+hide_table_of_contents: true
+---
+
+import {DetailHero, Section, SectionHead, CtaBanner} from '@conduction/docusaurus-preset/components';
+
+<DetailHero
+  appId="n8n"
+  crumb={[{label: 'Sidecars', href: '/sidecars'}, 'n8n']}
+  status={{label: 'Sidecar', color: 'var(--c-cobalt-400)'}}
+  version="upstream"
+  locales="NL · EN"
+  title="n8n"
+  tagline={<>Een <span className="next-blue">Nextcloud</span>-sidecar rond n8n. Draai de populaire visuele workflow-automatiserings-engine in je workspace, geïnstalleerd uit de Nextcloud-app-store, zonder aparte hosting.</>}
+  primaryCta={{label: 'Installeer uit de app store', href: '/install'}}
+  secondaryCta={{label: 'Lees de docs', href: 'https://docs.conduction.nl/n8n'}}
+  tertiaryCta={{label: 'Bekijk op GitHub', href: 'https://github.com/ConductionNL/n8n-nextcloud'}}
+  iconColor="var(--c-blue-cobalt)"
+  icon={<svg viewBox="0 0 24 24"><circle cx="5" cy="12" r="2"/><circle cx="12" cy="5" r="2"/><circle cx="12" cy="19" r="2"/><circle cx="19" cy="12" r="2"/><path d="M7 12h3M14 12h3M12 7v3M12 14v3"/></svg>}
+/>
+
+<Section spacing="default">
+  <SectionHead
+    eyebrow="Wat het is"
+    title="n8n als Nextcloud-app."
+    align="stack"
+    lede="n8n is een visuele tool voor workflow-automatisering met honderden kant-en-klare integraties. Wij verpakken het als Nextcloud-installeerbare sidecar. Je installeert de app, de upstream-container draait naast Nextcloud, en workflows praten direct met je registers en connectoren. Dezelfde upstream, minder DevOps."
+  />
+</Section>
+
+<Section spacing="default" background="tinted">
+  <SectionHead
+    eyebrow="Waarom een sidecar"
+    title="Een sidecar is geen fork."
+    align="stack"
+    lede="We forken n8n niet. De sidecar volgt de upstream-releases. De wrapper regelt install, lifecycle en het koppelvlak met Nextcloud. Je workflows blijven in de upstream-service staan. Conduction is verantwoordelijk voor de integratie, niet voor upstream n8n."
+  />
+</Section>
+
+<CtaBanner
+  title="Draai n8n in je eigen Nextcloud."
+  lede={<>Installeer uit de Nextcloud-app-store. Verbind met OpenRegister-rijen. Trigger workflows vanuit OpenConnector-events. Toon resultaten in MyDash.</>}
+  primaryCta={{label: 'Installeer uit de app store', href: '/install'}}
+  secondaryCta={{label: 'Praat met een partner', href: '/partners'}}
+/>

--- a/i18n/nl/docusaurus-plugin-content-pages/sidecars/ollama.mdx
+++ b/i18n/nl/docusaurus-plugin-content-pages/sidecars/ollama.mdx
@@ -1,0 +1,47 @@
+---
+title: Ollama-sidecar, Conduction
+description: Nextcloud-sidecar rond Ollama voor lokale LLM-inferentie.
+hide_table_of_contents: true
+---
+
+import {DetailHero, Section, SectionHead, CtaBanner} from '@conduction/docusaurus-preset/components';
+
+<DetailHero
+  appId="ollama"
+  crumb={[{label: 'Sidecars', href: '/sidecars'}, 'Ollama']}
+  status={{label: 'Sidecar', color: 'var(--c-cobalt-400)'}}
+  version="upstream"
+  locales="NL · EN"
+  title="Ollama"
+  tagline={<>Een <span className="next-blue">Nextcloud</span>-sidecar rond Ollama. Draai lokale large-language models in je workspace, installeer uit de app store, houd je prompts op je eigen hardware.</>}
+  primaryCta={{label: 'Installeer uit de app store', href: '/install'}}
+  secondaryCta={{label: 'Lees de docs', href: 'https://docs.conduction.nl/ollama'}}
+  tertiaryCta={{label: 'Bekijk op GitHub', href: 'https://github.com/ConductionNL/ollama-nextcloud'}}
+  iconColor="var(--c-blue-cobalt)"
+  icon={<svg viewBox="0 0 24 24"><path d="M12 3l9 5v8l-9 5-9-5V8z"/><circle cx="12" cy="12" r="2"/></svg>}
+/>
+
+<Section spacing="default">
+  <SectionHead
+    eyebrow="Wat het is"
+    title="Ollama als Nextcloud-app."
+    align="stack"
+    lede="Ollama draait open-weight LLM's lokaal met een schone HTTP-API. Wij verpakken het als Nextcloud-installeerbare sidecar. Je installeert de app, de upstream-container draait naast Nextcloud, en elke app in de workspace kan het inference-endpoint aanroepen. Dezelfde upstream, minder DevOps. Data verlaat de instance nooit."
+  />
+</Section>
+
+<Section spacing="default" background="tinted">
+  <SectionHead
+    eyebrow="Waarom een sidecar"
+    title="Een sidecar is geen fork."
+    align="stack"
+    lede="We forken Ollama niet. De sidecar volgt de upstream-releases. De wrapper regelt install, lifecycle en het koppelvlak met Nextcloud. Modellen blijven op de instance staan. Conduction is verantwoordelijk voor de integratie, niet voor upstream Ollama."
+  />
+</Section>
+
+<CtaBanner
+  title="Draai Ollama in je eigen Nextcloud."
+  lede={<>Installeer uit de Nextcloud-app-store. Koppel lokale modellen aan AI Companion. Drijf samenvattingsflows vanuit OpenConnector. Houd elke prompt op je eigen hardware.</>}
+  primaryCta={{label: 'Installeer uit de app store', href: '/install'}}
+  secondaryCta={{label: 'Praat met een partner', href: '/partners'}}
+/>

--- a/i18n/nl/docusaurus-plugin-content-pages/sidecars/open-webui.mdx
+++ b/i18n/nl/docusaurus-plugin-content-pages/sidecars/open-webui.mdx
@@ -1,0 +1,47 @@
+---
+title: Open WebUI-sidecar, Conduction
+description: Nextcloud-sidecar rond Open WebUI voor een chat-interface op lokale LLM's.
+hide_table_of_contents: true
+---
+
+import {DetailHero, Section, SectionHead, CtaBanner} from '@conduction/docusaurus-preset/components';
+
+<DetailHero
+  appId="open-webui"
+  crumb={[{label: 'Sidecars', href: '/sidecars'}, 'Open WebUI']}
+  status={{label: 'Sidecar', color: 'var(--c-cobalt-400)'}}
+  version="upstream"
+  locales="NL · EN"
+  title="Open WebUI"
+  tagline={<>Een <span className="next-blue">Nextcloud</span>-sidecar rond Open WebUI. Een ChatGPT-achtige interface voor je lokale LLM's, geïnstalleerd uit de app store, alles op je eigen hardware.</>}
+  primaryCta={{label: 'Installeer uit de app store', href: '/install'}}
+  secondaryCta={{label: 'Lees de docs', href: 'https://docs.conduction.nl/open-webui'}}
+  tertiaryCta={{label: 'Bekijk op GitHub', href: 'https://github.com/ConductionNL/open-webui-nextcloud'}}
+  iconColor="var(--c-blue-cobalt)"
+  icon={<svg viewBox="0 0 24 24"><rect x="3" y="4" width="18" height="14" rx="2"/><path d="M7 9h2M7 13h6"/></svg>}
+/>
+
+<Section spacing="default">
+  <SectionHead
+    eyebrow="Wat het is"
+    title="Open WebUI als Nextcloud-app."
+    align="stack"
+    lede="Open WebUI is een verzorgde chat-frontend voor lokale LLM-runtimes. Wij verpakken het als Nextcloud-installeerbare sidecar. Je installeert de app, de upstream-container draait naast Nextcloud, en gebruikers krijgen een vertrouwde chat-ervaring gekoppeld aan je eigen modellen. Dezelfde upstream, minder DevOps. Gesprekken verlaten de instance nooit."
+  />
+</Section>
+
+<Section spacing="default" background="tinted">
+  <SectionHead
+    eyebrow="Waarom een sidecar"
+    title="Een sidecar is geen fork."
+    align="stack"
+    lede="We forken Open WebUI niet. De sidecar volgt de upstream-releases. De wrapper regelt install, lifecycle en het koppelvlak met Nextcloud. Gesprekken en uploads blijven op de instance staan. Conduction is verantwoordelijk voor de integratie, niet voor upstream Open WebUI."
+  />
+</Section>
+
+<CtaBanner
+  title="Draai Open WebUI in je eigen Nextcloud."
+  lede={<>Installeer uit de Nextcloud-app-store. Combineer met de Ollama-sidecar voor het model. SSO komt van de Keycloak-sidecar. Eén workspace, geen cloud-round-trip.</>}
+  primaryCta={{label: 'Installeer uit de app store', href: '/install'}}
+  secondaryCta={{label: 'Praat met een partner', href: '/partners'}}
+/>


### PR DESCRIPTION
Part of ConductionNL/.github#75 SEO epic, addresses ConductionNL/.github#77. Adds NL counterparts for sidecars landing + 4 children (keycloak, n8n, ollama, open-webui). Sister PR covers the remaining 4 sidecars (openklant, opentalk, openzaak, valtimo).