### PR TITLE
feat(i18n): NL translations for 6 short academy posts (#77)

### DIFF
--- a/i18n/nl/docusaurus-plugin-content-blog/2026-04-20-build-an-app/index.mdx
+++ b/i18n/nl/docusaurus-plugin-content-blog/2026-04-20-build-an-app/index.mdx
@@ -1,0 +1,32 @@
+---
+slug: build-an-app
+title: Bouw je eerste Conduction-app, van begin tot eind
+contentType: tutorial
+authors: [conduction]
+date: 2026-04-20
+summary: Van een lege Nextcloud naar een gepubliceerde app in de store. Schema's, registers en een OpenConnector-flow.
+tags: [App-ontwikkeling, Schema's, OpenRegister, OpenConnector]
+apps: [openregister, openconnector]
+durationMinutes: 30
+---
+
+Een tutorial van 30 minuten die je van een verse Nextcloud-installatie naar een gepubliceerde app brengt. Placeholder terwijl we de volledige versie schrijven.
+
+{/* truncate */}
+
+## Wat je bouwt
+
+Een kleine "incidentmelder"-app: één register, twee schema's, een publiek formulier dat naar OpenRegister post via OpenConnector, en een privé-inbox in Nextcloud.
+
+## Stappen
+
+1. **Installeer OpenRegister en OpenConnector** uit de Nextcloud-app-store
+2. **Maak het register aan** met twee schema's (`incident`, `responder`)
+3. **Koppel het publieke formulier** als OpenConnector-bron
+4. **Map de formuliervelden** op het `incident`-schema
+5. **Bouw een klein Vue-paneel** in de app-map om incidenten te tonen
+6. **Publiceer** naar je eigen app store of naar apps.conduction.nl
+
+## Wanneer je klaar bent
+
+Je hebt een installeerbare Nextcloud-app, een gepubliceerde API en een werkend formulier. Totale tijd: ongeveer een half uur als Nextcloud al draait.

--- a/i18n/nl/docusaurus-plugin-content-blog/2026-04-23-semantic-conventions/index.mdx
+++ b/i18n/nl/docusaurus-plugin-content-blog/2026-04-23-semantic-conventions/index.mdx
@@ -1,0 +1,32 @@
+---
+slug: semantic-conventions
+title: OpenTelemetry semconv-migraties beheren met de collector
+contentType: webinar
+authors: [conduction]
+date: 2026-04-23
+summary: Een walk-through van 45 minuten met live Q&A over het uitrollen van semconv 1.27 over een vloot services.
+tags: [OpenTelemetry, Instrumentation]
+durationMinutes: 45
+videoUrl: https://example.com/webinars/semconv-1.27
+---
+
+Opname en Q&A van het webinar. Placeholder terwijl de video wordt geüpload en het transcript wordt voorbereid.
+
+{/* truncate */}
+
+## Wat we behandelden
+
+- Waarom semconv 1.27 ertoe doet en wat er is veranderd
+- Drie migratiestrategieën (in-process, collector-side, hybride)
+- Live demo: een collector-side rename uitrollen over een vloot van 30 services
+- Q&A van het publiek over randgevallen (niet-OTel libraries, vendor drift, legacy velden)
+
+## Sprekers
+
+Conductions observability-lead en een gast van een Nederlandse gemeente die de migratie recent voltooide op productieverkeer.
+
+## Bronnen
+
+- Slidedeck (gelinkt zodra de opname online staat)
+- Collector-config snippets uit de demo
+- De post-migratie-retrospective van de klant

--- a/i18n/nl/docusaurus-plugin-content-blog/2026-04-27-parhelion/index.mdx
+++ b/i18n/nl/docusaurus-plugin-content-blog/2026-04-27-parhelion/index.mdx
@@ -1,0 +1,30 @@
+---
+slug: parhelion
+title: Vier SaaS-abonnementen vervangen door vijf Conduction-apps
+contentType: case-study
+authors: [conduction]
+date: 2026-04-27
+summary: Hoe een Friese gemeente in elf weken van vier gehoste diensten naar één Nextcloud-workspace ging.
+tags: [MKB, Migratie, OpenCatalogi, MyDash]
+apps: [opencatalogi, mydash]
+durationMinutes: 6
+---
+
+Een korte samenvatting van de migratie. Placeholder terwijl we de volledige versie schrijven met toestemming van de klant.
+
+{/* truncate */}
+
+## Het startpunt
+
+Vier SaaS-abonnementen, drie leverancierscontracten en een vierde op komst. De IT-lead schatte dat 9 procent van het operationeel budget naar per-seat licenties ging op tools die niet met elkaar praatten.
+
+## Wat we deden
+
+Nextcloud opgezet op de bestaande on-prem hardware en OpenRegister, OpenCatalogi, OpenConnector, DocuDesk en MyDash uit de app store geïnstalleerd. De data gemigreerd met twee OpenConnector-flows. Het team getraind in twee halve-dag-sessies.
+
+## De cijfers
+
+- Elf weken van kickoff tot cutover
+- Vijf apps ter vervanging van vier SaaS-abonnementen
+- Eén leverancierscontract in plaats van drie
+- Jaarlijkse besparing: ruwweg twee FTE-maanden aan beheertijd, plus het licentieverschil

--- a/i18n/nl/docusaurus-plugin-content-blog/2026-04-29-mcp-server/index.mdx
+++ b/i18n/nl/docusaurus-plugin-content-blog/2026-04-29-mcp-server/index.mdx
@@ -1,0 +1,36 @@
+---
+slug: mcp-server
+title: De Conduction MCP-server opzetten
+contentType: guide
+authors: [conduction]
+date: 2026-04-29
+summary: Richt Claude of een andere MCP-aware client op OpenRegister en schrijf je eerste MCP-gedreven query.
+tags: [AI & LLMs, MCP, OpenRegister]
+apps: [openregister]
+durationMinutes: 8
+---
+
+Een korte walk-through van de Model Context Protocol-server die we voor OpenRegister meeleveren. Placeholder terwijl we de volledige versie schrijven.
+
+{/* truncate */}
+
+## Voor je begint
+
+Je hebt nodig:
+
+- Een draaiende OpenRegister met minimaal één register en schema
+- Claude Code, Claude Desktop, of een andere MCP-aware client
+- De MCP-server draaiend op `http://localhost:8080/index.php/apps/openregister/mcp`
+
+## De client koppelen
+
+Voeg het OpenRegister MCP-endpoint toe aan de config van je client. De server biedt:
+
+- `register.list`, `register.get`
+- `schema.list`, `schema.get`
+- `object.search`, `object.get`, `object.create`
+- `audit.read` voor read-only toegang tot het audit trail
+
+## Wat je kunt vragen
+
+Eenmaal gekoppeld kan de assistent vragen beantwoorden als "laat me alle WOO-documenten uit 2024 zien met categorie-2-redacties" zonder dat je de query met de hand schrijft.

--- a/i18n/nl/docusaurus-plugin-content-blog/2026-05-03-welcome/index.mdx
+++ b/i18n/nl/docusaurus-plugin-content-blog/2026-05-03-welcome/index.mdx
@@ -1,0 +1,26 @@
+---
+slug: welcome
+title: Conduction is online
+contentType: blog
+authors: [conduction]
+date: 2026-05-03
+summary: Eerste post op de nieuwe Conduction-site. Het brand book verhuist hierheen zodra de OpenCatalogi content-plugin landt.
+tags: [Conduction, design-system, Docusaurus]
+apps: [opencatalogi]
+---
+
+Dit is de eerste post op de nieuwe Conduction-site. We zijn in actieve ontwikkeling; het brand book op [connext.conduction.nl/identity](https://connext.conduction.nl/identity/) verhuist hierheen zodra de OpenCatalogi content-plugin landt.
+
+{/* truncate */}
+
+## Wat er op de site staat
+
+- **Productpropositie:** wat Conduction is, voor wie het is, hoe de apps op Nextcloud passen
+- **Per-app docs:** aparte subdomeinen onder `*.conduction.nl`, allemaal gebouwd op dezelfde `@conduction/docusaurus-preset`
+- **Diagrammen-set:** de zeven `<cn-*>` web components live gerenderd, met API-tabellen en walk-throughs
+
+## Wat er nu komt
+
+- `@conduction/docusaurus-plugin-opencatalogi` koppelen zodat editors content bijwerken vanuit de Nextcloud-kant van OpenCatalogi
+- De homepage en docs vertalen naar EN, DE, FR (NL is canoniek)
+- `apps.conduction.nl` en `commonground.nu` opzetten op dezelfde preset

--- a/i18n/nl/docusaurus-plugin-content-blog/2026-05-04-tame-log-noise/index.mdx
+++ b/i18n/nl/docusaurus-plugin-content-blog/2026-05-04-tame-log-noise/index.mdx
@@ -1,0 +1,24 @@
+---
+slug: tame-log-noise
+title: Log-ruis temmen met de drain-processor van OpenTelemetry
+contentType: blog
+authors: [conduction]
+date: 2026-05-04
+summary: Hoe één processor ons trace-volume op de OpenRegister-API met 40 procent verlaagde.
+tags: [OpenTelemetry, Instrumentation]
+apps: [openregister]
+---
+
+Een korte notitie over één OpenTelemetry-collector-processor die voor ons onevenredig veel effect had. Deze post is een placeholder terwijl we de volledige versie schrijven.
+
+{/* truncate */}
+
+## Wat er veranderde
+
+We voegden de `drain`-processor toe aan de collector-pipeline van de OpenRegister-API. Hij clustert bijna-identieke logregels en zendt één getemplate trace uit in plaats van N bijna-duplicaten. Het trace-volume daalde 40 procent, de alert-ruis daalde nog verder, en de dashboards beantwoordden nog steeds elke vraag die we ze stelden.
+
+## Wat er nu komt
+
+- Uitrollen naar OpenConnector en DocuDesk
+- De template-regels documenteren zodat app-auteurs zichzelf kunnen bedienen
+- Een beveiliging tegen over-clustering op zeldzame error-paden toevoegen


### PR DESCRIPTION
Part of ConductionNL/.github#75 SEO epic, addresses ConductionNL/.github#77.

Adds NL counterparts for 6 EN-native academy posts so /nl/academy/<slug>/ stops serving EN fallback with duplicate canonicals:

- 2026-04-20-build-an-app
- 2026-04-23-semantic-conventions
- 2026-04-27-parhelion
- 2026-04-29-mcp-server
- 2026-05-03-welcome
- 2026-05-04-tame-log-noise

Tone: je/jij/we, active voice, sentence-case headings, no em-dashes, no banned phrases. Code blocks, file paths, brand names, and technical acronyms preserved verbatim.