### PR TITLE
fix(solutions/openwoo): drop Nextcloud platform from the pipeline diagram

### DIFF
--- a/src/pages/solutions/openwoo.mdx
+++ b/src/pages/solutions/openwoo.mdx
@@ -83,7 +83,6 @@ import {DetailHero, Section, SectionHead, FeatureList, FeatureItem, Pipeline, Pa
     steps={[
       {number: '01', kicker: 'Ingest',  name: 'OpenConnector', caption: 'Pulls Woo-records from your DMS via REST, SOAP, or file drops.'},
       {number: '02', kicker: 'Store',   name: 'OpenRegister',  caption: 'One typed register per Woo-categorie. Versioned, audit-logged.'},
-      {number: 'PLATFORM',              name: 'Nextcloud',     family: 'workspace', pill: 'files · users · auth', caption: 'The workspace your team already logs in to.'},
       {number: '03', kicker: 'Present', name: 'OpenCatalogi',  caption: 'Indexes every register. Search, federation, citation-stable URLs.'},
     ]}
     end={{label: 'Consumers', items: [


### PR DESCRIPTION
Tightens the Pipeline component on /solutions/openwoo/ from 4 boxes (Ingest · Store · Platform · Present) to 3 (Ingest · Store · Present). The platform step muddied the three-app flow without adding information — Nextcloud stays mentioned in the hero, FeatureList, and body copy.

One-line change in `src/pages/solutions/openwoo.mdx`.