### PR TITLE
feat(i18n): NL translations for deskdesk tutorials 2 + 4 (#77)

### DIFF
--- a/i18n/nl/docusaurus-plugin-content-blog/2026-05-13-deskdesk-tutorial-2-schemas-manifest/index.mdx
+++ b/i18n/nl/docusaurus-plugin-content-blog/2026-05-13-deskdesk-tutorial-2-schemas-manifest/index.mdx
@@ -1,0 +1,303 @@
+---
+slug: deskdesk-tutorial-2-schemas-manifest
+title: "Bouw een Nextcloud-app op de Conduction-stack — Deel 2: Schema's + manifest"
+contentType: tutorial
+authors: [conduction]
+date: 2026-05-13
+summary: Definieer de desk-, booking- en floor-schema's in OpenRegister, declareer ze in een manifest.json, en zie hoe CnAppRoot ongeveer 200 regels handgeschreven Vue vervangt door drie regels config.
+tags: [App development, OpenRegister, Schemas, Manifest, nextcloud-vue]
+apps: [openregister]
+durationMinutes: 25
+series: deskdesk-tutorial
+partNumber: 2
+---
+
+import {
+  Outcomes,
+  Outcome,
+  Prerequisites,
+  PrerequisiteItem,
+  NextSteps,
+  NextStep,
+  HexCard,
+} from '@conduction/docusaurus-preset/components';
+
+Dit is **Deel 2 van de vierdelige DeskDesk-tutorial**. Deel 1 liet je achter met een leeg app-skelet: een chassis zonder data. Deel 2 vult dat chassis: drie schema's, een manifest, en dezelfde vijf Cn*-pagina's sturen elke lijst, elke detailweergave en elk dashboard met het schema als enige bron van waarheid.
+
+De vorm waar we steeds van zeggen "dit scheelt je code" krijgt eindelijk getallen: ongeveer 200 regels handgeschreven Vue krimpen tot drie.
+
+{/* truncate */}
+
+<Outcomes title="Wat je hebt aan het eind van Deel 2">
+  <Outcome>Drie OpenRegister-schema's — <code>floor</code>, <code>desk</code>, <code>booking</code> — geïnstalleerd en bij de eerste boot gevuld met realistische demo-data.</Outcome>
+  <Outcome>Een <code>src/manifest.json</code> die de navigatie, de routes en de configuratie voor elke pagina declareert. CnAppRoot leest hem; CnPageRenderer dispatcht.</Outcome>
+  <Outcome>Een <code>App.vue</code> van ongeveer 10 regels en een <code>router/index.js</code> die routes genereert vanuit het manifest. <strong>navigation/MainMenu.vue is weg</strong>. Net als <code>views/Dashboard.vue</code>, <code>views/items/*</code> en de user-settings-shells. De manifest-renderer vervangt ze.</Outcome>
+  <Outcome>Index-pagina's, detail-pagina's en CRUD-dialogen die het schema genereert: sorteerbaar, filterbaar, doorzoekbaar, zonder dat je een kolomdefinitie schrijft.</Outcome>
+</Outcomes>
+
+<Prerequisites title="Waar je moet staan">
+  <PrerequisiteItem>Deel 1 af: DeskDesk geïnstalleerd, het chassis rendert op <code>http://localhost:8080/apps/deskdesk/</code>.</PrerequisiteItem>
+  <PrerequisiteItem>OpenRegister geïnstalleerd, ingeschakeld, op versie 0.2.10 of nieuwer (de <code>importFromFilePath</code>-methode in ConfigurationService is verplicht).</PrerequisiteItem>
+  <PrerequisiteItem>Een lokale clone van <a href="https://github.com/ConductionNL/deskdesk">ConductionNL/deskdesk</a> op je schijf en een werkende <code>npm run build</code>.</PrerequisiteItem>
+</Prerequisites>
+
+## Stap 1: Definieer de drie schema's
+
+Open `lib/Settings/deskdesk_register.json` en vervang het placeholder `article`-schema door de echte drie. Elk schema is een JSON Schema met een paar OpenRegister-extensies: `slug` voor de URL-identifier, `icon` voor de MDI-glyph die de UI gebruikt, en `x-openregister-relations` voor getypeerde kruisverwijzingen tussen schema's.
+
+```json title="lib/Settings/deskdesk_register.json (excerpt)"
+"floor": {
+  "slug": "floor",
+  "title": "Floor",
+  "description": "A physical floor in a building.",
+  "type": "object",
+  "required": ["label"],
+  "properties": {
+    "label":     { "type": "string", "example": "Floor 3" },
+    "building":  { "type": "string", "example": "Amsterdam HQ" },
+    "planImage": { "type": "string", "format": "uri" }
+  }
+}
+```
+
+Het `desk`-schema voegt de getypeerde relatie naar floor toe:
+
+```json title="lib/Settings/deskdesk_register.json (excerpt)"
+"desk": {
+  "slug": "desk",
+  "title": "Desk",
+  "type": "object",
+  "required": ["label", "floor", "zone"],
+  "properties": {
+    "label": { "type": "string", "example": "3-East-12" },
+    "floor": {
+      "type": "string",
+      "x-openregister-relations": {
+        "schema": "floor",
+        "cardinality": "many-to-one"
+      }
+    },
+    "zone": {
+      "type": "string",
+      "enum": ["north", "south", "east", "west", "central"]
+    },
+    "equipment": {
+      "type": "array",
+      "items": { "type": "string", "enum": ["dual-monitor", "standing", "phonebooth-adjacent", "wired-network", "extra-power"] }
+    },
+    "capacity":      { "type": "integer", "minimum": 1, "default": 1 },
+    "accessibility": { "type": "boolean", "default": false },
+    "photo":         { "type": "string", "format": "uri" },
+    "notes":         { "type": "string" }
+  }
+}
+```
+
+Booking heeft dezelfde vorm: een relatie, een paar datetimes, een enum-status en een optionele RRULE voor terugkerende boekingen.
+
+Het volledige bestand staat in [de deskdesk repo](https://github.com/ConductionNL/deskdesk/blob/main/lib/Settings/deskdesk_register.json), met vijf seed-desks, twee floors en drie bookings. Zo is de app meteen te doorbladeren na de eerste install.
+
+## Stap 2: Declareer het register zelf
+
+OpenRegister's importhandler maakt schema's gretig aan, maar maakt alleen een **register** als de JSON er expliciet één declareert. Voeg een `components.registers`-blok toe boven je schema's:
+
+```json title="lib/Settings/deskdesk_register.json"
+"components": {
+  "registers": {
+    "deskdesk": {
+      "slug": "deskdesk",
+      "title": "DeskDesk",
+      "description": "Floors, desks, and bookings for the DeskDesk app.",
+      "version": "0.2.0",
+      "schemas": ["floor", "desk", "booking"]
+    }
+  },
+  "schemas": { /* ... */ },
+  "objects": { /* ... */ }
+}
+```
+
+De `schemas`-array vertelt OpenRegister welke schema's uit hetzelfde bestand bij dit register horen. De `slug` wordt de stabiele identifier van het register.
+
+## Stap 3: Trigger de import
+
+Twee manieren. Of trigger het via de SettingsController (de app stelt `POST /api/settings/load` beschikbaar):
+
+```bash title="From your shell, via curl, with a logged-in cookie jar"
+curl -X POST -b cookies.txt \
+  -H "requesttoken: $REQUESTTOKEN" \
+  http://localhost:8080/index.php/apps/deskdesk/api/settings/load
+```
+
+Of, schoner tijdens lokale ontwikkeling, schakel de app uit en weer in. Dat vuurt de `<install>`-repair-stap uit `appinfo/info.xml`:
+
+```bash
+docker exec nextcloud php occ app:disable deskdesk
+docker exec nextcloud php occ app:enable deskdesk
+```
+
+Hoe dan ook, je ziet in de registerlijst van OpenRegister:
+
+```
+slug: deskdesk    title: DeskDesk    application: deskdesk    schemas: floor, desk, booking
+```
+
+Het pad dat de SettingsService neemt is **importFromFilePath** met een pad dat relatief aan `\OC::$SERVERROOT` wordt opgelost (dat is `/var/www/html` in een standaardinstall). De boot-time bug die ik raakte tijdens deze tutorial — `Configuration file not found: html/custom_apps/deskdesk/...` — was een relatief-pad-fout; de fix staat in [de diff](https://github.com/ConductionNL/deskdesk/pull/2/files#diff-lib-Service-SettingsService.php).
+
+## Stap 4: Het manifest
+
+`src/manifest.json` is de enige declaratieve beschrijving van de app-shell. Drie top-level keys: `dependencies`, `menu`, `pages`.
+
+```json title="src/manifest.json"
+{
+  "$schema": "https://raw.githubusercontent.com/ConductionNL/nextcloud-vue/main/src/schemas/app-manifest.schema.json",
+  "version": "1.0.0",
+  "id": "deskdesk",
+  "title": "DeskDesk",
+  "dependencies": ["openregister"],
+  "menu": [
+    {"id": "desks-index",    "label": "deskdesk.menu.desks",    "icon": "icon-category-organization", "route": "desks-index",    "order": 10},
+    {"id": "bookings-index", "label": "deskdesk.menu.bookings", "icon": "icon-calendar",              "route": "bookings-index", "order": 20},
+    {"id": "floors-index",   "label": "deskdesk.menu.floors",   "icon": "icon-category-monitoring",   "route": "floors-index",   "order": 30}
+  ],
+  "pages": [
+    {"id": "desks-index",  "route": "/",          "type": "index",  "title": "deskdesk.desks.indexTitle",
+     "config": {"register": "deskdesk", "schema": "desk", "columns": ["label","floor","zone","equipment","capacity","accessibility"], "filters": ["floor","zone","equipment","accessibility"], "defaultSort": {"key": "label", "order": "asc"}}},
+    {"id": "desks-detail", "route": "/desks/:id", "type": "detail", "title": "deskdesk.desks.detailTitle",
+     "config": {"register": "deskdesk", "schema": "desk"}}
+    /* bookings + floors pages follow the same pattern */
+  ]
+}
+```
+
+Een paar regels om te onthouden:
+
+- **`page.id` is de naam van de vue-router-route.** CnPageRenderer matcht `$route.name === page.id` om de juiste pagina te kiezen.
+- **`page.type` is gesloten.** `index | detail | dashboard | custom`. Gebruik `custom` met een `component`-registry-entry voor eenmalige pagina's.
+- **`page.config` gaat als props door.** `register`, `schema`, `columns`, `filters`, `defaultSort` mappen één-op-één op de props van CnIndexPage.
+
+## Stap 5: Vervang App.vue en de router
+
+Nu het bevredigende deel. Open `src/App.vue` (de 175-regelige shell uit Deel 1) en vervang hem hierdoor:
+
+```vue title="src/App.vue"
+<template>
+  <CnAppRoot :app-id="appId" :manifest="manifest" />
+</template>
+
+<script>
+import { CnAppRoot } from '@conduction/nextcloud-vue'
+import manifest from './manifest.json'
+
+export default {
+  name: 'App',
+  components: { CnAppRoot },
+  data: () => ({ appId: 'deskdesk', manifest }),
+}
+</script>
+```
+
+Dat is alles. De `<NcContent>`, de dependency-check empty-state, de loading-spinner, het menu, de sidebars, de user-settings-dialog: CnAppRoot levert ze allemaal en zet ze achter de `dependencies`-array uit het manifest.
+
+Dan wordt `src/router/index.js` een mapping van manifest naar routes:
+
+```js title="src/router/index.js"
+import Vue from 'vue'
+import Router from 'vue-router'
+import { generateUrl } from '@nextcloud/router'
+import { CnPageRenderer } from '@conduction/nextcloud-vue'
+import manifest from '../manifest.json'
+
+Vue.use(Router)
+
+const routes = manifest.pages.map((page) => ({
+  name: page.id,
+  path: page.route,
+  component: CnPageRenderer,
+}))
+
+routes.push({ path: '*', redirect: '/' })
+
+export default new Router({
+  mode: 'history',
+  base: generateUrl('/apps/deskdesk'),
+  routes,
+})
+```
+
+Elke pagina in het manifest krijgt een route. Elke route rendert CnPageRenderer. CnPageRenderer leest het manifest, vindt de matchende pagina-entry op routenaam, en dispatcht op `page.type`:
+
+- `type: "index"` → CnIndexPage met de kolommen en filters van het schema
+- `type: "detail"` → CnDetailPage met de properties van het schema
+- `type: "dashboard"` → CnDashboardPage met de layout
+- `type: "custom"` → je geregistreerde component
+
+## Stap 6: Verwijder de oude views
+
+Het hele punt van Deel 2 is dat het framework de views voor je schrijft. Verwijder:
+
+- `src/navigation/MainMenu.vue` — vervangen door CnAppNav (auto-mounted door CnAppRoot)
+- `src/views/Dashboard.vue` — placeholder; komt later terug in een rijkere vorm wanneer de dashboardpagina dat nodig heeft
+- `src/views/items/ItemList.vue`, `src/views/items/ItemDetail.vue` — vervangen door CnIndexPage + CnDetailPage
+- `src/views/settings/UserSettings.vue`, `src/views/settings/Settings.vue` — instellingen leven op de admin-pagina (`AdminRoot.vue`) en de in-app-dialog komt mee met CnAppRoot
+
+Het voor-en-na op schijf:
+
+```
+before: 12 .vue files in src/, ~600 lines of hand-rolled component code
+after:   3 .vue files (App.vue, AdminRoot.vue, that's it), ~30 lines
+```
+
+## Stap 7: Bouw, herlaad, blader
+
+```bash
+npm run build
+docker cp ./js nextcloud:/var/www/html/custom_apps/deskdesk/
+docker exec nextcloud apache2ctl graceful
+```
+
+Open `/apps/deskdesk/`. De linker rail leest nu **Desks · Bookings · Floors** (de vertaalkeys zien er nog uit als `deskdesk.menu.desks` totdat je `l10n/`-entries toevoegt; dat is een follow-up). De hoofdkolom toont CnIndexPage met de kolommen uit het schema. Klik een rij aan, je belandt op CnDetailPage voor die desk. De hele CRUD-flow krijg je cadeau.
+
+## Waarom dit belangrijk is
+
+Je schreef drie JSON-bestanden. Het framework leest ze en rendert de app. Er is geen `DesksList.vue`, geen `DeskForm.vue`, geen `useDesks.js`. Als je een `priority`-veld toevoegt aan het booking-schema, pikt elke plek waar een booking verschijnt — tabelkolom, detailrij, filter-sidebar, formulierdialoog — het nieuwe veld automatisch op.
+
+Dit is de schema-gedreven discipline waarover [nextcloud-vue.conduction.nl](https://nextcloud-vue.conduction.nl/docs/architecture/schemas-and-registers/) praat. Deel 3 zet het op een manier in die mensen de eerste keer verrast: één JSON-blok op het booking-schema laat elke booking in de Nextcloud-agenda van de gebruiker verschijnen. Geen controller, geen event, geen listener.
+
+## Troubleshooting
+
+<HexCard title="Configuration file not found: html/custom_apps/...">
+  Het relatieve pad dat ConfigurationService::importFromFilePath gebruikt wordt berekend tegen <code>/var/www/html</code> (de <code>SERVERROOT</code> van Nextcloud). Als je SettingsService het verkeerde prefix afsnijdt krijg je deze fout. Gebruik <code>\OC::$SERVERROOT</code> als anker bij het strippen.
+</HexCard>
+
+<HexCard title="Schemas importeren maar het register verschijnt niet">
+  Voeg een <code>components.registers.YOURAPP</code>-blok toe aan de JSON. Zonder dat maakt de importhandler de schema's als wezen aan. Het blok heeft <code>slug</code>, <code>title</code>, <code>version</code> en <code>schemas[]</code> nodig.
+</HexCard>
+
+<HexCard title="Index-pagina's renderen maar zeggen 'No items found'">
+  De store van CnIndexPage wil het numerieke register-id, terwijl <code>/api/settings</code> meestal de register-slug teruggeeft. Bouw een slug → id-resolutie in je settings-store, of geef het numerieke id rechtstreeks vanuit de SettingsService door. Staat als follow-up in de Deel 2-PR.
+</HexCard>
+
+<HexCard title="Vertaalkeys renderen letterlijk">
+  De keys (bijvoorbeeld <code>deskdesk.menu.desks</code>) hebben entries in <code>l10n/en.json</code> en <code>l10n/nl.json</code> nodig. De library rendert de key wanneer er geen vertaling is. Voeg ze toe wanneer je er klaar voor bent; de app werkt sowieso.
+</HexCard>
+
+## Wat is het volgende
+
+<NextSteps>
+  <NextStep
+    title="Deel 3 — Schema-gedreven integraties (NC Agenda)"
+    href="/academy/deskdesk-tutorial-3-calendar"
+    description="Eén calendarProvider-blok op het booking-schema. Bookings verschijnen in de Nextcloud-agenda van de gebruiker. Geen controller, geen listener, geen lijmcode."
+  />
+  <NextStep
+    title="Schemas and registers reference"
+    href="https://nextcloud-vue.conduction.nl/docs/architecture/schemas-and-registers/"
+    description="Het architectuurverhaal achter waarom schema's zowel de OpenRegister-backend als de @conduction/nextcloud-vue-frontend sturen."
+  />
+  <NextStep
+    title="App manifest reference"
+    href="https://nextcloud-vue.conduction.nl/docs/architecture/manifest/"
+    description="Volledige manifest-spec — pagina-types, slot-configuratie, custom components, sidebar-gating."
+  />
+</NextSteps>

--- a/i18n/nl/docusaurus-plugin-content-blog/2026-05-17-deskdesk-tutorial-4-knowledge-and-ship/index.mdx
+++ b/i18n/nl/docusaurus-plugin-content-blog/2026-05-17-deskdesk-tutorial-4-knowledge-and-ship/index.mdx
@@ -1,0 +1,443 @@
+---
+slug: deskdesk-tutorial-4-knowledge-and-ship
+title: "Bouw een Nextcloud-app op de Conduction-stack — Deel 4: Kennis + uitleveren"
+contentType: tutorial
+authors: [conduction]
+date: 2026-05-17
+summary: Zet xWiki lokaal op, schrijf zone-specifieke kennisartikelen, toon ze per desk via een knowledge_article-schema in OpenRegister, package de app en publiceer in de Conduction app store.
+tags: [App development, OpenConnector, xWiki, Knowledge management, Release]
+apps: [openconnector, openregister]
+durationMinutes: 35
+series: deskdesk-tutorial
+partNumber: 4
+---
+
+import {
+  Outcomes,
+  Outcome,
+  Prerequisites,
+  PrerequisiteItem,
+  NextSteps,
+  NextStep,
+  HexCard,
+} from '@conduction/docusaurus-preset/components';
+
+Het laatste deel van de vierdelige DeskDesk-tutorial. Deel 3 liet boekingen in de NC Agenda verschijnen met één schema-annotatie. Deel 4 haalt externe kennis — zone-specifieke etiquette, equipment-notities, troubleshooting — uit xWiki naar de detail-sidebar van een desk via een `knowledge_article`-schema in OpenRegister. Daarna packagen we de app en leveren we hem uit.
+
+Externe kennis integreren is dé canonieke case voor OpenConnector: data ophalen uit een systeem dat je niet bezit (xWiki hier, maar hetzelfde geldt voor Confluence, Notion, SharePoint, Decos, Mendix), en die binnen de Nextcloud-native UI tonen zonder dat de gebruiker hoeft te schakelen.
+
+{/* truncate */}
+
+<Outcomes title="Wat je hebt aan het eind van Deel 4">
+  <Outcome>Een draaiende xWiki-instantie op <code>http://localhost:8086</code>, op hetzelfde Docker-netwerk als Nextcloud, met dezelfde Postgres.</Outcome>
+  <Outcome>Drie xWiki-artikelen die je zelf schrijft, gegroepeerd per zone (<code>DeskDeskKnowledge.East.Etiquette</code>, <code>.Central.MeetingDesks</code>, <code>.West.QuietRules</code>).</Outcome>
+  <Outcome>Een nieuw <code>knowledge_article</code>-schema in OpenRegister binnen DeskDesk, met seed-data die overeenkomt met wat xWiki bevat.</Outcome>
+  <Outcome>Een "Kennis"-tab op de detailpagina van elke desk die de artikelen toont waarvan de <code>zone</code> matcht met de zone van de desk, zonder dat je DeskDesk verlaat.</Outcome>
+  <Outcome>Een gepackagede, geversioneerde DeskDesk-release in de Conduction app store, installeerbaar vanuit de app-browser van elke Nextcloud.</Outcome>
+</Outcomes>
+
+<Prerequisites title="Waar je moet staan">
+  <PrerequisiteItem>Delen 1 tot en met 3 af: DeskDesk-shell, schema's + manifest, agenda-integratie werken allemaal.</PrerequisiteItem>
+  <PrerequisiteItem>Een lokale Nextcloud + OpenRegister-stack waar je in kunt <code>docker exec</code>'en. De referentie-stack op <a href="/academy/nextcloud-lokaal-draaien">Nextcloud lokaal draaien met Docker</a> is wat we tegen testen; die levert al de xWiki-service die we in Stap 0 starten.</PrerequisiteItem>
+  <PrerequisiteItem><strong>OpenConnector</strong> geïnstalleerd en ingeschakeld, voor wanneer je later in de tutorial van seed-data naar een live xWiki-sync overschakelt.</PrerequisiteItem>
+</Prerequisites>
+
+## Stap 0: Start xWiki op
+
+De Conduction-dev-stack declareert al een xWiki-service onder het `xwiki`-profiel van `apps-extra/openregister/docker-compose.yml`:
+
+```yaml title="openregister/docker-compose.yml (excerpt)"
+  xwiki:
+    profiles: [xwiki, integrations]
+    image: xwiki:lts-postgres-tomcat
+    container_name: openregister-xwiki
+    ports: ["8086:8080"]
+    volumes: ["xwiki-data:/usr/local/xwiki"]
+    environment:
+      DB_USER: nextcloud
+      DB_PASSWORD: "!ChangeMe!"
+      DB_HOST: db
+      DB_DATABASE: xwiki
+    depends_on: [db]
+```
+
+xWiki deelt de Postgres-container met Nextcloud + OpenRegister, maar gebruikt een aparte database genaamd `xwiki`. Maak die eenmalig aan:
+
+```bash
+docker exec openregister-postgres psql -U nextcloud -d postgres -c "CREATE DATABASE xwiki;"
+```
+
+Start xWiki nu met het profiel:
+
+```bash
+cd apps-extra/openregister
+docker compose --profile xwiki up -d xwiki
+```
+
+De eerste boot duurt ongeveer een minuut. xWiki initialiseert zijn schema in de lege Postgres-database en pakt gebundelde webapps uit. Wacht tot de health check op healthy springt:
+
+```bash
+docker ps --filter name=openregister-xwiki --format '{{.Status}}'
+# Up 22 seconds (health: starting)   <- still booting
+# Up 1 minute (healthy)              <- ready
+```
+
+Open `http://localhost:8086`. xWiki stuurt je door naar de **Distribution Wizard**, omdat de lege database geen admin-user en geen flavor heeft.
+
+## Stap 0a: Loop door de Distribution Wizard
+
+1. **Continue** voorbij het welkomstscherm.
+2. **Step 1 - Admin user.** Vul in:
+   ```
+   First Name:  Desk
+   Last Name:   Admin
+   Username:    admin
+   Password:    admin1234     (any 8+ chars works)
+   Confirm:     admin1234
+   Email:       admin@deskdesk.local
+   ```
+   Klik **Register and login**. Je bent nu ingelogd als `admin`.
+3. **Step 2 - Flavor.** Klik **Let the wiki be empty** (de gebundelde Standard Flavor is een download van zo'n 150 MB die we voor deze tutorial niet nodig hebben). Bevestig.
+4. **Step 5 - Report** toont de aangemaakte pagina's (alleen `Home` en `XWiki`). Klik **Continue** om op de hoofdpagina te landen.
+
+De wiki is nu gebootstrapt. Doe een sanity check op het REST-endpoint:
+
+```bash
+curl -u admin:admin1234 -H 'Accept: application/json' \
+  http://localhost:8086/rest/wikis/xwiki/spaces | head -c 200
+# {"links":[],"spaces":[{"links":[...,"id":"xwiki:XWiki", ...}]}
+```
+
+Twee dingen om over de URL te weten: de REST API leeft op `/rest`, **niet** `/xwiki/rest` (dat laatste is het pad voor de menselijke weergave), en basic auth is de standaard.
+
+## Stap 1: Schrijf de kennisartikelen
+
+Voor deze tutorial gebruiken we een eigen parent space **DeskDeskKnowledge** met één subspace per zone. De mappenstructuur matcht de `zone`-enum van de desk (`east`, `central`, `west`, `north`, `south`), zodat elke desk netjes op de artikelen van zijn zone uitkomt.
+
+Je kunt de artikelen via xWiki's UI schrijven (Create Page → set parent space → write content). Sneller: spreek de REST API van xWiki direct aan. Dezelfde payload-vorm werkt vanuit cURL, OpenConnector of een willekeurige HTTP-client.
+
+```bash title="Three short articles, one PUT each"
+put() {
+  curl -s -u admin:admin1234 -X PUT \
+    -H "Content-Type: application/xml" \
+    -d "<page xmlns=\"http://www.xwiki.org\"><title>$3</title><syntax>xwiki/2.1</syntax><content>$4</content></page>" \
+    "http://localhost:8086/rest/wikis/xwiki/spaces/DeskDeskKnowledge/spaces/$1/pages/$2" \
+    -o /dev/null -w "%{http_code} $1/$2\n"
+}
+put East    Etiquette     "East zone etiquette" \
+    "The east windows get direct sun 14:00 to 17:00 in summer. Bring a curtain clip from the supplies cabinet on floor 3. Phone calls are fine in this zone, phonebooths are a 30-second walk away."
+put Central MeetingDesks  "Central zone meeting desks" \
+    "Central desks 11 to 14 seat four. The cabling channel under each desk has two HDMI ports and USB-C 100W power. Camera and mic in the ceiling are wired into the in-room Jitsi instance. See the QR code on the desk."
+put West    QuietRules    "West zone quiet rules" \
+    "The west zone is the designated quiet zone. No calls, no meetings. Keep notifications muted. The kitchen is on the opposite side of the floor for a reason."
+```
+
+Elke call geeft `201` terug. Surf naar `http://localhost:8086/xwiki/bin/view/DeskDeskKnowledge/East/Etiquette` om het East-artikel in de standaardweergave van xWiki te zien. Dezelfde inhoud is ook via REST op te halen:
+
+```bash
+curl -u admin:admin1234 \
+  http://localhost:8086/rest/wikis/xwiki/spaces/DeskDeskKnowledge/spaces/East/pages
+```
+
+Drie korte artikelen. Realistisch genoeg dat je ze in productie ook zo zou schrijven. Het belangrijkste stuk is de **subspace-naam**: dat is waar we vanuit DeskDesk op pivoten.
+
+Waarom de tutorial je het schrijven van artikelen laat doen in plaats van ze programmatisch te seeden: in echte teams zijn wiki-artikelen *organisch* — geschreven door wie het etiquette-gat opmerkt, bewerkt door de volgende persoon, gearchiveerd als de plattegrond verandert. De integratie die we bouwen maakt ze vindbaar vanaf waar de gebruiker al staat, niet andersom.
+
+## Stap 2: Voeg een knowledge_article-schema toe aan DeskDesk
+
+Voordat we vanuit xWiki gaan synchroniseren, geef je OpenRegister een plek om de artikelen op te slaan. Voeg een vierde schema toe aan `lib/Settings/deskdesk_register.json`:
+
+```json title="lib/Settings/deskdesk_register.json (excerpt)"
+"knowledge_article": {
+  "slug": "knowledge_article",
+  "icon": "BookOpenVariantOutline",
+  "version": "0.1.0",
+  "title": "Knowledge article",
+  "description": "An external knowledge article surfaced in DeskDesk via OpenConnector. Read-only — canonical source lives in xWiki.",
+  "type": "object",
+  "required": ["name", "zone"],
+  "properties": {
+    "name":       { "type": "string" },
+    "zone":       { "type": "string", "enum": ["north", "south", "east", "west", "central"] },
+    "body":       { "type": "string" },
+    "url":        { "type": "string", "format": "uri" },
+    "externalId": { "type": "string" }
+  }
+}
+```
+
+Belangrijk: de **JSON-key** en het **`slug`-veld moeten matchen** (`knowledge_article` aan beide kanten). OpenRegister bouwt het REST-endpoint vanuit de slug, dus een mismatch levert `Schema not found: 'knowledge_article'` op bij ophalen.
+
+Bump terwijl je daar bent ook de `info.version` van het register naar `0.3.0`, zodat de importhandler het nieuwe schema bij de volgende run oppikt:
+
+```json title="lib/Settings/deskdesk_register.json (info block)"
+"info": {
+  "title": "DeskDesk Register",
+  "description": "Floors, desks, bookings, and knowledge articles.",
+  "version": "0.3.0"
+}
+```
+
+Seed ook drie artikelen die matchen met de xWiki-inhoud. De seeds maken de app demo-baar voordat je de sync hebt aangesloten, en dienen als referentie-vorm voor de OpenConnector-mapping die je in Stap 3 bouwt.
+
+```json title="components.objects (excerpt)"
+"knowledge-east-etiquette": {
+  "@self": { "register": "deskdesk", "schema": "knowledge_article", "slug": "knowledge-east-etiquette" },
+  "name": "East zone etiquette",
+  "zone": "east",
+  "body": "The east windows get direct sun 14:00 to 17:00 in summer...",
+  "url": "http://localhost:8086/xwiki/bin/view/DeskDeskKnowledge/East/Etiquette",
+  "externalId": "xwiki:DeskDeskKnowledge.East.Etiquette"
+}
+```
+
+Voeg de `knowledge_article`-slug toe aan de kleine lijst `SettingsService::SCHEMA_SLUGS` in [lib/Service/SettingsService.php](https://github.com/ConductionNL/deskdesk/blob/main/lib/Service/SettingsService.php), zodat `/api/settings` het numerieke id naast de andere schema's blootlegt. Hetzelfde in `src/store/store.js`:
+
+```js title="src/store/store.js"
+const SCHEMAS = ['floor', 'desk', 'booking', 'knowledge_article']
+```
+
+Herlaad de configuratie zodat OpenRegister het nieuwe schema + de seeds oppikt:
+
+```bash
+docker exec nextcloud apache2ctl graceful
+# then from your Nextcloud session, POST /apps/deskdesk/api/settings/load
+# (the deskdesk admin page has a Reload button that does this for you)
+```
+
+## Stap 3: Maak een OpenConnector-source voor xWiki aan
+
+De seeds krijgen de UI meteen aan de praat. Voor *live* data — als een artikel in xWiki verandert wil je die wijziging bij de volgende sync in DeskDesk zien — sluit je OpenConnector aan.
+
+Ga naar `/apps/openconnector/sources` en maak een nieuwe source.
+
+```
+Name:       xWiki Knowledge
+Type:       API
+Location:   http://openregister-xwiki:8080/rest
+            (container-to-container hostname; from the host you use http://localhost:8086/rest)
+Auth:       Basic
+Username:   admin
+Password:   admin1234
+Headers:    Accept: application/json
+Test:       GET /wikis/xwiki/spaces/DeskDeskKnowledge/spaces/East/pages
+```
+
+De Test zou het East-artikel moeten teruggeven. OpenConnector slaat de source op met een numeriek id; we refereren ernaar vanuit de synchronisation in de volgende stap.
+
+## Stap 4: Definieer de synchronisation
+
+Sources tonen ruwe API-responses; **synchronisations** mappen ze naar OpenRegister-objecten. Maak een synchronisation aan:
+
+```
+Name:             xWiki articles → OpenRegister
+Source:           xWiki Knowledge (the one you just made)
+Source endpoint:  /wikis/xwiki/spaces/DeskDeskKnowledge/spaces/{zone}/pages
+                  with zone iterated over ['East', 'Central', 'West']
+Target register:  deskdesk
+Target schema:    knowledge_article
+Mapping:
+  title           → name
+  content         → body
+  spaces.last     → zone     (lowercased)
+  id              → externalId
+  xwikiAbsoluteUrl → url
+Schedule:         every 30 minutes
+```
+
+Sla op en draai één keer. Je ziet drie `knowledge_article`-objecten in OpenRegister waarvan het `externalId`-veld begint met `xwiki:`. Verwijder de seed-objecten die je in Stap 2 toevoegde: ze worden vervangen door de gesyncde versies.
+
+## Stap 5: Toon artikelen in CnObjectSidebar
+
+De desk-detail-pagina mount al een CnObjectSidebar. Declareer een custom tab in het manifest om er een **Kennis-tab** aan toe te voegen:
+
+```json title="src/manifest.json (excerpt)"
+{
+  "id": "desks-detail",
+  "route": "/desks/:id",
+  "type": "detail",
+  "title": "deskdesk.desks.detailTitle",
+  "config": {
+    "register": "deskdesk",
+    "schema": "desk",
+    "sidebar": {
+      "tabs": [
+        { "id": "data",      "label": "deskdesk.sidebar.data",      "widgets": [{ "type": "data" }] },
+        { "id": "knowledge", "label": "deskdesk.sidebar.knowledge", "component": "knowledge-tab" },
+        { "id": "metadata",  "label": "deskdesk.sidebar.metadata",  "widgets": [{ "type": "metadata" }] }
+      ]
+    }
+  }
+}
+```
+
+De `data`- en `metadata`-tabs gebruiken ingebouwde widget-types. De `knowledge`-tab wijst naar een custom component `knowledge-tab`, dat de App registreert via de `customComponents`-map.
+
+Maak het tab-component zelf aan op `src/views/KnowledgeTab.vue`:
+
+```vue title="src/views/KnowledgeTab.vue"
+<template>
+  <div class="knowledge-tab">
+    <NcLoadingIcon v-if="loading" :size="32" />
+    <NcEmptyContent
+      v-else-if="!articles.length"
+      :name="t('deskdesk', 'No articles for this zone yet')" />
+    <article v-for="article in articles" :key="article.id" class="knowledge-tab__article">
+      <header class="knowledge-tab__head">
+        <h3>{{ article.name }}</h3>
+        <a v-if="article.url" :href="article.url" target="_blank" rel="noopener noreferrer">
+          {{ t('deskdesk', 'Open in wiki') }} ↗
+        </a>
+      </header>
+      <p class="knowledge-tab__body">{{ article.body }}</p>
+    </article>
+  </div>
+</template>
+
+<script>
+import { NcEmptyContent, NcLoadingIcon } from '@nextcloud/vue'
+import { useObjectStore } from '../store/store.js'
+
+export default {
+  name: 'KnowledgeTab',
+  components: { NcEmptyContent, NcLoadingIcon },
+  props: {
+    objectId:   { type: String, required: true },
+    objectType: { type: String, default: 'desk' },
+  },
+  setup() { return { objectStore: useObjectStore() } },
+  data() { return { articles: [], loading: true } },
+  watch: {
+    objectId: {
+      immediate: true,
+      async handler() {
+        this.loading = true
+        try {
+          const desk = await this.objectStore.fetchObject(this.objectType, this.objectId)
+          if (!desk?.zone) { this.articles = []; return }
+          await this.objectStore.fetchCollection('knowledge_article', { zone: desk.zone, _limit: 25 })
+          this.articles = this.objectStore.collections.knowledge_article || []
+        } finally { this.loading = false }
+      },
+    },
+  },
+}
+</script>
+```
+
+Registreer het component in `src/App.vue` en geef het door aan `CnAppRoot` via de `:custom-components`-prop:
+
+```vue title="src/App.vue (excerpt)"
+<script>
+import KnowledgeTab from './views/KnowledgeTab.vue'
+
+const customComponents = {
+  'knowledge-tab': KnowledgeTab,
+}
+
+export default {
+  /* ... */
+  data() {
+    return { customComponents, /* ... */ }
+  },
+}
+</script>
+
+<template>
+  <CnAppRoot
+    :app-id="appId"
+    :manifest="manifest"
+    :page-types="pageTypes"
+    :custom-components="customComponents">
+    <template #sidebar>
+      <CnObjectSidebar v-if="objectSidebarState.active" ... />
+    </template>
+  </CnAppRoot>
+</template>
+```
+
+(Zie de [reference repo](https://github.com/ConductionNL/deskdesk/blob/main/src/App.vue) voor het volledige bestand. App.vue voorziet ook in `objectSidebarState`, zodat het externe-sidebar-kanaal van CnDetailPage werkt.)
+
+Bouw, herlaad en navigeer naar de detail-URL van een 3-East-desk. De rechter sidebar toont drie tabs: Data, Kennis, Metadata. Klik op **Kennis**. Het artikel "East zone etiquette" verschijnt, met de body gerenderd en een link terug naar de wiki om te bewerken.
+
+Navigeer naar een 2-West-desk: zelfde tab, ander artikel ("West zone quiet rules"). De zonefilter doet de match gratis voor je; je hoefde geen per-desk bedrading te schrijven.
+
+## Stap 6: Package de app
+
+Het release-proces is mechanisch:
+
+1. **Bump de versie** in `appinfo/info.xml` (`<version>0.1.0</version>` → `<version>0.4.0</version>`).
+2. **Draai de production build:**
+   ```bash
+   composer install --no-dev --optimize-autoloader
+   npm install --legacy-peer-deps
+   npm run build
+   ```
+3. **Strip ongewenste bestanden** — vendor-dev-dependencies, node_modules, tests, openspec-changes, .git, .github (je CI staat al op source-niveau). Het template levert een `Makefile`-target hiervoor; anders is het patroon voor de productie-tarball:
+   ```bash
+   tar --exclude=node_modules --exclude=vendor/bin \
+       --exclude=tests --exclude=openspec/changes \
+       --exclude=.git --exclude=.github \
+       -czf deskdesk-0.4.0.tar.gz deskdesk/
+   ```
+4. **Onderteken de tarball** met de EC-key die de Nextcloud app store verwacht (zie [de Nextcloud-docs](https://nextcloudappstore.readthedocs.io/en/latest/developer.html#publishing-your-app)).
+5. **Push naar GitHub** met een tag die overeenkomt met de versie (`git tag v0.4.0 && git push origin v0.4.0`). Het template levert een `.github/workflows/release.yml` die de tag oppikt, de tarball bouwt, ondertekent en de release publiceert.
+
+Voor de **Conduction app store** (`apps.conduction.nl`) duwt dezelfde release-pipeline naar dat endpoint als de secret is geconfigureerd. Zie [de .github/workflows/release.yml](https://github.com/ConductionNL/nextcloud-app-template/blob/main/.github/workflows/release.yml) als referentie.
+
+## Stap 7: Indienen bij apps.nextcloud.com (optioneel)
+
+Als je DeskDesk in de publieke Nextcloud app store wilt, registreer je je op [apps.nextcloud.com](https://apps.nextcloud.com), upload je je ondertekende tarball, vul je het formulier in (beschrijving, screenshots, licentie — EUPL-1.2 is prima — categorieën `organization`) en wacht je op review. De cyclus is meestal 1 tot 3 dagen voor een nieuwe app.
+
+## Wat je hebt gebouwd
+
+Je begon Deel 1 met een leeg template. Achtenveertig stappen verder heb je:
+
+- Een echte Nextcloud-app met het canonieke chassis
+- Vier OpenRegister-schema's met relaties en seed-data
+- Een manifest-gedreven shell met twee kleine wrappers (Index, Detail) die verdwijnen zodra de library auto-fetch in de default page-types verdraagt
+- Boekingen die via een schema-annotatie in de NC Agenda verschijnen
+- Kennisartikelen uit xWiki die via OpenConnector in de desk-detail-sidebar verschijnen
+- Een geversioneerde, gepackagede, publiceerbare release
+
+Totaal aan geschreven Vue: **drie kleine bestanden** (`IndexPageWrapper`, `DetailPageWrapper`, `KnowledgeTab`), samen ongeveer 100 regels. Totaal PHP: het rename-ritueel, een pad-resolutie-fix in SettingsService en de schema-slug-lijst. Al het andere is JSON.
+
+Die verhouding — JSON beschrijft wat je wil, het framework rendert het — is het hele punt van de Conduction-stack. Schema's sturen zowel backend als frontend. Manifesten sturen de shell. Schema-annotaties sturen cross-app-integraties. Jij declareert; het framework rendert.
+
+## Troubleshooting
+
+<HexCard title='"Schema not found: knowledge_article" bij ophalen'>
+  De JSON-key en het <code>slug</code>-veld van het schema moeten matchen. Als je <code>knowledge-article</code> (streepje) voor de een gebruikte en <code>knowledge_article</code> (underscore) voor de ander, faalt OpenRegister's URL-lookup. Kies één, gebruik die op beide plekken.
+</HexCard>
+
+<HexCard title="Sidebar-tabs renderen maar de body zegt 'No data available'">
+  CnPageRenderer geeft <code>page.config</code> en <code>$route.params</code> als ruwe props door. De route-param heet <code>id</code>, maar de prop van CnDetailPage heet <code>objectId</code>. De DetailPageWrapper overbrugt de namen en haalt het object via de store op; zonder de wrapper rendert CnDetailPage alleen de empty state.
+</HexCard>
+
+<HexCard title="De xWiki Distribution Wizard wil de Flavor downloaden maar de container heeft geen internet">
+  Kies <strong>Let the wiki be empty</strong> in Stap 2. De lege flavor ondersteunt nog steeds REST + pagina-creatie, en dat is alles wat de tutorial nodig heeft.
+</HexCard>
+
+<HexCard title="De OpenConnector-source-'Test' geeft HTML terug in plaats van JSON">
+  Zet <code>Accept: application/json</code> in het Headers-veld van de source. xWiki staat voor REST-responses standaard op XML, maar onderhandelt JSON wanneer je erom vraagt.
+</HexCard>
+
+## Waar nu naartoe
+
+<NextSteps>
+  <NextStep
+    title="De component-referentie"
+    href="https://nextcloud-vue.conduction.nl/docs/components/"
+    description="Blader door elk Cn*-component dat de library levert. Live playgrounds, prop-tabellen, slot-referentie."
+  />
+  <NextStep
+    title="Conduction-app-catalogus"
+    href="https://www.conduction.nl/apps"
+    description="Zie hoe Procest, OpenCatalogi, MyDash en de rest dezelfde patronen samenstellen. DeskDesk hoort nu bij die rij."
+  />
+  <NextStep
+    title="Bouw iets anders"
+    href="/academy/build-an-app"
+    description="De 30 minuten durende end-to-end-overzichtstutorial. Of fork DeskDesk naar je eigen use case. Het template is een momentopname; je app is de reis."
+  />
+</NextSteps>


### PR DESCRIPTION
Part of ConductionNL/.github#75 SEO epic, addresses ConductionNL/.github#77. The two longest academy posts.