### PR TITLE
fix(ai-baseline): point FAQPage check at /quality after /iso rename

### DIFF
--- a/scripts/validate-ai-baseline.mjs
+++ b/scripts/validate-ai-baseline.mjs
@@ -221,8 +221,8 @@ check('/support has FAQPage JSON-LD with >= 5 questions', () =>
 check('/install has FAQPage JSON-LD with >= 5 questions', () =>
   checkFaqPage('install', '/install', 5));
 
-check('/iso has FAQPage JSON-LD with >= 5 questions', () =>
-  checkFaqPage('iso', '/iso', 5));
+check('/quality has FAQPage JSON-LD with >= 5 questions', () =>
+  checkFaqPage('quality', '/quality', 5));
 
 /* Per-app SoftwareApplication regression marker */
 check('/apps/openregister has SoftwareApplication JSON-LD', () => {


### PR DESCRIPTION
Follow-up to #77. The AI-baseline regression script still pointed the FAQPage JSON-LD check at /iso. Since /iso is now a meta-refresh stub to /quality, the check unconditionally fails. Updates the check to /quality, where the new FAQPage block lives (7 Q&A).