### PR TITLE
feat(academy): publish CTO thinkpiece "Nextcloud is a platform"

### DIFF
--- a/academy/2026-05-19-the-platform-moment/index.mdx
+++ b/academy/2026-05-19-the-platform-moment/index.mdx
@@ -1,0 +1,80 @@
+---
+slug: the-platform-moment
+title: Nextcloud is a platform
+contentType: opinion
+authors: [ruben]
+date: 2026-05-19
+summary: A thinkpiece on why Nextcloud should be viewed as a platform, not a product. The sovereign-workplace bundles are the start, not the finish. Microsoft has eighteen to thirty-six months. So does Europe.
+tags: [Nextcloud, Platform, Sovereignty, AI]
+durationMinutes: 7
+---
+
+The same pattern shows up every time a software category goes through its platform moment. WordPress in 2011. Salesforce a few years earlier. Atlassian after that. The iPhone, in the consumer space, before any of them. Each one started life as a product. Each one became a platform. The companies that managed the transition own their category two decades later. The ones that did not are footnotes.
+
+I think Nextcloud is in front of that transition right now, and I do not think the field around it has noticed yet.
+
+{/* truncate */}
+
+## The pattern
+
+What turns a product into a platform is not a feature release. It is a reframe.
+
+WordPress core stayed deliberately small while the plugin ecosystem grew into a multi-billion-euro marketplace. The plugin layer became the actual product. WordPress core became infrastructure. By 2020 you could not pick anything else for anything except enterprise CMS or proprietary SaaS, not because WordPress had won on features, but because the ecosystem around it had.
+
+Salesforce AppExchange shipped in 2006. By the late 2010s, 91% of Salesforce customers were using at least one app from it. That is the actual moat under the company. Competitors do not just have to beat the CRM. They have to beat the CRM plus six thousand integrations. The AppExchange partners collectively earn multiples of what Salesforce earns directly from the marketplace. Both win in the same outcome.
+
+The iPhone won smartphones not by being a better phone. It won by being declared "the platform that runs apps" before that was technically true. By 2010 every other platform either copied the App Store model or died. The naming preceded the platform reality by years. The naming was load-bearing.
+
+SharePoint is the cautionary case. Microsoft positioned it as the platform for a decade. The technical surface supported it. The marketing budget supported it. The architecture and the economics did not. SharePoint never produced an ecosystem. It stayed a product. Power Platform displaced it as Microsoft's positioned platform for business apps.
+
+Five cases. One pattern. Each one is the same shape.
+
+## Why Nextcloud sits in this position
+
+The substrate for a workplace platform sits in Nextcloud Hub today. It just is not framed as substrate.
+
+Files. Calendar. Contacts. Talk. Mail. An identity layer that already speaks LDAP, SAML, and OIDC. A permission model that runs across all of them. Every business app needs these primitives. Nextcloud ships them already integrated, in one product, with one access control surface. ExApps adds the second piece: a production-grade pattern for running anything, in any language, as an integrated app inside the workspace. Two to three hundred thousand servers. Several hundred apps in the store. ISO 27001. Blauer Engel. EU data hosting by default. None of these are decisions still to be made. They already shipped.
+
+The sovereign-workplace push around openDesk, Mijn Bureau, La Suite Numérique, and the Bechtle-Nextcloud offering uses Nextcloud as a core component. Schleswig-Holstein moved 40,000 civil servants off Microsoft in October 2025 with openDesk as the collaboration layer. The Bundeswehr signed a seven-year agreement. The Robert Koch Institute and the International Criminal Court run on it. The deployments are real and at scale.
+
+What none of those bundles do, yet, is frame Nextcloud as the platform underneath the suite. They frame it as one of several components in a bundle. The frame is correct for the moment of cutover from Microsoft. It will not be correct three years later.
+
+## The bundle is not the workspace
+
+Year one, a buyer asks "can I replace Microsoft." Year three, they ask "where does my organisation run."
+
+A bundle answers the first question. It does not answer the second. A bundle ships a fixed set of tools, with the integration between them happening in the user's head or in their browser tabs. A workspace is a different thing: the unified surface where people work, with the platform underneath it that hosts everything else. Tools, data, AI, the hundreds of small workflows every organisation runs that are too small for IT to formalise and too operational to outsource. Leave requests. Equipment loans. Visitor registration. Hardware inventory. Vendor onboarding. The long tail.
+
+The vendor that answers year three wins the relationship. Nextcloud-as-bundle does not. Nextcloud-as-platform does. That reframe is the thing I think is overdue.
+
+## AI as substrate, not as a checkbox
+
+AI changes the calculus on local data, and not in the direction most workplace vendors want it to.
+
+Microsoft Copilot routes user data to Azure for inference. Google Workspace does the same, to Google Cloud. Both have built sovereign-cloud variants — Bleu in France through a Capgemini and Orange joint venture, Delos in Germany through SAP and Telekom, Microsoft Cloud for Sovereignty as the umbrella programme — and these variants are serious engineering efforts. They reduce the surface of exposure. They do not eliminate it. The CLOUD Act still applies to Microsoft itself, even when European partners operate the infrastructure. The structural problem is jurisdictional, not contractual.
+
+For most market segments, the partial-sovereignty pitch will be enough. For the buyers who chose openDesk and Mijn Bureau specifically because the architecture matters, it will not be. They picked the suite path for a reason.
+
+An open workplace architecture inverts the problem. The data is already on infrastructure the customer controls. The AI substrate comes to the data, not the other way around. Local LLM endpoints. Retrieval indexing across the workspace. Tools that expose registers to models under the user's session, audit-logged at every step, with the operator choosing the model. Mistral on-premise. A self-hosted Llama variant. Or, where policy allows, a commodity API. The architecture supports the operator's policy choices, not the vendor's.
+
+The features are competitive. The architecture is structurally different. The structural difference shows up in every procurement evaluation that takes sovereignty seriously. This is the part where Nextcloud's position compounds. Microsoft cannot win on sovereignty for the buyers who care most about it. Microsoft can absolutely win on time-to-value and ecosystem depth, which is what they are spending five years and significant capital trying to do. The race is over which structural advantage matters more for which buyer.
+
+## The Microsoft clock
+
+A bit of context on the size of the other side. Power Platform was at 33 million monthly active users in 2023. 48 million in 2024. 56 million in 2025. Microsoft has named 500 million by the end of the decade as their public target. 97% of Fortune 500 companies use Power Platform in some capacity. The 2026 release wave unifies Power Apps, Power Automate, Power Pages, Copilot Studio, and Dataverse into one AI-native citizen-developer story. The framing they use internally is "low code is dead": apps start as conversations with Copilot and quietly become React.
+
+Europe has, by my read, somewhere between eighteen and thirty-six months to ship a credible architectural answer. After that window closes, citizen developers in European organisations will have trained on the Microsoft stack, and switching costs become real in a way no sales motion fixes. Mindshare is the most important window. It is the one that closes the fastest.
+
+## What needs to be true
+
+The architectural answer exists in pieces. The sovereign-workplace bundles are one piece. Open-source workflow tools — Windmill, n8n, OpenProject — are another. Open-weight LLMs hosted in Europe are a third. The composition layer that lets a non-developer in a municipality ship a leave-request app in an afternoon is the piece most still missing in production. It is the piece we are building at Conduction, in the open, as [OpenBuilt](/apps/openbuilt). It is not the only such piece that needs to ship. It is one.
+
+The other thing that needs to be true is naming. Steve Jobs did not market the iPhone as a phone with extensible features. He positioned it as the platform that runs apps, years before the platform reality fully shipped. The naming was load-bearing. It still is.
+
+Nextcloud-as-platform is true today in every structural sense that matters. What is missing is for the company, the ecosystem, and the buyers to all describe it that way out loud.
+
+## A personal note
+
+I have spent four quarters of my company's runway building toward this view. It is not a quiet view. I am writing it down because I think the architectural argument is settled, the competitive window is open, and the next move belongs to people who can see the shape of the moment clearly. That includes Nextcloud's team. That includes the buyers running European sovereign-workplace migrations. That includes peer companies in the open-source workplace stack.
+
+If you read this and disagree, I would genuinely like to hear why. ruben@conduction.nl.

