### PR TITLE
feat(i18n): flip 3 NL-native academy posts to EN canonical + NL translations (#77)

### DIFF
--- a/academy/2026-05-07-nextcloud-lokaal-draaien/index.mdx
+++ b/academy/2026-05-07-nextcloud-lokaal-draaien/index.mdx
@@ -1,61 +1,61 @@
 ---
 slug: nextcloud-lokaal-draaien
-title: Nextcloud lokaal draaien met Docker
+title: Run Nextcloud locally with Docker
 contentType: tutorial
 authors: [conduction]
 date: 2026-05-07
-summary: Drie commando's, vier stappen, een kwartier werk. Daarna draait er een schone Nextcloud op je laptop, klaar om Conduction-apps op te installeren.
-tags: [Nextcloud, Docker, Setup, Demo, Lokaal]
+summary: Three commands, four steps, a quarter of an hour. After that you have a clean Nextcloud running on your laptop, ready for Conduction apps.
+tags: [Nextcloud, Docker, Setup, Demo, Local]
 durationMinutes: 15
 ---
 
 import {Outcomes, Outcome, Prerequisites, PrerequisiteItem, ContactCta} from '@conduction/docusaurus-preset/components';
 
-Voor elke andere tutorial in deze academy heb je een werkende Nextcloud nodig. Dit is de snelste route: drie commando's en je draait de officiële Nextcloud-image lokaal, identiek aan productie. Geen sales-call, geen demo-omgeving die offline kan, geen custom Dockerfile. Daarna installeer je de Conduction-apps via de Nextcloud app store, hetzelfde pad als productie.
+Every other tutorial in this academy needs a working Nextcloud. This is the fastest route: three commands and you run the official Nextcloud image locally, identical to production. No sales call, no demo environment that can go offline, no custom Dockerfile. After that you install the Conduction apps from the Nextcloud app store, the same path as production.
 
 {/* truncate */}
 
-<Outcomes title="Wat je leert">
-  <Outcome>Een werkende Nextcloud op <code>http://localhost:8080</code> opzetten met Docker.</Outcome>
-  <Outcome>Postgres voor data, Redis voor cache, Nextcloud voor het werk en <code>notify_push</code> voor realtime updates in één compose-bestand combineren.</Outcome>
-  <Outcome>Een admin-account aanmaken waar je naar believen Conduction-apps op installeert.</Outcome>
-  <Outcome>Met één commando de hele stack weer opruimen.</Outcome>
+<Outcomes title="What you'll learn">
+  <Outcome>How to run a working Nextcloud on <code>http://localhost:8080</code> with Docker.</Outcome>
+  <Outcome>How to combine Postgres for data, Redis for cache, Nextcloud for the work, and <code>notify_push</code> for realtime updates in one compose file.</Outcome>
+  <Outcome>How to create an admin account where you can install Conduction apps at will.</Outcome>
+  <Outcome>How to tear down the whole stack with one command.</Outcome>
 </Outcomes>
 
-Daarna kun je verder met [Een Woo-register opzetten](/academy/woo-register-opzetten), [Bestanden uploaden bij een Woo-publicatie](/academy/woo-bestanden-uploaden), of een eigen experiment.
+After this you can move on to [Set up a Woo register](/academy/woo-register-opzetten), [Upload files to a Woo publication](/academy/woo-bestanden-uploaden), or your own experiment.
 
-<Prerequisites title="Wat je nodig hebt">
-  <PrerequisiteItem>Een laptop met minimaal 4 GB vrij geheugen.</PrerequisiteItem>
-  <PrerequisiteItem>Docker, lokaal draaiend.</PrerequisiteItem>
-  <PrerequisiteItem>Een terminal en een teksteditor.</PrerequisiteItem>
+<Prerequisites title="What you need">
+  <PrerequisiteItem>A laptop with at least 4 GB of free memory.</PrerequisiteItem>
+  <PrerequisiteItem>Docker, running locally.</PrerequisiteItem>
+  <PrerequisiteItem>A terminal and a text editor.</PrerequisiteItem>
 </Prerequisites>
 
-Op een schone laptop is stap 0 (Docker installeren) ongeveer tien minuten. Daarna is stap 1 t/m 3 samen een kwartier.
+On a clean laptop, step 0 (installing Docker) takes about ten minutes. After that, steps 1 through 3 together take a quarter of an hour.
 
-## Stap 0: Zorg dat Docker draait
+## Step 0: Make sure Docker is running
 
-Eenmalig.
+One-time setup.
 
-- **Mac of Linux:** installeer [Docker Desktop](https://docs.docker.com/get-docker/).
-- **Windows:** zet eerst [WSL 2](https://learn.microsoft.com/nl-nl/windows/wsl/install) aan en installeer daarna Docker Desktop.
+- **Mac or Linux:** install [Docker Desktop](https://docs.docker.com/get-docker/).
+- **Windows:** first enable [WSL 2](https://learn.microsoft.com/en-us/windows/wsl/install), then install Docker Desktop.
 
-Test of het werkt:
+Check that it works:
 
 ```bash
 docker --version
 docker compose version
 ```
 
-Allebei moeten een versie teruggeven, geen foutmelding.
+Both should return a version, not an error.
 
-## Stap 1: Maak een werkmap en het compose-bestand
+## Step 1: Create a working directory and the compose file
 
 ```bash
 mkdir conduction-demo
 cd conduction-demo
 ```
 
-Sla het volgende op als `docker-compose.yml` in die map:
+Save the following as `docker-compose.yml` in that directory:
 
 ```yaml title="docker-compose.yml"
 services:
@@ -108,49 +108,49 @@ volumes:
   nextcloud:
 ```
 
-Vier services, allemaal officiële images, geen custom build. De `./apps`-bind-mount is optioneel: handig als je een Conduction-app als zip naast de installatie wilt zetten in plaats van via de app store. `notify_push` is de WebSocket push-server die Conduction-apps gebruiken voor realtime updates — meer daarover in stap 5.
+Four services, all official images, no custom build. The `./apps` bind mount is optional. It is handy when you want to drop a Conduction app next to the installation as a zip instead of going through the app store. `notify_push` is the WebSocket push server that Conduction apps use for realtime updates. More on that in step 5.
 
-## Stap 2: Start de stack
+## Step 2: Start the stack
 
 ```bash
 docker compose up -d
 ```
 
-De eerste keer trekt Docker ongeveer 750 MB aan images binnen. Daarna start de stack in seconden.
+The first time, Docker pulls about 750 MB of images. After that the stack starts in seconds.
 
-Volg de logs terwijl Nextcloud zichzelf bootstrapt:
+Follow the logs while Nextcloud bootstraps itself:
 
 ```bash
 docker compose logs -f nextcloud
 ```
 
-Wacht tot je `apache2 -D FOREGROUND` of vergelijkbaar ziet, en `Ctrl+C` om de log-volger af te sluiten. De containers blijven draaien.
+Wait until you see `apache2 -D FOREGROUND` or similar, then `Ctrl+C` to exit the log follower. The containers keep running.
 
-## Stap 3: Voltooi de Nextcloud setup-wizard
+## Step 3: Finish the Nextcloud setup wizard
 
-Open `http://localhost:8080` in je browser. Nextcloud toont een setup-wizard:
+Open `http://localhost:8080` in your browser. Nextcloud shows a setup wizard:
 
-1. Vul een **admin-naam** en **wachtwoord** in. `admin` en `admin` is prima voor lokaal werk; in productie natuurlijk niet.
-2. Onder **Storage & database** kies je niets, want de Postgres-config zit al in `docker-compose.yml`.
-3. Klik op **Install**.
+1. Fill in an **admin name** and **password**. `admin` and `admin` is fine for local work. In production it is not.
+2. Under **Storage & database**, pick nothing. The Postgres config is already in `docker-compose.yml`.
+3. Click **Install**.
 
-Na een halve minuut land je op het dashboard, ingelogd als admin.
+After half a minute, you land on the dashboard, signed in as admin.
 
-## Stap 4: Installeer de Conduction-apps
+## Step 4: Install the Conduction apps
 
-Klik je avatar rechtsboven en kies **Apps**. De Conduction-apps staan onder **Integration** en **Office & text**. Onze suggestie voor een eerste demo:
+Click your avatar in the top right and choose **Apps**. The Conduction apps are listed under **Integration** and **Office & text**. Our suggestion for a first demo:
 
-- **OpenRegister.** De typed-data foundation. Installeer deze als eerste, alle andere apps lezen ervan af.
-- **OpenCatalogi.** Maakt elk register doorzoekbaar als publieke entry. Federation naar `data.overheid.nl`.
-- **OpenConnector.** Trekt voorbeelddata binnen via REST, SOAP en file-drops.
+- **OpenRegister.** The typed-data foundation. Install this first. Every other app reads from it.
+- **OpenCatalogi.** Makes every register searchable as a public entry. Federates to `data.overheid.nl`.
+- **OpenConnector.** Pulls in sample data via REST, SOAP, and file drops.
 
-Na elke install draait de schema-bootstrap automatisch. Voorbeelddata is binnen seconden zichtbaar.
+After every install, the schema bootstrap runs automatically. Sample data is visible within seconds.
 
-Installeer ook de `notify_push`-app (onder **Integration**). Die is de Nextcloud-zijde van de WebSocket push-server die je in stap 1 al hebt gestart — je hoeft hem alleen te enabelen, geen verdere config nodig.
+Also install the `notify_push` app (under **Integration**). It is the Nextcloud side of the WebSocket push server you already started in step 1. You only have to enable it. No further config needed.
 
-## Stap 5: Koppel `notify_push` aan de push-server
+## Step 5: Wire `notify_push` to the push server
 
-`notify_push` heeft één eenmalige setup-stap zodat de Nextcloud-app weet waar de Rust-binary draait. Voer in de werkmap uit:
+`notify_push` has one one-off setup step so the Nextcloud app knows where the Rust binary runs. Run this in your working directory:
 
 ```bash
 docker compose exec --user www-data nextcloud php occ config:system:set redis host --value redis
@@ -160,71 +160,71 @@ docker compose exec --user www-data nextcloud php occ config:system:set trusted_
 docker compose exec --user www-data nextcloud php occ notify_push:setup http://notify_push:7867
 ```
 
-De eerste drie regels vertellen Nextcloud dat Redis de gedeelde cache is — `notify_push` luistert daarop voor change-events. De vierde regel markeert het Docker-netwerk als trusted zodat de push-server bij Nextcloud terugmag bellen voor authenticatie. De laatste regel registreert de URL bij de Nextcloud-app.
+The first three lines tell Nextcloud that Redis is the shared cache. `notify_push` listens on it for change events. The fourth line marks the Docker network as trusted so the push server can call back to Nextcloud for authentication. The last line registers the URL with the Nextcloud app.
 
-Verifieer dat alles werkt:
+Verify everything works:
 
 ```bash
 docker compose exec --user www-data nextcloud php occ notify_push:self-test
 ```
 
-Je krijgt een lijstje vinkjes — `redis is configured`, `push server is receiving redis messages`, `push server can connect to the Nextcloud server`, et cetera. De waarschuwing over `unencrypted http` is voor lokaal werk normaal; in productie zit `notify_push` achter dezelfde reverse proxy als Nextcloud, dus dan is dat geen issue.
+You get a list of checkmarks: `redis is configured`, `push server is receiving redis messages`, `push server can connect to the Nextcloud server`, and so on. The warning about `unencrypted http` is normal for local work. In production, `notify_push` sits behind the same reverse proxy as Nextcloud, so it is not an issue there.
 
-Vanaf nu krijgen apps die op `notify_push` luisteren — zoals OpenRegister's live-update-integratie via `@conduction/nextcloud-vue` — direct doorduwingen op object-wijzigingen, zonder dat de browser hoeft te pollen.
+From now on, apps that listen to `notify_push` (like OpenRegister's live-update integration via `@conduction/nextcloud-vue`) get direct pushes on object changes. The browser does not have to poll.
 
-## Wat je krijgt
+## What you get
 
-| Eigenschap | Waarde |
+| Property | Value |
 | --- | --- |
-| Eerste boot | Ongeveer drie minuten (eerste keer 750 MB download) |
-| Volgende boots | Seconden |
-| Image | Officiële `nextcloud:latest`, identiek aan productie |
-| Geheugen | Rond 1 GB onder lichte load |
-| Reset | `docker compose down -v` (verwijdert volumes) |
+| First boot | About three minutes (first run downloads 750 MB) |
+| Subsequent boots | Seconds |
+| Image | Official `nextcloud:latest`, identical to production |
+| Memory | Around 1 GB under light load |
+| Reset | `docker compose down -v` (removes volumes) |
 
-Geen vooraf opgenomen screencast, geen demo-omgeving die offline kan. Wat je hier ziet, is precies wat een echte klant ziet.
+No pre-recorded screencast, no demo environment that can go offline. What you see here is exactly what a real customer sees.
 
-## Reset of stoppen
+## Reset or stop
 
 ```bash
-# tijdelijk stoppen, data behouden
+# temporarily stop, keep data
 docker compose stop
 
-# weer starten
+# start again
 docker compose start
 
-# helemaal opruimen, ook volumes
+# tear down completely, including volumes
 docker compose down -v
 ```
 
-Na `down -v` is je laptop weer schoon. Twee minuten later kun je opnieuw beginnen.
+After `down -v`, your laptop is clean again. Two minutes later, you can start over.
 
-## Probleemoplossing
+## Troubleshooting
 
-**Apache port 8080 in gebruik:** wijzig `"8080:80"` naar bijvoorbeeld `"8081:80"` in `docker-compose.yml`. Vergeet niet de URL aan te passen naar `http://localhost:8081`.
+**Apache port 8080 in use:** change `"8080:80"` to something like `"8081:80"` in `docker-compose.yml`. Remember to update the URL to `http://localhost:8081`.
 
-**Setup-wizard wil opnieuw beginnen:** waarschijnlijk is de Postgres-database leeg geraakt. Voer `docker compose down -v` uit en start opnieuw met `docker compose up -d`.
+**Setup wizard wants to start over:** the Postgres database probably emptied out. Run `docker compose down -v` and start again with `docker compose up -d`.
 
-**Nextcloud toont "Trusted domain"-foutmelding:** voeg de host toe aan `NEXTCLOUD_TRUSTED_DOMAINS` (komma-gescheiden) en herstart met `docker compose up -d`.
+**Nextcloud shows a "Trusted domain" error:** add the host to `NEXTCLOUD_TRUSTED_DOMAINS` (comma-separated) and restart with `docker compose up -d`.
 
-**App-store install werkt niet:** controleer of Nextcloud naar buiten kan. In een corporate netwerk soms blokkade op `apps.nextcloud.com`. Een proxy via `HTTP_PROXY`-env-variabelen lost dit op.
+**App store install does not work:** check that Nextcloud can reach the internet. Corporate networks sometimes block `apps.nextcloud.com`. A proxy via `HTTP_PROXY` env variables fixes this.
 
-**`notify_push` self-test faalt op `is not trusted as a reverse proxy`:** het Docker-netwerk-bereik in jouw setup wijkt af van `172.16.0.0/12`. Bekijk het bereik met `docker network inspect $(docker network ls --filter name=conduction-demo -q) --format '{{range .IPAM.Config}}{{.Subnet}}{{end}}'` en pas de `trusted_proxies`-regel uit stap 5 aan met die subnet.
+**`notify_push` self-test fails on `is not trusted as a reverse proxy`:** the Docker network range in your setup differs from `172.16.0.0/12`. Inspect the range with `docker network inspect $(docker network ls --filter name=conduction-demo -q) --format '{{range .IPAM.Config}}{{.Subnet}}{{end}}'` and update the `trusted_proxies` line from step 5 with that subnet.
 
-**`notify_push` blijft restarten na `docker compose up -d`:** kijk in de logs (`docker compose logs notify_push`) of je `× No redis server is configured` ziet. Dat betekent dat Nextcloud's `memcache.distributed`-config nog niet op Redis staat — voer de eerste drie `occ config:system:set`-commando's uit stap 5 uit, en herstart dan met `docker compose up -d notify_push`.
+**`notify_push` keeps restarting after `docker compose up -d`:** check the logs (`docker compose logs notify_push`) for `× No redis server is configured`. That means Nextcloud's `memcache.distributed` config is not on Redis yet. Run the first three `occ config:system:set` commands from step 5, then restart with `docker compose up -d notify_push`.
 
-## Volgende stap
+## Next step
 
-Een werkende Nextcloud is de aanleiding voor de andere tutorials in deze serie:
+A working Nextcloud is the entry point for the other tutorials in this series:
 
-- [Een Woo-register opzetten](/academy/woo-register-opzetten) — importeer het canonieke Woo-register in OpenRegister
-- [Bestanden uploaden bij een Woo-publicatie](/academy/woo-bestanden-uploaden) — vier upload-modes voor documenten
-- [Build je eerste Conduction-app](/academy/build-an-app) — eindigt met een geïnstalleerde app op deze stack
+- [Set up a Woo register](/academy/woo-register-opzetten): import the canonical Woo register into OpenRegister
+- [Upload files to a Woo publication](/academy/woo-bestanden-uploaden): four upload modes for documents
+- [Build your first Conduction app](/academy/build-an-app): ends with an installed app on this stack
 
-Stuur het `docker-compose.yml` naar een collega als je dit samen wilt zien werken.
+Send the `docker-compose.yml` to a colleague if you want to see this work together.
 
 <ContactCta
-  title="Wil je meer weten?"
-  body="Mail ons. We helpen je in een halve dag op weg met je eigen Conduction-stack op Nextcloud, van eerste demo tot productie."
-  cta={{ label: "Mail ons", href: "mailto:info@conduction.nl?subject=Nextcloud%20setup" }}
+  title="Want to know more?"
+  body="Send us an email. We help you set up your own Conduction stack on Nextcloud in half a day, from first demo to production."
+  cta={{ label: "Email us", href: "mailto:info@conduction.nl?subject=Nextcloud%20setup" }}
 />

--- a/academy/2026-05-07-woo-bestanden-uploaden/index.mdx
+++ b/academy/2026-05-07-woo-bestanden-uploaden/index.mdx
@@ -1,64 +1,64 @@
 ---
 slug: woo-bestanden-uploaden
-title: Bestanden bij een Woo-publicatie uploaden
+title: Upload files to a Woo publication
 contentType: tutorial
 authors: [conduction]
 date: 2026-05-07
-summary: Vier manieren om documenten aan een Woo-publicatie te koppelen, van één PDF tot een 6 MB rapport in chunks. Met geteste API-aanroepen.
-tags: [Woo, OpenRegister, Bestanden, Upload, Publicaties]
+summary: Four ways to attach documents to a Woo publication, from one PDF to a 6 MB report in chunks. With tested API calls.
+tags: [Woo, OpenRegister, Files, Upload, Publications]
 apps: [openregister, openwoo]
 durationMinutes: 18
 ---
 
 import {Outcomes, Outcome, Prerequisites, PrerequisiteItem, Troubleshooting, TroubleshootingItem, NextSteps, NextStep, ContactCta} from '@conduction/docusaurus-preset/components';
 
-Een Woo-publicatie zonder bestanden is metadata zonder bewijs. In deze tutorial koppel je documenten aan een Woo-publicatie via vier upload-modes: één bestand, meerdere bestanden tegelijk, en grote bestanden in chunks. Plus publiceren, depubliceren en opruimen.
+A Woo publication without files is metadata without evidence. In this tutorial you attach documents to a Woo publication through four upload modes: one file, multiple files at once, and large files in chunks. Plus publish, unpublish, and clean up.
 
 {/* truncate */}
 
-<Outcomes title="Wat je leert">
-  <Outcome>Vier upload-modes voor documenten bij een Woo-publicatie, van klein naar groot.</Outcome>
-  <Outcome>Wanneer je JSON+base64, multipart of WebDAV chunked upload gebruikt.</Outcome>
-  <Outcome>Hoe je bestanden publiceert, depubliceert en weer opruimt.</Outcome>
+<Outcomes title="What you'll learn">
+  <Outcome>Four upload modes for documents on a Woo publication, from small to large.</Outcome>
+  <Outcome>When to use JSON+base64, multipart, or WebDAV chunked upload.</Outcome>
+  <Outcome>How to publish, unpublish, and clean up files.</Outcome>
 </Outcomes>
 
-<Prerequisites title="Wat je nodig hebt">
+<Prerequisites title="What you need">
   <PrerequisiteItem>
-    Een werkend Woo-register. Volg eerst <a href="/academy/woo-register-opzetten">Een Woo-register opzetten</a> als je dat nog niet hebt.
+    A working Woo register. Follow <a href="/academy/woo-register-opzetten">Set up a Woo register</a> first if you do not have one yet.
   </PrerequisiteItem>
-  <PrerequisiteItem>Een publicatie-object met bekende UUID.</PrerequisiteItem>
-  <PrerequisiteItem><code>curl</code>, basisauth, en een paar testbestanden.</PrerequisiteItem>
+  <PrerequisiteItem>A publication object with a known UUID.</PrerequisiteItem>
+  <PrerequisiteItem><code>curl</code>, basic auth, and a few test files.</PrerequisiteItem>
 </Prerequisites>
 
-In de voorbeelden gebruiken we:
+In the examples we use:
 
 - Host: `http://localhost:8080`
 - Auth: `admin:admin`
-- Register-slug: `woo`
-- Schema-slug: `onderzoeksrapporten`
-- Object-UUID: `3422e6cd-1ba5-478c-b842-8f206f9d7358`
+- Register slug: `woo`
+- Schema slug: `onderzoeksrapporten`
+- Object UUID: `3422e6cd-1ba5-478c-b842-8f206f9d7358`
 
-Vervang het object-UUID door de jouwe.
+Replace the object UUID with your own.
 
-![Het Woo-register met de geïmporteerde TOOI-schemas](./01-woo-register-context.png)
+![The Woo register with the imported TOOI schemas](./01-woo-register-context.png)
 
-## Het basispatroon
+## The base pattern
 
-Alle bestanden worden gekoppeld aan een specifiek object. De URL volgt altijd hetzelfde patroon:
+All files are attached to a specific object. The URL always follows the same pattern:
 
 ```
 POST /index.php/apps/openregister/api/objects/{register}/{schema}/{id}/files
 ```
 
-OpenRegister maakt automatisch een map aan voor het object onder `Open Registers/{Register Title}/{Object UUID}/`. Daar landen alle bestanden. De map ontstaat zodra je het eerste bestand uploadt.
+OpenRegister automatically creates a folder for the object under `Open Registers/{Register Title}/{Object UUID}/`. All files land there. The folder appears as soon as you upload the first file.
 
-## Mode 1: één bestand via JSON en base64
+## Mode 1: one file via JSON and base64
 
-De eenvoudigste route, prima voor kleine documenten tot enkele megabytes:
+The simplest route, fine for small documents up to a few megabytes:
 
 ```bash
 OBJ=3422e6cd-1ba5-478c-b842-8f206f9d7358
-B64=$(echo "Inhoud van het rapport." | base64 -w0)
+B64=$(echo "Report content." | base64 -w0)
 
 curl -u admin:admin \
   -X POST "http://localhost:8080/index.php/apps/openregister/api/objects/woo/onderzoeksrapporten/$OBJ/files" \
@@ -71,7 +71,7 @@ curl -u admin:admin \
   }"
 ```
 
-De respons:
+The response:
 
 ```json
 {
@@ -89,13 +89,13 @@ De respons:
 }
 ```
 
-`share: true` maakt direct een publieke share-link aan. De `accessUrl` is dan meteen de publieke landings-URL. Wil je het bestand vooralsnog privé houden, laat `share` weg of zet hem op `false`.
+`share: true` creates a public share link right away. The `accessUrl` is then the public landing URL. If you want to keep the file private for now, leave `share` out or set it to `false`.
 
-**Wanneer wel:** scripts en synchronisaties waar je tekstinhoud genereert, kleine PDF's, of CI-pipelines. **Wanneer niet:** bestanden boven enkele MB. Base64 maakt de payload 33% groter en je raakt al snel de PHP `post_max_size`-grens.
+**When to use it:** scripts and synchronisations where you generate text content, small PDFs, or CI pipelines. **When not:** files above a few MB. Base64 makes the payload 33% larger and you quickly hit the PHP `post_max_size` limit.
 
-## Mode 2: één bestand binair via multipart
+## Mode 2: one binary file via multipart
 
-Voor binaire bestanden (PDF, DOCX, afbeeldingen) gebruik je het `filesMultipart`-endpoint. Dat scheelt de base64-overhead en is sneller voor middelgrote bestanden.
+For binary files (PDF, DOCX, images) you use the `filesMultipart` endpoint. It avoids the base64 overhead and is faster for mid-size files.
 
 ```bash
 OBJ=3422e6cd-1ba5-478c-b842-8f206f9d7358
@@ -103,11 +103,11 @@ OBJ=3422e6cd-1ba5-478c-b842-8f206f9d7358
 curl -u admin:admin \
   -X POST "http://localhost:8080/index.php/apps/openregister/api/objects/woo/onderzoeksrapporten/$OBJ/filesMultipart" \
   -H "OCS-APIRequest: true" \
-  -F "files[]=@/pad/naar/rapport.pdf" \
+  -F "files[]=@/path/to/rapport.pdf" \
   -F "share=true"
 ```
 
-De respons is een array met één element:
+The response is an array with one element:
 
 ```json
 [
@@ -123,11 +123,11 @@ De respons is een array met één element:
 ]
 ```
 
-> **`files[]` werkt voor één en voor meerdere bestanden.** Het endpoint accepteert ook een enkelvoudig `file=`-veld, maar `files[]` is consistenter: precies dezelfde aanroep schaalt door naar Mode 3 hieronder zonder dat je je veldnaam hoeft aan te passen.
+> **`files[]` works for one file and for multiple files.** The endpoint also accepts a single `file=` field, but `files[]` is more consistent. The exact same call scales to Mode 3 below without changing your field name.
 
-## Mode 3: meerdere bestanden in één request
+## Mode 3: multiple files in one request
 
-Het `filesMultipart`-endpoint accepteert meerdere bestanden in één enkele request. Eén HTTP-call, één transactie, één respons-array. Handig voor publicaties met meerdere bijlagen.
+The `filesMultipart` endpoint accepts multiple files in a single request. One HTTP call, one transaction, one response array. Handy for publications with multiple attachments.
 
 ```bash
 OBJ=3422e6cd-1ba5-478c-b842-8f206f9d7358
@@ -135,35 +135,35 @@ OBJ=3422e6cd-1ba5-478c-b842-8f206f9d7358
 curl -u admin:admin \
   -X POST "http://localhost:8080/index.php/apps/openregister/api/objects/woo/onderzoeksrapporten/$OBJ/filesMultipart" \
   -H "OCS-APIRequest: true" \
-  -F "files[]=@/pad/naar/bijlage-1.pdf" \
-  -F "files[]=@/pad/naar/bijlage-2.pdf" \
-  -F "files[]=@/pad/naar/bijlage-3.pdf" \
+  -F "files[]=@/path/to/attachment-1.pdf" \
+  -F "files[]=@/path/to/attachment-2.pdf" \
+  -F "files[]=@/path/to/attachment-3.pdf" \
   -F "share=true"
 ```
 
-Respons:
+Response:
 
 ```json
 [
-  { "id": 3308, "title": "bijlage-1.pdf", "size": 29, "hash": "b753b747...", ... },
-  { "id": 3309, "title": "bijlage-2.pdf", "size": 32, "hash": "f370ad27...", ... },
-  { "id": 3310, "title": "bijlage-3.pdf", "size": 28, "hash": "80a9a215...", ... }
+  { "id": 3308, "title": "attachment-1.pdf", "size": 29, "hash": "b753b747...", ... },
+  { "id": 3309, "title": "attachment-2.pdf", "size": 32, "hash": "f370ad27...", ... },
+  { "id": 3310, "title": "attachment-3.pdf", "size": 28, "hash": "80a9a215...", ... }
 ]
 ```
 
-Elk bestand krijgt een eigen entry in de respons. De `share`-vlag geldt voor het hele batch: alle bestanden worden tegelijk publiek gemaakt of houden tegelijk privé.
+Every file gets its own entry in the response. The `share` flag applies to the whole batch. All files go public at the same time, or all stay private at the same time.
 
-**Praktische limiet:** PHP's `post_max_size` is meestal 100 MB. Het totaal van alle bestanden in één request mag daar niet overheen. Voor grotere uploads spring je naar Mode 4.
+**Practical limit:** PHP's `post_max_size` is usually 100 MB. The total of all files in one request must stay under that. For larger uploads, jump to Mode 4.
 
-## Mode 4: grote bestanden in chunks via WebDAV
+## Mode 4: large files in chunks via WebDAV
 
-Bestanden boven de PHP-uploadlimiet (typisch 100 MB) splits je in chunks en verstuur je via Nextcloud's WebDAV chunked upload-protocol. Daarna verplaats je het samengestelde bestand naar de objectmap.
+For files above the PHP upload limit (typically 100 MB) you split them into chunks and send them via Nextcloud's WebDAV chunked upload protocol. After that you move the assembled file to the object folder.
 
-Dit is hetzelfde protocol dat de Nextcloud webclient en desktop-app gebruiken. Het werkt voor alle bestandsgroottes en past zich aan netwerkonderbrekingen aan.
+This is the same protocol the Nextcloud web client and desktop app use. It works for any file size and adapts to network interruptions.
 
-### Stap 4.1: maak een transfer-map
+### Step 4.1: create a transfer folder
 
-Geef de transfer een unieke ID, bijvoorbeeld een tijdstempel:
+Give the transfer a unique ID, for example a timestamp:
 
 ```bash
 TRANSFER_ID="woo-chunked-$(date +%s)"
@@ -173,14 +173,14 @@ curl -u admin:admin \
   -X MKCOL "$DAV_BASE/uploads/admin/$TRANSFER_ID"
 ```
 
-Een 201 betekent dat de transfer-map klaar staat.
+A 201 means the transfer folder is ready.
 
-### Stap 4.2: split het bestand en upload de chunks
+### Step 4.2: split the file and upload the chunks
 
-We splitsen een testbestand van 6 MB in drie chunks van 2 MB:
+We split a 6 MB test file into three 2 MB chunks:
 
 ```bash
-split -b 2M /pad/naar/groot-rapport.pdf /tmp/chunk-
+split -b 2M /path/to/large-report.pdf /tmp/chunk-
 
 i=1
 for chunk in /tmp/chunk-*; do
@@ -192,16 +192,16 @@ for chunk in /tmp/chunk-*; do
 done
 ```
 
-De chunks krijgen vijfcijferige nummers (`00001`, `00002`, `00003`). Houd de volgorde in de bestandsnamen aan, want Nextcloud assembleert op basis daarvan.
+Chunks get five-digit numbers (`00001`, `00002`, `00003`). Keep the order in the file names, because Nextcloud assembles based on it.
 
-### Stap 4.3: assembleer en plaats in de objectmap
+### Step 4.3: assemble and place in the object folder
 
-Een MOVE-call combineert de chunks tot één bestand op de uiteindelijke locatie:
+A MOVE call combines the chunks into one file at the final location:
 
 ```bash
 OBJ=3422e6cd-1ba5-478c-b842-8f206f9d7358
-DEST="$DAV_BASE/files/admin/Open%20Registers/Woo%20Register/$OBJ/groot-rapport.pdf"
-TOTAL_LENGTH=$(wc -c < /pad/naar/groot-rapport.pdf)
+DEST="$DAV_BASE/files/admin/Open%20Registers/Woo%20Register/$OBJ/large-report.pdf"
+TOTAL_LENGTH=$(wc -c < /path/to/large-report.pdf)
 
 curl -u admin:admin \
   -X MOVE "$DAV_BASE/uploads/admin/$TRANSFER_ID/.file" \
@@ -209,9 +209,9 @@ curl -u admin:admin \
   -H "OC-Total-Length: $TOTAL_LENGTH"
 ```
 
-Een 201 betekent dat het bestand op de bestemming staat. OpenRegister pikt het automatisch op: zodra je de files-lijst van het object opvraagt, staat het bestand erbij.
+A 201 means the file is at its destination. OpenRegister picks it up automatically. As soon as you ask for the files list of the object, the file shows up.
 
-### Stap 4.4: verifieer in OpenRegister
+### Step 4.4: verify in OpenRegister
 
 ```bash
 curl -u admin:admin \
@@ -219,26 +219,26 @@ curl -u admin:admin \
   -H "OCS-APIRequest: true"
 ```
 
-Je ziet het nieuwe bestand met zijn echte grootte:
+You see the new file at its real size:
 
 ```json
 {
   "id": 3316,
-  "path": "/admin/files/Open Registers/Woo Register/3422e6cd-.../groot-rapport.pdf",
-  "title": "groot-rapport.pdf",
+  "path": "/admin/files/Open Registers/Woo Register/3422e6cd-.../large-report.pdf",
+  "title": "large-report.pdf",
   "size": 6291456,
   "hash": "d7d7eec53f6d70d1bdceea08c10d0bb1",
   "modified": "2026-05-07T05:14:34+00:00"
 }
 ```
 
-**Belangrijk:** chunks moeten naar de map van de actuele gebruiker (`admin` in dit voorbeeld). Een service-account upload je dus eerst in dat account; de MOVE plaatst het daarna in de gedeelde register-map.
+**Important:** chunks have to go to the folder of the current user (`admin` in this example). For a service account, upload into that account first. The MOVE then places the file in the shared register folder.
 
-## Publiceren en depubliceren
+## Publish and unpublish
 
-Een geüpload bestand staat standaard niet publiek (`accessUrl: null`). Bij Woo-publicaties wil je expliciet kiezen welke bestanden publiek zijn en welke niet, bijvoorbeeld omdat een bijlage privacygevoelig is en eerst gelakt moet worden.
+An uploaded file is not public by default (`accessUrl: null`). For Woo publications you want to choose explicitly which files are public and which are not, for example because an attachment is privacy-sensitive and has to be redacted first.
 
-Publiek maken:
+Make public:
 
 ```bash
 FID=3306
@@ -247,7 +247,7 @@ curl -u admin:admin \
   -H "OCS-APIRequest: true"
 ```
 
-In de respons verschijnt een `accessUrl`:
+The response now has an `accessUrl`:
 
 ```json
 {
@@ -258,7 +258,7 @@ In de respons verschijnt een `accessUrl`:
 }
 ```
 
-Weer privé maken:
+Make private again:
 
 ```bash
 curl -u admin:admin \
@@ -266,19 +266,19 @@ curl -u admin:admin \
   -H "OCS-APIRequest: true"
 ```
 
-Na depublicatie zijn `accessUrl` en `downloadUrl` weer `null` en is de share-link ingetrokken.
+After unpublishing, `accessUrl` and `downloadUrl` are `null` again and the share link is revoked.
 
-## Lijst, downloaden, verwijderen
+## List, download, delete
 
-| Actie | Methode | URL |
+| Action | Method | URL |
 | --- | --- | --- |
-| Lijst van bestanden bij een object | `GET` | `/api/objects/{register}/{schema}/{id}/files` |
-| Detail van één bestand | `GET` | `/api/objects/{register}/{schema}/{id}/files/{fileId}` |
-| Download (alle bestanden als zip) | `GET` | `/api/objects/{register}/{schema}/{id}/files/download` |
-| Download direct via id | `GET` | `/api/files/{fileId}/download` |
-| Verwijder één bestand | `DELETE` | `/api/objects/{register}/{schema}/{id}/files/{fileId}` |
+| List of files on an object | `GET` | `/api/objects/{register}/{schema}/{id}/files` |
+| Detail of one file | `GET` | `/api/objects/{register}/{schema}/{id}/files/{fileId}` |
+| Download (all files as zip) | `GET` | `/api/objects/{register}/{schema}/{id}/files/download` |
+| Download directly by id | `GET` | `/api/files/{fileId}/download` |
+| Delete one file | `DELETE` | `/api/objects/{register}/{schema}/{id}/files/{fileId}` |
 
-Voorbeeld voor een lijst:
+Example for a list:
 
 ```bash
 curl -u admin:admin \
@@ -286,7 +286,7 @@ curl -u admin:admin \
   -H "OCS-APIRequest: true"
 ```
 
-Verwijderen van één bestand:
+Delete one file:
 
 ```bash
 curl -u admin:admin \
@@ -294,55 +294,55 @@ curl -u admin:admin \
   -H "OCS-APIRequest: true"
 ```
 
-## Welke mode kies je wanneer?
+## Which mode do you pick when?
 
-| Mode | Beste voor | Limiet | Codecomplexiteit |
+| Mode | Best for | Limit | Code complexity |
 | --- | --- | --- | --- |
-| 1. JSON + base64 | Server-naar-server scripts, kleine PDF's | ≈ 75 MB ruwe inhoud (33% overhead op `post_max_size`) | Laag |
-| 2. Multipart, één bestand | Browser-uploads, gewone PDF's en DOCX | `post_max_size`, meestal 100 MB | Laag |
-| 3. Multipart, meerdere bestanden | Publicaties met meerdere bijlagen | Som van bestanden onder `post_max_size` | Laag |
-| 4. WebDAV chunked + MOVE | Video, scans, datasets > 100 MB | Geen praktische bovengrens | Hoog |
+| 1. JSON + base64 | Server-to-server scripts, small PDFs | About 75 MB raw content (33% overhead on `post_max_size`) | Low |
+| 2. Multipart, one file | Browser uploads, regular PDFs and DOCX | `post_max_size`, usually 100 MB | Low |
+| 3. Multipart, multiple files | Publications with multiple attachments | Sum of files under `post_max_size` | Low |
+| 4. WebDAV chunked + MOVE | Video, scans, datasets above 100 MB | No practical upper bound | High |
 
-Voor de meeste Woo-publicaties pak je Mode 2 of 3. Pas op het moment dat een bestand groter dan 100 MB binnenkomt, schakel je over naar Mode 4.
+For most Woo publications you pick Mode 2 or 3. The moment a file larger than 100 MB shows up, you switch to Mode 4.
 
-<Troubleshooting title="Probleemoplossing">
+<Troubleshooting title="Troubleshooting">
   <TroubleshootingItem symptom="The uploaded file exceeds upload_max_filesize">
-    Verhoog <code>upload_max_filesize</code> en <code>post_max_size</code> in <code>php.ini</code>, of stap over op Mode 4.
+    Raise <code>upload_max_filesize</code> and <code>post_max_size</code> in <code>php.ini</code>, or switch to Mode 4.
   </TroubleshootingItem>
-  <TroubleshootingItem symptom="Bestand verschijnt niet in /files-lijst na MOVE">
-    Controleer dat de <code>Destination</code>-header naar <code>{'Open Registers/{Register Title}/{Object UUID}/'}</code> wijst en dat de UUID overeenkomt met een bestaand object. OpenRegister scant alleen die map.
+  <TroubleshootingItem symptom="File does not appear in the /files list after MOVE">
+    Check that the <code>Destination</code> header points to <code>{'Open Registers/{Register Title}/{Object UUID}/'}</code> and that the UUID matches an existing object. OpenRegister scans only that folder.
   </TroubleshootingItem>
-  <TroubleshootingItem symptom="accessUrl blijft null na publish">
-    Controleer of share-links aanstaan in de Nextcloud admin (Settings → Sharing → "Allow apps to use the share API"). Zonder deze instelling kunnen publicaties geen publieke link krijgen.
+  <TroubleshootingItem symptom="accessUrl stays null after publish">
+    Check that share links are enabled in the Nextcloud admin (Settings -> Sharing -> "Allow apps to use the share API"). Without this setting, publications cannot get a public link.
   </TroubleshootingItem>
 </Troubleshooting>
 
-<NextSteps title="Volgende stap" lede="Met deze vier modes kun je elk type Woo-document koppelen aan een publicatie. Een paar logische vervolgstappen:">
+<NextSteps title="Next step" lede="With these four modes you can attach any type of Woo document to a publication. A few logical next steps:">
   <NextStep
     href="https://github.com/ConductionNL/opencatalogi"
-    title="Toon op een portaal"
-    cta="Bekijk OpenCatalogi"
+    title="Show on a portal"
+    cta="View OpenCatalogi"
   >
-    De publicatie samen met andere apps tonen op een portaal.
+    Show the publication together with other apps on a portal.
   </NextStep>
   <NextStep
     href="https://github.com/ConductionNL/docudesk"
-    title="Documenten lakken"
-    cta="Bekijk DocuDesk"
+    title="Redact documents"
+    cta="View DocuDesk"
   >
-    Documenten automatisch laten lakken op privacygevoelige passages.
+    Automatically redact documents on privacy-sensitive passages.
   </NextStep>
   <NextStep
     href="https://github.com/ConductionNL/openconnector"
-    title="Synchroniseer naar PLOOI"
-    cta="Bekijk OpenConnector"
+    title="Sync to PLOOI"
+    cta="View OpenConnector"
   >
-    Publicaties periodiek synchroniseren naar <a href="https://open.overheid.nl">open.overheid.nl</a>.
+    Periodically sync publications to <a href="https://open.overheid.nl">open.overheid.nl</a>.
   </NextStep>
 </NextSteps>
 
 <ContactCta
-  title="Wil je meer weten?"
-  body="Mail ons. We helpen je in een halve dag op weg met je eigen Woo-publicatieflow, van eerste import tot publieke share-links."
-  cta={{ label: "Mail ons", href: "mailto:info@conduction.nl?subject=Woo-publicaties" }}
+  title="Want to know more?"
+  body="Send us an email. We help you set up your own Woo publication flow in half a day, from first import to public share links."
+  cta={{ label: "Email us", href: "mailto:info@conduction.nl?subject=Woo-publicaties" }}
 />

--- a/academy/2026-05-07-woo-register-opzetten/index.mdx
+++ b/academy/2026-05-07-woo-register-opzetten/index.mdx
@@ -1,66 +1,66 @@
 ---
 slug: woo-register-opzetten
-title: Een Woo-register opzetten in OpenRegister
+title: Set up a Woo register in OpenRegister
 contentType: tutorial
 authors: [conduction]
 date: 2026-05-07
-summary: Importeer het canonieke Woo-register in OpenRegister. Eén API-aanroep, tien TOOI-categorieën, klaar om publicaties op te slaan.
-tags: [Woo, OpenRegister, Publicaties, TOOI, Open data]
+summary: Import the canonical Woo register into OpenRegister. One API call, ten TOOI categories, ready to store publications.
+tags: [Woo, OpenRegister, Publications, TOOI, Open data]
 apps: [openregister, openwoo]
 durationMinutes: 10
 ---
 
 import {Outcomes, Outcome, Prerequisites, PrerequisiteItem, ContactCta} from '@conduction/docusaurus-preset/components';
 
-De [Wet open overheid (Woo)](https://www.rijksoverheid.nl/onderwerpen/wet-open-overheid-woo) verplicht overheden om documenten openbaar te maken in elf informatiecategorieën. OpenRegister levert het opslagmodel daarvoor. In deze tutorial importeer je het canonieke Woo-register, met alle [TOOI](https://standaarden.overheid.nl/tooi)-categorieën, in een paar minuten.
+The [Dutch Open Government Act (Woo)](https://www.rijksoverheid.nl/onderwerpen/wet-open-overheid-woo) requires government bodies to publish documents in eleven information categories. OpenRegister provides the storage model for that. In this tutorial you import the canonical Woo register, with all [TOOI](https://standaarden.overheid.nl/tooi) categories, in a few minutes.
 
 {/* truncate */}
 
-<Outcomes title="Wat je leert">
-  <Outcome>Eén register met de slug <code>woo</code> in je OpenRegister-installatie aanmaken.</Outcome>
-  <Outcome>Tien schemas importeren, één per TOOI-informatiecategorie.</Outcome>
-  <Outcome>Een werkend startpunt opzetten om publicaties aan te maken en bestanden te koppelen.</Outcome>
+<Outcomes title="What you'll learn">
+  <Outcome>How to create one register with the slug <code>woo</code> in your OpenRegister installation.</Outcome>
+  <Outcome>How to import ten schemas, one per Woo information category.</Outcome>
+  <Outcome>How to set up a working starting point for creating publications and attaching files.</Outcome>
 </Outcomes>
 
-De <a href="/academy/woo-bestanden-uploaden">vervolgtutorial over bestanden uploaden</a> bouwt hierop voort.
+The <a href="/academy/woo-bestanden-uploaden">follow-up tutorial on uploading files</a> builds on this.
 
-<Prerequisites title="Wat je nodig hebt">
-  <PrerequisiteItem>Een draaiende Nextcloud met OpenRegister geïnstalleerd. Heb je dat nog niet, volg dan eerst <a href="/academy/nextcloud-lokaal-draaien">Nextcloud lokaal draaien met Docker</a>.</PrerequisiteItem>
-  <PrerequisiteItem>Een gebruiker met admin-rechten, of een gebruiker die registers mag aanmaken.</PrerequisiteItem>
-  <PrerequisiteItem><code>curl</code> of een vergelijkbare HTTP-client.</PrerequisiteItem>
+<Prerequisites title="What you need">
+  <PrerequisiteItem>A running Nextcloud with OpenRegister installed. If you do not have that yet, first follow <a href="/academy/nextcloud-lokaal-draaien">Run Nextcloud locally with Docker</a>.</PrerequisiteItem>
+  <PrerequisiteItem>A user with admin rights, or a user allowed to create registers.</PrerequisiteItem>
+  <PrerequisiteItem><code>curl</code> or a comparable HTTP client.</PrerequisiteItem>
 </Prerequisites>
 
-In de voorbeelden gebruiken we de lokale dev-omgeving op `http://localhost:8080` met `admin:admin`. Vervang dat door je eigen host en credentials.
+In the examples we use the local dev environment at `http://localhost:8080` with `admin:admin`. Replace those with your own host and credentials.
 
-## De canonieke bron
+## The canonical source
 
-Het Woo-register bestaat al, gepubliceerd door Conduction op GitHub:
+The Woo register already exists, published by Conduction on GitHub:
 
 ```
 https://raw.githubusercontent.com/ConductionNL/woo-website/main/website/static/oas/woo_register.json
 ```
 
-Het is een OpenAPI-bundel van 1.0.1, met één register (`woo`) en tien schemas. Elk schema bevat de [TOOI-metadata](https://standaarden.overheid.nl/diwoo/metadata/doc/0.9.1/diwoo-metadata-lijsten_xsd_Simple_Type_diwoo_scw_woo_informatiecategorieen) van één Woo-informatiecategorie:
+It is an OpenAPI bundle of 1.0.1, with one register (`woo`) and ten schemas. Each schema contains the [TOOI metadata](https://standaarden.overheid.nl/diwoo/metadata/doc/0.9.1/diwoo-metadata-lijsten_xsd_Simple_Type_diwoo_scw_woo_informatiecategorieen) of one Woo information category:
 
-| Slug | Categorie |
+| Slug | Category |
 | --- | --- |
-| `vergaderstukken_decentrale_overheden` | Vergaderstukken decentrale overheden |
-| `subsidieverplichtingen_anders_dan_met_beschikking` | Subsidieverplichtingen zonder beschikking |
-| `overige_besluiten_van_algemene_strekking` | Overige besluiten van algemene strekking |
-| `organisatie_en_werkwijze` | Organisatie en werkwijze |
-| `ontwerpen_van_wet_en_regelgeving_met_adviesaanvraag` | Ontwerpen van wet- en regelgeving |
-| `onderzoeksrapporten` | Onderzoeksrapporten |
-| `klachtoordelen` | Klachtoordelen |
-| `wetten_en_algemeen_verbindende_voorschriften` | Wetten en algemeen verbindende voorschriften |
-| `woo_verzoeken_en_besluiten` | Woo-verzoeken en -besluiten |
-| `convenanten` | Convenanten |
-| `agendas_en_besluitenlijsten_bestuurscolleges` | Agenda's en besluitenlijsten bestuurscolleges |
-| `vergaderstukken_staten_generaal` | Vergaderstukken Staten-Generaal |
-| `adviezen` | Adviezen |
+| `vergaderstukken_decentrale_overheden` | Meeting documents of decentralised authorities |
+| `subsidieverplichtingen_anders_dan_met_beschikking` | Subsidy obligations without a decision |
+| `overige_besluiten_van_algemene_strekking` | Other decisions of general scope |
+| `organisatie_en_werkwijze` | Organisation and working methods |
+| `ontwerpen_van_wet_en_regelgeving_met_adviesaanvraag` | Drafts of laws and regulations |
+| `onderzoeksrapporten` | Research reports |
+| `klachtoordelen` | Complaint rulings |
+| `wetten_en_algemeen_verbindende_voorschriften` | Laws and generally binding regulations |
+| `woo_verzoeken_en_besluiten` | Woo requests and decisions |
+| `convenanten` | Covenants |
+| `agendas_en_besluitenlijsten_bestuurscolleges` | Agendas and decision lists of executive boards |
+| `vergaderstukken_staten_generaal` | Meeting documents of the States General |
+| `adviezen` | Advisory reports |
 
-## Stap 1: Importeer het register
+## Step 1: Import the register
 
-OpenRegister heeft een `import/url`-endpoint dat een OpenAPI-bundel ophaalt en in één transactie omzet naar register, schemas en (optioneel) seed-objecten.
+OpenRegister has an `import/url` endpoint that fetches an OpenAPI bundle and converts it in one transaction into register, schemas, and (optionally) seed objects.
 
 ```bash
 curl -u admin:admin \
@@ -72,7 +72,7 @@ curl -u admin:admin \
   }'
 ```
 
-Als alles goed gaat, krijg je terug:
+If all goes well, you get back:
 
 ```json
 {
@@ -87,11 +87,11 @@ Als alles goed gaat, krijg je terug:
 }
 ```
 
-`registersCount: 1` en `schemasCount: 10` bevestigen dat alles is aangemaakt. De `configurationId` heb je later nodig als je de bron wilt re-syncen.
+`registersCount: 1` and `schemasCount: 10` confirm that everything was created. The `configurationId` is what you need later if you want to re-sync the source.
 
-## Stap 2: Controleer wat is aangemaakt
+## Step 2: Verify what was created
 
-Vraag de lijst van registers op en filter op slug `woo`:
+Request the list of registers and filter on slug `woo`:
 
 ```bash
 curl -u admin:admin \
@@ -99,7 +99,7 @@ curl -u admin:admin \
   -H "OCS-APIRequest: true"
 ```
 
-In de respons vind je een entry zoals:
+In the response you find an entry like:
 
 ```json
 {
@@ -108,42 +108,42 @@ In de respons vind je een entry zoals:
   "slug": "woo",
   "title": "Woo",
   "version": "1.0.1",
-  "description": "Woo-register met TOOI-informatiecategorieën",
+  "description": "Woo register with TOOI information categories",
   "schemas": [1619, 1620, 1621, 1622, 1623, 1624, 1625, 1626, 1627, 1628]
 }
 ```
 
-De `id` is je interne register-id (924 in dit voorbeeld; bij jou kan het verschillen). De slug `woo` is stabiel en gebruik je verder in alle API-aanroepen.
+The `id` is your internal register id (924 in this example, yours may differ). The slug `woo` is stable and you use it in all further API calls.
 
-In de UI vind je het register onder **Apps → OpenRegister → Registers**:
+In the UI you find the register under **Apps -> OpenRegister -> Registers**:
 
-![Het Woo-register in de OpenRegister UI, met de tien TOOI-schemas in de zijkant](./02-or-woo-register-card.png)
+![The Woo register in the OpenRegister UI, with the ten TOOI schemas in the sidebar](./02-or-woo-register-card.png)
 
-Klik op **View Details** in het Actions-menu van de kaart voor een statistiekenpaneel:
+Click **View Details** in the Actions menu of the card for a statistics panel:
 
-![Het detailpaneel met statistieken voor het Woo-register: aantal objecten, logs, files en schemas](./04-or-woo-register-detail.png)
+![The detail panel with statistics for the Woo register: number of objects, logs, files, and schemas](./04-or-woo-register-detail.png)
 
-## Stap 3: Bekijk de schemas
+## Step 3: Look at the schemas
 
-De TOOI-schemas zijn metadata-schemas. Elk schema bevat zeven velden:
+The TOOI schemas are metadata schemas. Each schema contains seven fields:
 
-| Veld | Type | Beschrijving |
+| Field | Type | Description |
 | --- | --- | --- |
-| `tooiCategorieNaam` | string (verplicht) | Naam van de categorie |
-| `tooiCategorieId` | string | TOOI-id, bijvoorbeeld `c_fdaee95e` |
-| `tooiCategorieUri` | string | Volledige TOOI-URI |
-| `tooiThemaNaam` | string | Optioneel thema |
-| `tooiThemaId` | string | Optioneel thema-id |
-| `tooiThemaUri` | string | Optioneel thema-URI |
-| `values` | array | Vrij in te vullen sleutel-waarde-paren |
+| `tooiCategorieNaam` | string (required) | Name of the category |
+| `tooiCategorieId` | string | TOOI id, for example `c_fdaee95e` |
+| `tooiCategorieUri` | string | Full TOOI URI |
+| `tooiThemaNaam` | string | Optional theme |
+| `tooiThemaId` | string | Optional theme id |
+| `tooiThemaUri` | string | Optional theme URI |
+| `values` | array | Free-form key-value pairs |
 
-De `categorieId` en `categorieUri` zijn `const` in het schema. Je hoeft ze niet zelf te vullen. OpenRegister vult ze automatisch zodra je `tooiCategorieNaam` zet.
+The `categorieId` and `categorieUri` are `const` in the schema. You do not have to fill them yourself. OpenRegister fills them automatically as soon as you set `tooiCategorieNaam`.
 
-![De Schemas-pagina in OpenRegister](./03-or-tooi-schemas.png)
+![The Schemas page in OpenRegister](./03-or-tooi-schemas.png)
 
-## Stap 4: Maak een eerste publicatie
+## Step 4: Create your first publication
 
-Test je register met één publicatie. We pakken de categorie `onderzoeksrapporten`:
+Test your register with one publication. We use the category `onderzoeksrapporten`:
 
 ```bash
 curl -u admin:admin \
@@ -155,7 +155,7 @@ curl -u admin:admin \
   }'
 ```
 
-De respons toont onder andere:
+The response shows, among other things:
 
 ```json
 {
@@ -173,17 +173,17 @@ De respons toont onder andere:
 }
 ```
 
-OpenRegister heeft de TOOI-id en URI zelf ingevuld. Het object heeft een UUID. Onthoud die UUID, want je hebt hem nodig om bestanden aan deze publicatie te koppelen.
+OpenRegister filled in the TOOI id and URI itself. The object has a UUID. Remember that UUID. You need it to attach files to this publication.
 
-## Stap 5 (optioneel): Voeg eigen velden toe
+## Step 5 (optional): Add your own fields
 
-De canonieke schemas dekken de TOOI-metadata, niet de inhoud van de publicatie zelf. Voor titel, omschrijving, datum en verantwoordelijke organisatie maak je een eigen aanvullend schema, of breid je een bestaand schema uit.
+The canonical schemas cover the TOOI metadata, not the content of the publication itself. For title, description, date, and responsible organisation, you create your own additional schema, or extend an existing one.
 
-Een minimale uitbreiding voor `onderzoeksrapporten` ziet er bijvoorbeeld zo uit:
+A minimal extension for `onderzoeksrapporten` looks like this:
 
 ```json
 {
-  "title": "Onderzoeksrapport publicatie",
+  "title": "Research report publication",
   "properties": {
     "titel": { "type": "string", "maxLength": 255 },
     "omschrijving": { "type": "string", "maxLength": 2000 },
@@ -194,21 +194,21 @@ Een minimale uitbreiding voor `onderzoeksrapporten` ziet er bijvoorbeeld zo uit:
 }
 ```
 
-Je kunt zo'n schema via `POST /api/schemas` aanmaken en daarna in de Woo-register-configuratie toevoegen. Houd het zoveel mogelijk dichtbij de [DiWoo-metadata-standaard](https://standaarden.overheid.nl/diwoo) zodat je publicaties ook door [PLOOI](https://open.overheid.nl) en [woogle.nl](https://woogle.nl) opgepikt kunnen worden.
+You can create such a schema via `POST /api/schemas` and then add it to the Woo register configuration. Keep it as close as possible to the [DiWoo metadata standard](https://standaarden.overheid.nl/diwoo) so your publications can be picked up by [PLOOI](https://open.overheid.nl) and [woogle.nl](https://woogle.nl) as well.
 
-## En nu
+## And now
 
-Je hebt:
+You have:
 
-- Een werkend Woo-register met tien TOOI-schemas
-- Eén testpublicatie met UUID
-- Een patroon om eigen velden toe te voegen waar nodig
+- A working Woo register with ten TOOI schemas
+- One test publication with a UUID
+- A pattern to add your own fields where needed
 
-In de [vervolgtutorial koppel je bestanden aan deze publicatie](/academy/woo-bestanden-uploaden), van enkele PDF's tot grote videobestanden in chunks.
+In the [follow-up tutorial you attach files to this publication](/academy/woo-bestanden-uploaden), from a few PDFs to large video files in chunks.
 
-## Opruimen
+## Cleanup
 
-Als je het testregister wilt verwijderen:
+If you want to delete the test register:
 
 ```bash
 curl -u admin:admin \
@@ -216,10 +216,10 @@ curl -u admin:admin \
   -H "OCS-APIRequest: true"
 ```
 
-Dit verwijdert het register, alle schemas en alle objecten. De configuratie-import zelf blijft bestaan, zodat je hem opnieuw kunt afspelen.
+This removes the register, all schemas, and all objects. The configuration import itself remains, so you can replay it.
 
 <ContactCta
-  title="Wil je meer weten?"
-  body="Mail ons. We helpen je in een halve dag op weg met je eigen Woo-register, inclusief publicatie-schema's en koppelingen naar bestaande systemen."
-  cta={{ label: "Mail ons", href: "mailto:info@conduction.nl?subject=Woo-register" }}
+  title="Want to know more?"
+  body="Send us an email. We help you set up your own Woo register in half a day, including publication schemas and connections to existing systems."
+  cta={{ label: "Email us", href: "mailto:info@conduction.nl?subject=Woo-register" }}
 />

--- a/i18n/nl/docusaurus-plugin-content-blog/2026-05-07-nextcloud-lokaal-draaien/index.mdx
+++ b/i18n/nl/docusaurus-plugin-content-blog/2026-05-07-nextcloud-lokaal-draaien/index.mdx
@@ -1,0 +1,230 @@
+---
+slug: nextcloud-lokaal-draaien
+title: Nextcloud lokaal draaien met Docker
+contentType: tutorial
+authors: [conduction]
+date: 2026-05-07
+summary: Drie commando's, vier stappen, een kwartier werk. Daarna draait er een schone Nextcloud op je laptop, klaar om Conduction-apps op te installeren.
+tags: [Nextcloud, Docker, Setup, Demo, Lokaal]
+durationMinutes: 15
+---
+
+import {Outcomes, Outcome, Prerequisites, PrerequisiteItem, ContactCta} from '@conduction/docusaurus-preset/components';
+
+Voor elke andere tutorial in deze academy heb je een werkende Nextcloud nodig. Dit is de snelste route: drie commando's en je draait de officiële Nextcloud-image lokaal, identiek aan productie. Geen sales-call, geen demo-omgeving die offline kan, geen custom Dockerfile. Daarna installeer je de Conduction-apps via de Nextcloud app store, hetzelfde pad als productie.
+
+{/* truncate */}
+
+<Outcomes title="Wat je leert">
+  <Outcome>Een werkende Nextcloud op <code>http://localhost:8080</code> opzetten met Docker.</Outcome>
+  <Outcome>Postgres voor data, Redis voor cache, Nextcloud voor het werk en <code>notify_push</code> voor realtime updates in één compose-bestand combineren.</Outcome>
+  <Outcome>Een admin-account aanmaken waar je naar believen Conduction-apps op installeert.</Outcome>
+  <Outcome>Met één commando de hele stack weer opruimen.</Outcome>
+</Outcomes>
+
+Daarna kun je verder met [Een Woo-register opzetten](/academy/woo-register-opzetten), [Bestanden uploaden bij een Woo-publicatie](/academy/woo-bestanden-uploaden), of een eigen experiment.
+
+<Prerequisites title="Wat je nodig hebt">
+  <PrerequisiteItem>Een laptop met minimaal 4 GB vrij geheugen.</PrerequisiteItem>
+  <PrerequisiteItem>Docker, lokaal draaiend.</PrerequisiteItem>
+  <PrerequisiteItem>Een terminal en een teksteditor.</PrerequisiteItem>
+</Prerequisites>
+
+Op een schone laptop is stap 0 (Docker installeren) ongeveer tien minuten. Daarna is stap 1 t/m 3 samen een kwartier.
+
+## Stap 0: Zorg dat Docker draait
+
+Eenmalig.
+
+- **Mac of Linux:** installeer [Docker Desktop](https://docs.docker.com/get-docker/).
+- **Windows:** zet eerst [WSL 2](https://learn.microsoft.com/nl-nl/windows/wsl/install) aan en installeer daarna Docker Desktop.
+
+Test of het werkt:
+
+```bash
+docker --version
+docker compose version
+```
+
+Allebei moeten een versie teruggeven, geen foutmelding.
+
+## Stap 1: Maak een werkmap en het compose-bestand
+
+```bash
+mkdir conduction-demo
+cd conduction-demo
+```
+
+Sla het volgende op als `docker-compose.yml` in die map:
+
+```yaml title="docker-compose.yml"
+services:
+  db:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    volumes:
+      - db:/var/lib/postgresql/data
+    environment:
+      POSTGRES_DB: nextcloud
+      POSTGRES_USER: nextcloud
+      POSTGRES_PASSWORD: nextcloud
+
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+
+  nextcloud:
+    image: nextcloud:latest
+    restart: unless-stopped
+    depends_on: [db, redis]
+    ports:
+      - "8080:80"
+    volumes:
+      - nextcloud:/var/www/html
+      - ./apps:/var/www/html/custom_apps
+    environment:
+      POSTGRES_HOST: db
+      POSTGRES_DB: nextcloud
+      POSTGRES_USER: nextcloud
+      POSTGRES_PASSWORD: nextcloud
+      REDIS_HOST: redis
+      NEXTCLOUD_TRUSTED_DOMAINS: "localhost"
+
+  notify_push:
+    image: icewind1991/notify_push:latest
+    restart: unless-stopped
+    depends_on: [nextcloud, db, redis]
+    ports:
+      - "7867:7867"
+    volumes:
+      - nextcloud:/nextcloud:ro
+    environment:
+      NEXTCLOUD_URL: http://nextcloud
+      DATABASE_URL: postgres://nextcloud:nextcloud@db/nextcloud
+      REDIS_URL: redis://redis:6379
+
+volumes:
+  db:
+  nextcloud:
+```
+
+Vier services, allemaal officiële images, geen custom build. De `./apps`-bind-mount is optioneel: handig als je een Conduction-app als zip naast de installatie wilt zetten in plaats van via de app store. `notify_push` is de WebSocket push-server die Conduction-apps gebruiken voor realtime updates — meer daarover in stap 5.
+
+## Stap 2: Start de stack
+
+```bash
+docker compose up -d
+```
+
+De eerste keer trekt Docker ongeveer 750 MB aan images binnen. Daarna start de stack in seconden.
+
+Volg de logs terwijl Nextcloud zichzelf bootstrapt:
+
+```bash
+docker compose logs -f nextcloud
+```
+
+Wacht tot je `apache2 -D FOREGROUND` of vergelijkbaar ziet, en `Ctrl+C` om de log-volger af te sluiten. De containers blijven draaien.
+
+## Stap 3: Voltooi de Nextcloud setup-wizard
+
+Open `http://localhost:8080` in je browser. Nextcloud toont een setup-wizard:
+
+1. Vul een **admin-naam** en **wachtwoord** in. `admin` en `admin` is prima voor lokaal werk; in productie natuurlijk niet.
+2. Onder **Storage & database** kies je niets, want de Postgres-config zit al in `docker-compose.yml`.
+3. Klik op **Install**.
+
+Na een halve minuut land je op het dashboard, ingelogd als admin.
+
+## Stap 4: Installeer de Conduction-apps
+
+Klik je avatar rechtsboven en kies **Apps**. De Conduction-apps staan onder **Integration** en **Office & text**. Onze suggestie voor een eerste demo:
+
+- **OpenRegister.** De typed-data foundation. Installeer deze als eerste, alle andere apps lezen ervan af.
+- **OpenCatalogi.** Maakt elk register doorzoekbaar als publieke entry. Federation naar `data.overheid.nl`.
+- **OpenConnector.** Trekt voorbeelddata binnen via REST, SOAP en file-drops.
+
+Na elke install draait de schema-bootstrap automatisch. Voorbeelddata is binnen seconden zichtbaar.
+
+Installeer ook de `notify_push`-app (onder **Integration**). Die is de Nextcloud-zijde van de WebSocket push-server die je in stap 1 al hebt gestart — je hoeft hem alleen te enabelen, geen verdere config nodig.
+
+## Stap 5: Koppel `notify_push` aan de push-server
+
+`notify_push` heeft één eenmalige setup-stap zodat de Nextcloud-app weet waar de Rust-binary draait. Voer in de werkmap uit:
+
+```bash
+docker compose exec --user www-data nextcloud php occ config:system:set redis host --value redis
+docker compose exec --user www-data nextcloud php occ config:system:set redis port --value 6379 --type integer
+docker compose exec --user www-data nextcloud php occ config:system:set memcache.distributed --value '\OC\Memcache\Redis'
+docker compose exec --user www-data nextcloud php occ config:system:set trusted_proxies 0 --value 172.16.0.0/12
+docker compose exec --user www-data nextcloud php occ notify_push:setup http://notify_push:7867
+```
+
+De eerste drie regels vertellen Nextcloud dat Redis de gedeelde cache is — `notify_push` luistert daarop voor change-events. De vierde regel markeert het Docker-netwerk als trusted zodat de push-server bij Nextcloud terugmag bellen voor authenticatie. De laatste regel registreert de URL bij de Nextcloud-app.
+
+Verifieer dat alles werkt:
+
+```bash
+docker compose exec --user www-data nextcloud php occ notify_push:self-test
+```
+
+Je krijgt een lijstje vinkjes — `redis is configured`, `push server is receiving redis messages`, `push server can connect to the Nextcloud server`, et cetera. De waarschuwing over `unencrypted http` is voor lokaal werk normaal; in productie zit `notify_push` achter dezelfde reverse proxy als Nextcloud, dus dan is dat geen issue.
+
+Vanaf nu krijgen apps die op `notify_push` luisteren — zoals OpenRegister's live-update-integratie via `@conduction/nextcloud-vue` — direct doorduwingen op object-wijzigingen, zonder dat de browser hoeft te pollen.
+
+## Wat je krijgt
+
+| Eigenschap | Waarde |
+| --- | --- |
+| Eerste boot | Ongeveer drie minuten (eerste keer 750 MB download) |
+| Volgende boots | Seconden |
+| Image | Officiële `nextcloud:latest`, identiek aan productie |
+| Geheugen | Rond 1 GB onder lichte load |
+| Reset | `docker compose down -v` (verwijdert volumes) |
+
+Geen vooraf opgenomen screencast, geen demo-omgeving die offline kan. Wat je hier ziet, is precies wat een echte klant ziet.
+
+## Reset of stoppen
+
+```bash
+# tijdelijk stoppen, data behouden
+docker compose stop
+
+# weer starten
+docker compose start
+
+# helemaal opruimen, ook volumes
+docker compose down -v
+```
+
+Na `down -v` is je laptop weer schoon. Twee minuten later kun je opnieuw beginnen.
+
+## Probleemoplossing
+
+**Apache port 8080 in gebruik:** wijzig `"8080:80"` naar bijvoorbeeld `"8081:80"` in `docker-compose.yml`. Vergeet niet de URL aan te passen naar `http://localhost:8081`.
+
+**Setup-wizard wil opnieuw beginnen:** waarschijnlijk is de Postgres-database leeg geraakt. Voer `docker compose down -v` uit en start opnieuw met `docker compose up -d`.
+
+**Nextcloud toont "Trusted domain"-foutmelding:** voeg de host toe aan `NEXTCLOUD_TRUSTED_DOMAINS` (komma-gescheiden) en herstart met `docker compose up -d`.
+
+**App-store install werkt niet:** controleer of Nextcloud naar buiten kan. In een corporate netwerk soms blokkade op `apps.nextcloud.com`. Een proxy via `HTTP_PROXY`-env-variabelen lost dit op.
+
+**`notify_push` self-test faalt op `is not trusted as a reverse proxy`:** het Docker-netwerk-bereik in jouw setup wijkt af van `172.16.0.0/12`. Bekijk het bereik met `docker network inspect $(docker network ls --filter name=conduction-demo -q) --format '{{range .IPAM.Config}}{{.Subnet}}{{end}}'` en pas de `trusted_proxies`-regel uit stap 5 aan met die subnet.
+
+**`notify_push` blijft restarten na `docker compose up -d`:** kijk in de logs (`docker compose logs notify_push`) of je `× No redis server is configured` ziet. Dat betekent dat Nextcloud's `memcache.distributed`-config nog niet op Redis staat — voer de eerste drie `occ config:system:set`-commando's uit stap 5 uit, en herstart dan met `docker compose up -d notify_push`.
+
+## Volgende stap
+
+Een werkende Nextcloud is de aanleiding voor de andere tutorials in deze serie:
+
+- [Een Woo-register opzetten](/academy/woo-register-opzetten) — importeer het canonieke Woo-register in OpenRegister
+- [Bestanden uploaden bij een Woo-publicatie](/academy/woo-bestanden-uploaden) — vier upload-modes voor documenten
+- [Build je eerste Conduction-app](/academy/build-an-app) — eindigt met een geïnstalleerde app op deze stack
+
+Stuur het `docker-compose.yml` naar een collega als je dit samen wilt zien werken.
+
+<ContactCta
+  title="Wil je meer weten?"
+  body="Mail ons. We helpen je in een halve dag op weg met je eigen Conduction-stack op Nextcloud, van eerste demo tot productie."
+  cta={{ label: "Mail ons", href: "mailto:info@conduction.nl?subject=Nextcloud%20setup" }}
+/>

--- a/i18n/nl/docusaurus-plugin-content-blog/2026-05-07-woo-bestanden-uploaden/index.mdx
+++ b/i18n/nl/docusaurus-plugin-content-blog/2026-05-07-woo-bestanden-uploaden/index.mdx
@@ -1,0 +1,348 @@
+---
+slug: woo-bestanden-uploaden
+title: Bestanden bij een Woo-publicatie uploaden
+contentType: tutorial
+authors: [conduction]
+date: 2026-05-07
+summary: Vier manieren om documenten aan een Woo-publicatie te koppelen, van één PDF tot een 6 MB rapport in chunks. Met geteste API-aanroepen.
+tags: [Woo, OpenRegister, Bestanden, Upload, Publicaties]
+apps: [openregister, openwoo]
+durationMinutes: 18
+---
+
+import {Outcomes, Outcome, Prerequisites, PrerequisiteItem, Troubleshooting, TroubleshootingItem, NextSteps, NextStep, ContactCta} from '@conduction/docusaurus-preset/components';
+
+Een Woo-publicatie zonder bestanden is metadata zonder bewijs. In deze tutorial koppel je documenten aan een Woo-publicatie via vier upload-modes: één bestand, meerdere bestanden tegelijk, en grote bestanden in chunks. Plus publiceren, depubliceren en opruimen.
+
+{/* truncate */}
+
+<Outcomes title="Wat je leert">
+  <Outcome>Vier upload-modes voor documenten bij een Woo-publicatie, van klein naar groot.</Outcome>
+  <Outcome>Wanneer je JSON+base64, multipart of WebDAV chunked upload gebruikt.</Outcome>
+  <Outcome>Hoe je bestanden publiceert, depubliceert en weer opruimt.</Outcome>
+</Outcomes>
+
+<Prerequisites title="Wat je nodig hebt">
+  <PrerequisiteItem>
+    Een werkend Woo-register. Volg eerst <a href="/academy/woo-register-opzetten">Een Woo-register opzetten</a> als je dat nog niet hebt.
+  </PrerequisiteItem>
+  <PrerequisiteItem>Een publicatie-object met bekende UUID.</PrerequisiteItem>
+  <PrerequisiteItem><code>curl</code>, basisauth, en een paar testbestanden.</PrerequisiteItem>
+</Prerequisites>
+
+In de voorbeelden gebruiken we:
+
+- Host: `http://localhost:8080`
+- Auth: `admin:admin`
+- Register-slug: `woo`
+- Schema-slug: `onderzoeksrapporten`
+- Object-UUID: `3422e6cd-1ba5-478c-b842-8f206f9d7358`
+
+Vervang het object-UUID door de jouwe.
+
+![Het Woo-register met de geïmporteerde TOOI-schemas](./01-woo-register-context.png)
+
+## Het basispatroon
+
+Alle bestanden worden gekoppeld aan een specifiek object. De URL volgt altijd hetzelfde patroon:
+
+```
+POST /index.php/apps/openregister/api/objects/{register}/{schema}/{id}/files
+```
+
+OpenRegister maakt automatisch een map aan voor het object onder `Open Registers/{Register Title}/{Object UUID}/`. Daar landen alle bestanden. De map ontstaat zodra je het eerste bestand uploadt.
+
+## Mode 1: één bestand via JSON en base64
+
+De eenvoudigste route, prima voor kleine documenten tot enkele megabytes:
+
+```bash
+OBJ=3422e6cd-1ba5-478c-b842-8f206f9d7358
+B64=$(echo "Inhoud van het rapport." | base64 -w0)
+
+curl -u admin:admin \
+  -X POST "http://localhost:8080/index.php/apps/openregister/api/objects/woo/onderzoeksrapporten/$OBJ/files" \
+  -H "OCS-APIRequest: true" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"name\": \"rapport-2026.txt\",
+    \"content\": \"$B64\",
+    \"share\": true
+  }"
+```
+
+De respons:
+
+```json
+{
+  "id": 3306,
+  "path": "/admin/files/Open Registers/Woo Register/3422e6cd-.../rapport-2026.txt",
+  "title": "rapport-2026.txt",
+  "accessUrl": "http://localhost:8080/index.php/s/CH5JsTKtrczyQgw",
+  "downloadUrl": "http://localhost:8080/index.php/s/CH5JsTKtrczyQgw/download",
+  "type": "text/plain",
+  "size": 44,
+  "hash": "4bdf3a838bc59f367824ad59a14630c0",
+  "published": "1970-01-01T00:00:00+00:00",
+  "labels": [],
+  "object": "3422e6cd-..."
+}
+```
+
+`share: true` maakt direct een publieke share-link aan. De `accessUrl` is dan meteen de publieke landings-URL. Wil je het bestand vooralsnog privé houden, laat `share` weg of zet hem op `false`.
+
+**Wanneer wel:** scripts en synchronisaties waar je tekstinhoud genereert, kleine PDF's, of CI-pipelines. **Wanneer niet:** bestanden boven enkele MB. Base64 maakt de payload 33% groter en je raakt al snel de PHP `post_max_size`-grens.
+
+## Mode 2: één bestand binair via multipart
+
+Voor binaire bestanden (PDF, DOCX, afbeeldingen) gebruik je het `filesMultipart`-endpoint. Dat scheelt de base64-overhead en is sneller voor middelgrote bestanden.
+
+```bash
+OBJ=3422e6cd-1ba5-478c-b842-8f206f9d7358
+
+curl -u admin:admin \
+  -X POST "http://localhost:8080/index.php/apps/openregister/api/objects/woo/onderzoeksrapporten/$OBJ/filesMultipart" \
+  -H "OCS-APIRequest: true" \
+  -F "files[]=@/pad/naar/rapport.pdf" \
+  -F "share=true"
+```
+
+De respons is een array met één element:
+
+```json
+[
+  {
+    "id": 3307,
+    "path": "/admin/files/Open Registers/Woo Register/3422e6cd-.../rapport.pdf",
+    "title": "rapport.pdf",
+    "type": "application/pdf",
+    "size": 482310,
+    "hash": "a4abb3649eff2d9ba4f80675371a56b8",
+    "object": "3422e6cd-..."
+  }
+]
+```
+
+> **`files[]` werkt voor één en voor meerdere bestanden.** Het endpoint accepteert ook een enkelvoudig `file=`-veld, maar `files[]` is consistenter: precies dezelfde aanroep schaalt door naar Mode 3 hieronder zonder dat je je veldnaam hoeft aan te passen.
+
+## Mode 3: meerdere bestanden in één request
+
+Het `filesMultipart`-endpoint accepteert meerdere bestanden in één enkele request. Eén HTTP-call, één transactie, één respons-array. Handig voor publicaties met meerdere bijlagen.
+
+```bash
+OBJ=3422e6cd-1ba5-478c-b842-8f206f9d7358
+
+curl -u admin:admin \
+  -X POST "http://localhost:8080/index.php/apps/openregister/api/objects/woo/onderzoeksrapporten/$OBJ/filesMultipart" \
+  -H "OCS-APIRequest: true" \
+  -F "files[]=@/pad/naar/bijlage-1.pdf" \
+  -F "files[]=@/pad/naar/bijlage-2.pdf" \
+  -F "files[]=@/pad/naar/bijlage-3.pdf" \
+  -F "share=true"
+```
+
+Respons:
+
+```json
+[
+  { "id": 3308, "title": "bijlage-1.pdf", "size": 29, "hash": "b753b747...", ... },
+  { "id": 3309, "title": "bijlage-2.pdf", "size": 32, "hash": "f370ad27...", ... },
+  { "id": 3310, "title": "bijlage-3.pdf", "size": 28, "hash": "80a9a215...", ... }
+]
+```
+
+Elk bestand krijgt een eigen entry in de respons. De `share`-vlag geldt voor het hele batch: alle bestanden worden tegelijk publiek gemaakt of houden tegelijk privé.
+
+**Praktische limiet:** PHP's `post_max_size` is meestal 100 MB. Het totaal van alle bestanden in één request mag daar niet overheen. Voor grotere uploads spring je naar Mode 4.
+
+## Mode 4: grote bestanden in chunks via WebDAV
+
+Bestanden boven de PHP-uploadlimiet (typisch 100 MB) splits je in chunks en verstuur je via Nextcloud's WebDAV chunked upload-protocol. Daarna verplaats je het samengestelde bestand naar de objectmap.
+
+Dit is hetzelfde protocol dat de Nextcloud webclient en desktop-app gebruiken. Het werkt voor alle bestandsgroottes en past zich aan netwerkonderbrekingen aan.
+
+### Stap 4.1: maak een transfer-map
+
+Geef de transfer een unieke ID, bijvoorbeeld een tijdstempel:
+
+```bash
+TRANSFER_ID="woo-chunked-$(date +%s)"
+DAV_BASE="http://localhost:8080/remote.php/dav"
+
+curl -u admin:admin \
+  -X MKCOL "$DAV_BASE/uploads/admin/$TRANSFER_ID"
+```
+
+Een 201 betekent dat de transfer-map klaar staat.
+
+### Stap 4.2: split het bestand en upload de chunks
+
+We splitsen een testbestand van 6 MB in drie chunks van 2 MB:
+
+```bash
+split -b 2M /pad/naar/groot-rapport.pdf /tmp/chunk-
+
+i=1
+for chunk in /tmp/chunk-*; do
+  CHUNK_NUM=$(printf "%05d" $i)
+  curl -u admin:admin \
+    -X PUT --data-binary "@$chunk" \
+    "$DAV_BASE/uploads/admin/$TRANSFER_ID/$CHUNK_NUM"
+  i=$((i+1))
+done
+```
+
+De chunks krijgen vijfcijferige nummers (`00001`, `00002`, `00003`). Houd de volgorde in de bestandsnamen aan, want Nextcloud assembleert op basis daarvan.
+
+### Stap 4.3: assembleer en plaats in de objectmap
+
+Een MOVE-call combineert de chunks tot één bestand op de uiteindelijke locatie:
+
+```bash
+OBJ=3422e6cd-1ba5-478c-b842-8f206f9d7358
+DEST="$DAV_BASE/files/admin/Open%20Registers/Woo%20Register/$OBJ/groot-rapport.pdf"
+TOTAL_LENGTH=$(wc -c < /pad/naar/groot-rapport.pdf)
+
+curl -u admin:admin \
+  -X MOVE "$DAV_BASE/uploads/admin/$TRANSFER_ID/.file" \
+  -H "Destination: $DEST" \
+  -H "OC-Total-Length: $TOTAL_LENGTH"
+```
+
+Een 201 betekent dat het bestand op de bestemming staat. OpenRegister pikt het automatisch op: zodra je de files-lijst van het object opvraagt, staat het bestand erbij.
+
+### Stap 4.4: verifieer in OpenRegister
+
+```bash
+curl -u admin:admin \
+  "http://localhost:8080/index.php/apps/openregister/api/objects/woo/onderzoeksrapporten/$OBJ/files" \
+  -H "OCS-APIRequest: true"
+```
+
+Je ziet het nieuwe bestand met zijn echte grootte:
+
+```json
+{
+  "id": 3316,
+  "path": "/admin/files/Open Registers/Woo Register/3422e6cd-.../groot-rapport.pdf",
+  "title": "groot-rapport.pdf",
+  "size": 6291456,
+  "hash": "d7d7eec53f6d70d1bdceea08c10d0bb1",
+  "modified": "2026-05-07T05:14:34+00:00"
+}
+```
+
+**Belangrijk:** chunks moeten naar de map van de actuele gebruiker (`admin` in dit voorbeeld). Een service-account upload je dus eerst in dat account; de MOVE plaatst het daarna in de gedeelde register-map.
+
+## Publiceren en depubliceren
+
+Een geüpload bestand staat standaard niet publiek (`accessUrl: null`). Bij Woo-publicaties wil je expliciet kiezen welke bestanden publiek zijn en welke niet, bijvoorbeeld omdat een bijlage privacygevoelig is en eerst gelakt moet worden.
+
+Publiek maken:
+
+```bash
+FID=3306
+curl -u admin:admin \
+  -X POST "http://localhost:8080/index.php/apps/openregister/api/objects/woo/onderzoeksrapporten/$OBJ/files/$FID/publish" \
+  -H "OCS-APIRequest: true"
+```
+
+In de respons verschijnt een `accessUrl`:
+
+```json
+{
+  "id": 3306,
+  "title": "rapport-2026.txt",
+  "accessUrl": "http://localhost:8080/index.php/s/CH5JsTKtrczyQgw",
+  "downloadUrl": "http://localhost:8080/index.php/s/CH5JsTKtrczyQgw/download"
+}
+```
+
+Weer privé maken:
+
+```bash
+curl -u admin:admin \
+  -X POST "http://localhost:8080/index.php/apps/openregister/api/objects/woo/onderzoeksrapporten/$OBJ/files/$FID/depublish" \
+  -H "OCS-APIRequest: true"
+```
+
+Na depublicatie zijn `accessUrl` en `downloadUrl` weer `null` en is de share-link ingetrokken.
+
+## Lijst, downloaden, verwijderen
+
+| Actie | Methode | URL |
+| --- | --- | --- |
+| Lijst van bestanden bij een object | `GET` | `/api/objects/{register}/{schema}/{id}/files` |
+| Detail van één bestand | `GET` | `/api/objects/{register}/{schema}/{id}/files/{fileId}` |
+| Download (alle bestanden als zip) | `GET` | `/api/objects/{register}/{schema}/{id}/files/download` |
+| Download direct via id | `GET` | `/api/files/{fileId}/download` |
+| Verwijder één bestand | `DELETE` | `/api/objects/{register}/{schema}/{id}/files/{fileId}` |
+
+Voorbeeld voor een lijst:
+
+```bash
+curl -u admin:admin \
+  "http://localhost:8080/index.php/apps/openregister/api/objects/woo/onderzoeksrapporten/$OBJ/files" \
+  -H "OCS-APIRequest: true"
+```
+
+Verwijderen van één bestand:
+
+```bash
+curl -u admin:admin \
+  -X DELETE "http://localhost:8080/index.php/apps/openregister/api/objects/woo/onderzoeksrapporten/$OBJ/files/3306" \
+  -H "OCS-APIRequest: true"
+```
+
+## Welke mode kies je wanneer?
+
+| Mode | Beste voor | Limiet | Codecomplexiteit |
+| --- | --- | --- | --- |
+| 1. JSON + base64 | Server-naar-server scripts, kleine PDF's | ≈ 75 MB ruwe inhoud (33% overhead op `post_max_size`) | Laag |
+| 2. Multipart, één bestand | Browser-uploads, gewone PDF's en DOCX | `post_max_size`, meestal 100 MB | Laag |
+| 3. Multipart, meerdere bestanden | Publicaties met meerdere bijlagen | Som van bestanden onder `post_max_size` | Laag |
+| 4. WebDAV chunked + MOVE | Video, scans, datasets > 100 MB | Geen praktische bovengrens | Hoog |
+
+Voor de meeste Woo-publicaties pak je Mode 2 of 3. Pas op het moment dat een bestand groter dan 100 MB binnenkomt, schakel je over naar Mode 4.
+
+<Troubleshooting title="Probleemoplossing">
+  <TroubleshootingItem symptom="The uploaded file exceeds upload_max_filesize">
+    Verhoog <code>upload_max_filesize</code> en <code>post_max_size</code> in <code>php.ini</code>, of stap over op Mode 4.
+  </TroubleshootingItem>
+  <TroubleshootingItem symptom="Bestand verschijnt niet in /files-lijst na MOVE">
+    Controleer dat de <code>Destination</code>-header naar <code>{'Open Registers/{Register Title}/{Object UUID}/'}</code> wijst en dat de UUID overeenkomt met een bestaand object. OpenRegister scant alleen die map.
+  </TroubleshootingItem>
+  <TroubleshootingItem symptom="accessUrl blijft null na publish">
+    Controleer of share-links aanstaan in de Nextcloud admin (Settings → Sharing → "Allow apps to use the share API"). Zonder deze instelling kunnen publicaties geen publieke link krijgen.
+  </TroubleshootingItem>
+</Troubleshooting>
+
+<NextSteps title="Volgende stap" lede="Met deze vier modes kun je elk type Woo-document koppelen aan een publicatie. Een paar logische vervolgstappen:">
+  <NextStep
+    href="https://github.com/ConductionNL/opencatalogi"
+    title="Toon op een portaal"
+    cta="Bekijk OpenCatalogi"
+  >
+    De publicatie samen met andere apps tonen op een portaal.
+  </NextStep>
+  <NextStep
+    href="https://github.com/ConductionNL/docudesk"
+    title="Documenten lakken"
+    cta="Bekijk DocuDesk"
+  >
+    Documenten automatisch laten lakken op privacygevoelige passages.
+  </NextStep>
+  <NextStep
+    href="https://github.com/ConductionNL/openconnector"
+    title="Synchroniseer naar PLOOI"
+    cta="Bekijk OpenConnector"
+  >
+    Publicaties periodiek synchroniseren naar <a href="https://open.overheid.nl">open.overheid.nl</a>.
+  </NextStep>
+</NextSteps>
+
+<ContactCta
+  title="Wil je meer weten?"
+  body="Mail ons. We helpen je in een halve dag op weg met je eigen Woo-publicatieflow, van eerste import tot publieke share-links."
+  cta={{ label: "Mail ons", href: "mailto:info@conduction.nl?subject=Woo-publicaties" }}
+/>

--- a/i18n/nl/docusaurus-plugin-content-blog/2026-05-07-woo-register-opzetten/index.mdx
+++ b/i18n/nl/docusaurus-plugin-content-blog/2026-05-07-woo-register-opzetten/index.mdx
@@ -1,0 +1,225 @@
+---
+slug: woo-register-opzetten
+title: Een Woo-register opzetten in OpenRegister
+contentType: tutorial
+authors: [conduction]
+date: 2026-05-07
+summary: Importeer het canonieke Woo-register in OpenRegister. Eén API-aanroep, tien TOOI-categorieën, klaar om publicaties op te slaan.
+tags: [Woo, OpenRegister, Publicaties, TOOI, Open data]
+apps: [openregister, openwoo]
+durationMinutes: 10
+---
+
+import {Outcomes, Outcome, Prerequisites, PrerequisiteItem, ContactCta} from '@conduction/docusaurus-preset/components';
+
+De [Wet open overheid (Woo)](https://www.rijksoverheid.nl/onderwerpen/wet-open-overheid-woo) verplicht overheden om documenten openbaar te maken in elf informatiecategorieën. OpenRegister levert het opslagmodel daarvoor. In deze tutorial importeer je het canonieke Woo-register, met alle [TOOI](https://standaarden.overheid.nl/tooi)-categorieën, in een paar minuten.
+
+{/* truncate */}
+
+<Outcomes title="Wat je leert">
+  <Outcome>Eén register met de slug <code>woo</code> in je OpenRegister-installatie aanmaken.</Outcome>
+  <Outcome>Tien schemas importeren, één per TOOI-informatiecategorie.</Outcome>
+  <Outcome>Een werkend startpunt opzetten om publicaties aan te maken en bestanden te koppelen.</Outcome>
+</Outcomes>
+
+De <a href="/academy/woo-bestanden-uploaden">vervolgtutorial over bestanden uploaden</a> bouwt hierop voort.
+
+<Prerequisites title="Wat je nodig hebt">
+  <PrerequisiteItem>Een draaiende Nextcloud met OpenRegister geïnstalleerd. Heb je dat nog niet, volg dan eerst <a href="/academy/nextcloud-lokaal-draaien">Nextcloud lokaal draaien met Docker</a>.</PrerequisiteItem>
+  <PrerequisiteItem>Een gebruiker met admin-rechten, of een gebruiker die registers mag aanmaken.</PrerequisiteItem>
+  <PrerequisiteItem><code>curl</code> of een vergelijkbare HTTP-client.</PrerequisiteItem>
+</Prerequisites>
+
+In de voorbeelden gebruiken we de lokale dev-omgeving op `http://localhost:8080` met `admin:admin`. Vervang dat door je eigen host en credentials.
+
+## De canonieke bron
+
+Het Woo-register bestaat al, gepubliceerd door Conduction op GitHub:
+
+```
+https://raw.githubusercontent.com/ConductionNL/woo-website/main/website/static/oas/woo_register.json
+```
+
+Het is een OpenAPI-bundel van 1.0.1, met één register (`woo`) en tien schemas. Elk schema bevat de [TOOI-metadata](https://standaarden.overheid.nl/diwoo/metadata/doc/0.9.1/diwoo-metadata-lijsten_xsd_Simple_Type_diwoo_scw_woo_informatiecategorieen) van één Woo-informatiecategorie:
+
+| Slug | Categorie |
+| --- | --- |
+| `vergaderstukken_decentrale_overheden` | Vergaderstukken decentrale overheden |
+| `subsidieverplichtingen_anders_dan_met_beschikking` | Subsidieverplichtingen zonder beschikking |
+| `overige_besluiten_van_algemene_strekking` | Overige besluiten van algemene strekking |
+| `organisatie_en_werkwijze` | Organisatie en werkwijze |
+| `ontwerpen_van_wet_en_regelgeving_met_adviesaanvraag` | Ontwerpen van wet- en regelgeving |
+| `onderzoeksrapporten` | Onderzoeksrapporten |
+| `klachtoordelen` | Klachtoordelen |
+| `wetten_en_algemeen_verbindende_voorschriften` | Wetten en algemeen verbindende voorschriften |
+| `woo_verzoeken_en_besluiten` | Woo-verzoeken en -besluiten |
+| `convenanten` | Convenanten |
+| `agendas_en_besluitenlijsten_bestuurscolleges` | Agenda's en besluitenlijsten bestuurscolleges |
+| `vergaderstukken_staten_generaal` | Vergaderstukken Staten-Generaal |
+| `adviezen` | Adviezen |
+
+## Stap 1: Importeer het register
+
+OpenRegister heeft een `import/url`-endpoint dat een OpenAPI-bundel ophaalt en in één transactie omzet naar register, schemas en (optioneel) seed-objecten.
+
+```bash
+curl -u admin:admin \
+  -X POST "http://localhost:8080/index.php/apps/openregister/api/configurations/import/url" \
+  -H "OCS-APIRequest: true" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "url": "https://raw.githubusercontent.com/ConductionNL/woo-website/main/website/static/oas/woo_register.json"
+  }'
+```
+
+Als alles goed gaat, krijg je terug:
+
+```json
+{
+  "success": true,
+  "message": "Configuration imported successfully from url",
+  "configurationId": 271,
+  "result": {
+    "registersCount": 1,
+    "schemasCount": 10,
+    "objectsCount": 0
+  }
+}
+```
+
+`registersCount: 1` en `schemasCount: 10` bevestigen dat alles is aangemaakt. De `configurationId` heb je later nodig als je de bron wilt re-syncen.
+
+## Stap 2: Controleer wat is aangemaakt
+
+Vraag de lijst van registers op en filter op slug `woo`:
+
+```bash
+curl -u admin:admin \
+  "http://localhost:8080/index.php/apps/openregister/api/registers" \
+  -H "OCS-APIRequest: true"
+```
+
+In de respons vind je een entry zoals:
+
+```json
+{
+  "id": 924,
+  "uuid": "cd44ca36-e3de-4d6f-9af9-abbb49710c83",
+  "slug": "woo",
+  "title": "Woo",
+  "version": "1.0.1",
+  "description": "Woo-register met TOOI-informatiecategorieën",
+  "schemas": [1619, 1620, 1621, 1622, 1623, 1624, 1625, 1626, 1627, 1628]
+}
+```
+
+De `id` is je interne register-id (924 in dit voorbeeld; bij jou kan het verschillen). De slug `woo` is stabiel en gebruik je verder in alle API-aanroepen.
+
+In de UI vind je het register onder **Apps → OpenRegister → Registers**:
+
+![Het Woo-register in de OpenRegister UI, met de tien TOOI-schemas in de zijkant](./02-or-woo-register-card.png)
+
+Klik op **View Details** in het Actions-menu van de kaart voor een statistiekenpaneel:
+
+![Het detailpaneel met statistieken voor het Woo-register: aantal objecten, logs, files en schemas](./04-or-woo-register-detail.png)
+
+## Stap 3: Bekijk de schemas
+
+De TOOI-schemas zijn metadata-schemas. Elk schema bevat zeven velden:
+
+| Veld | Type | Beschrijving |
+| --- | --- | --- |
+| `tooiCategorieNaam` | string (verplicht) | Naam van de categorie |
+| `tooiCategorieId` | string | TOOI-id, bijvoorbeeld `c_fdaee95e` |
+| `tooiCategorieUri` | string | Volledige TOOI-URI |
+| `tooiThemaNaam` | string | Optioneel thema |
+| `tooiThemaId` | string | Optioneel thema-id |
+| `tooiThemaUri` | string | Optioneel thema-URI |
+| `values` | array | Vrij in te vullen sleutel-waarde-paren |
+
+De `categorieId` en `categorieUri` zijn `const` in het schema. Je hoeft ze niet zelf te vullen. OpenRegister vult ze automatisch zodra je `tooiCategorieNaam` zet.
+
+![De Schemas-pagina in OpenRegister](./03-or-tooi-schemas.png)
+
+## Stap 4: Maak een eerste publicatie
+
+Test je register met één publicatie. We pakken de categorie `onderzoeksrapporten`:
+
+```bash
+curl -u admin:admin \
+  -X POST "http://localhost:8080/index.php/apps/openregister/api/objects/woo/onderzoeksrapporten" \
+  -H "OCS-APIRequest: true" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "tooiCategorieNaam": "onderzoeksrapporten"
+  }'
+```
+
+De respons toont onder andere:
+
+```json
+{
+  "id": "3422e6cd-1ba5-478c-b842-8f206f9d7358",
+  "tooiCategorieNaam": "onderzoeksrapporten",
+  "tooiCategorieId": "c_fdaee95e",
+  "tooiCategorieUri": "https://identifier.overheid.nl/tooi/def/thes/kern/c_fdaee95e",
+  "@self": {
+    "register": "924",
+    "schema": "1624",
+    "uri": "http://localhost:8080/apps/openregister/api/objects/924/1624/3422e6cd-...",
+    "owner": "admin",
+    "created": "2026-05-07T05:12:24+00:00"
+  }
+}
+```
+
+OpenRegister heeft de TOOI-id en URI zelf ingevuld. Het object heeft een UUID. Onthoud die UUID, want je hebt hem nodig om bestanden aan deze publicatie te koppelen.
+
+## Stap 5 (optioneel): Voeg eigen velden toe
+
+De canonieke schemas dekken de TOOI-metadata, niet de inhoud van de publicatie zelf. Voor titel, omschrijving, datum en verantwoordelijke organisatie maak je een eigen aanvullend schema, of breid je een bestaand schema uit.
+
+Een minimale uitbreiding voor `onderzoeksrapporten` ziet er bijvoorbeeld zo uit:
+
+```json
+{
+  "title": "Onderzoeksrapport publicatie",
+  "properties": {
+    "titel": { "type": "string", "maxLength": 255 },
+    "omschrijving": { "type": "string", "maxLength": 2000 },
+    "openbaarmakingsdatum": { "type": "string", "format": "date" },
+    "verantwoordelijkeOrganisatie": { "type": "string" }
+  },
+  "required": ["titel", "openbaarmakingsdatum"]
+}
+```
+
+Je kunt zo'n schema via `POST /api/schemas` aanmaken en daarna in de Woo-register-configuratie toevoegen. Houd het zoveel mogelijk dichtbij de [DiWoo-metadata-standaard](https://standaarden.overheid.nl/diwoo) zodat je publicaties ook door [PLOOI](https://open.overheid.nl) en [woogle.nl](https://woogle.nl) opgepikt kunnen worden.
+
+## En nu
+
+Je hebt:
+
+- Een werkend Woo-register met tien TOOI-schemas
+- Eén testpublicatie met UUID
+- Een patroon om eigen velden toe te voegen waar nodig
+
+In de [vervolgtutorial koppel je bestanden aan deze publicatie](/academy/woo-bestanden-uploaden), van enkele PDF's tot grote videobestanden in chunks.
+
+## Opruimen
+
+Als je het testregister wilt verwijderen:
+
+```bash
+curl -u admin:admin \
+  -X DELETE "http://localhost:8080/index.php/apps/openregister/api/registers/924" \
+  -H "OCS-APIRequest: true"
+```
+
+Dit verwijdert het register, alle schemas en alle objecten. De configuratie-import zelf blijft bestaan, zodat je hem opnieuw kunt afspelen.
+
+<ContactCta
+  title="Wil je meer weten?"
+  body="Mail ons. We helpen je in een halve dag op weg met je eigen Woo-register, inclusief publicatie-schema's en koppelingen naar bestaande systemen."
+  cta={{ label: "Mail ons", href: "mailto:info@conduction.nl?subject=Woo-register" }}
+/>


### PR DESCRIPTION
## Summary

Three academy posts written natively in Dutch were served under the canonical English URL (`/academy/<slug>/`). Google flagged a content-language mismatch. This PR flips them so the EN URL serves EN and `/nl/academy/<slug>/` serves the NL original.

**Files flipped:**
- `2026-05-07-nextcloud-lokaal-draaien` (230 lines, Docker setup tutorial)
- `2026-05-07-woo-bestanden-uploaden` (348 lines, file upload modes)
- `2026-05-07-woo-register-opzetten` (225 lines, register import tutorial)

**Per post:**
1. Original Dutch content copied verbatim to `i18n/nl/docusaurus-plugin-content-blog/<date-slug>/index.mdx` (now serves `/nl/academy/<slug>/`).
2. Fresh EN translation written at `academy/<date-slug>/index.mdx`, overwriting the Dutch (now serves `/academy/<slug>/`).

**Translation conventions:**
- Slugs, frontmatter keys, code blocks, container names, shell commands, REST endpoints, JSON keys, schema field names (`onderzoeksrapporten`, `tooiCategorieNaam`, etc.) all preserved verbatim.
- "Woo" expanded on first mention as "Dutch Open Government Act (Woo)", then "Woo" thereafter.
- Sentence case for headings, straight quotes, no em-dashes.
- "Gemeente" -> "municipality"; "publicatie" -> "publication"; "bestand" -> "file".
- Image paths (`./01-woo-register-context.png` etc.) unchanged. Docusaurus serves them from the EN post folder for both locales.

Completes the bilingual academy surface that wave 2 (#68, #69, #70) started. Part of ConductionNL/.github#75 SEO epic, addresses ConductionNL/.github#77.

## Test plan

- [ ] After deploy, `/academy/nextcloud-lokaal-draaien/` serves English content
- [ ] After deploy, `/nl/academy/nextcloud-lokaal-draaien/` serves Dutch content
- [ ] Same check for `woo-bestanden-uploaden` and `woo-register-opzetten`
- [ ] Image references resolve in both locales