--- a/academy/authors.yml
+++ b/academy/authors.yml
@@ -4,3 +4,13 @@ conduction:
   url: https://conduction.nl
   image_url: https://github.com/ConductionNL.png
   page: true
+
+ruben:
+  name: Ruben van der Linde
+  title: CTO, Conduction
+  url: https://github.com/rubenvdlinde
+  image_url: https://github.com/rubenvdlinde.png
+  page: true
+  socials:
+    github: rubenvdlinde
+    email: ruben@conduction.nl

--- a/src/pages/connext.mdx
+++ b/src/pages/connext.mdx
@@ -103,6 +103,18 @@ import {APP_COUNT, ECOSYSTEM_COUNT} from '@site/src/data/apps-catalog';
   />
 </PlatformOverview>
 
+<Section spacing="default">
+  <SectionHead
+    eyebrow="The bigger picture"
+    title={<>This is not an app shelf.<br/>It is <span className="next-blue">Nextcloud</span> as a platform.</>}
+    align="stack"
+    lede={<>The sovereign-workplace bundles are the start, not the finish. Microsoft has spent five years training a generation of citizen developers on Power Platform; Europe has eighteen to thirty-six months to ship a credible architectural answer. Our CTO wrote down why we think the shape of that answer is already sitting in front of us.</>}
+  />
+  <p style={{textAlign: 'center', marginTop: 'var(--space-6)', marginBottom: 0}}>
+    <a href="/academy/the-platform-moment" style={{fontSize: 17, fontWeight: 600, color: 'var(--c-cobalt-700)', textDecoration: 'underline', textUnderlineOffset: '6px', textDecorationThickness: '2px'}}>Read the thinkpiece</a>
+  </p>
+</Section>
+
 <Showcase
   eyebrow="Plays well with the workspace"
   title="Seven ecosystems, one workspace."


### PR DESCRIPTION
## Summary

Publishes a 7-minute opinion piece by Ruben (CTO) on why Nextcloud is in front of a product-to-platform transition — the same one WordPress, Salesforce, Atlassian and the iPhone each went through.

### Adds

- **/academy/the-platform-moment** — full thinkpiece, opinion contentType, tagged Nextcloud / Platform / Sovereignty / AI.
- `academy/authors.yml` — adds Ruben as an academy author so the post has a proper byline.
- `/connext` — new "The bigger picture" section between the platform overview and the integrations showcase, linking to the thinkpiece.

## Test plan

- [x] npm run start compiles cleanly
- [x] /academy/the-platform-moment renders, page title "Nextcloud is a platform | Conduction", zero console errors
- [x] /connext "Read the thinkpiece" link resolves to the post