### PR TITLE
feat(quality): redesign hero with DetailHero (cobalt) like openregister.conduction.nl

### DIFF
--- a/i18n/nl/docusaurus-plugin-content-pages/quality.mdx
+++ b/i18n/nl/docusaurus-plugin-content-pages/quality.mdx
@@ -4,16 +4,75 @@ description: Het kwaliteitsmanagementsysteem van Conduction. ISO 9001:2015 en IS
 hide_table_of_contents: true
 ---
 
-import {Section, SectionHead, Showcase, FAQ, FAQItem} from '@conduction/docusaurus-preset/components';
+import {DetailHero, Section, SectionHead, Showcase, FAQ, FAQItem} from '@conduction/docusaurus-preset/components';
 
-<Section spacing="default">
-  <SectionHead
-    eyebrow="Kwaliteitsmanagement"
-    title="Eén systeem. Vier tools die het waarmaken."
-    align="stack"
-    lede="Conduction werkt met één geïntegreerd kwaliteits- en informatiebeveiligingsmanagementsysteem. ISO 9001:2015 en ISO 27001:2022 verankeren de beleidskaders, pentest-tools.com verzorgt de doorlopende externe scans, en het volledige bouwproces staat publiek op GitHub. Samen leveren ze scope, audittrail en doorlopende borging voor elke Conduction-app."
-  />
-</Section>
+export const QualityIcon = (
+  <svg viewBox="0 0 24 24">
+    <path d="M12 2 4 6v6c0 4.4 3.4 8.5 8 10 4.6-1.5 8-5.6 8-10V6l-8-4z" />
+    <path d="m9 12 2 2 4-4" />
+  </svg>
+);
+
+export const QualityHeroIllustration = (
+  <div style={{
+    background: 'rgba(255,255,255,0.06)',
+    border: '1px solid rgba(255,255,255,0.15)',
+    borderRadius: 12,
+    padding: 24,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 16,
+    minHeight: 320,
+  }}>
+    <div style={{
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      fontFamily: 'var(--conduction-typography-font-family-code)',
+      fontSize: 10,
+      letterSpacing: '0.08em',
+      textTransform: 'uppercase',
+      color: 'rgba(255,255,255,0.65)',
+    }}>
+      <span>Certificaten · scans · workflow</span>
+      <span style={{color: 'var(--c-mint-300)'}}>● live</span>
+    </div>
+    <div style={{display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12}}>
+      <div style={{background: 'white', borderRadius: 4, padding: 6, boxShadow: '0 4px 12px rgba(0,0,0,0.2)'}}>
+        <img src="/img/certificates/iso-9001-2015.png" alt="ISO 9001:2015 certificaat" style={{width: '100%', height: 'auto', display: 'block', borderRadius: 2}} />
+        <div style={{fontSize: 9, fontWeight: 700, color: 'var(--c-cobalt-900)', textAlign: 'center', marginTop: 4, letterSpacing: '0.04em'}}>ISO 9001:2015</div>
+      </div>
+      <div style={{background: 'white', borderRadius: 4, padding: 6, boxShadow: '0 4px 12px rgba(0,0,0,0.2)'}}>
+        <img src="/img/certificates/iso-27001-2022.png" alt="ISO 27001:2022 certificaat" style={{width: '100%', height: 'auto', display: 'block', borderRadius: 2}} />
+        <div style={{fontSize: 9, fontWeight: 700, color: 'var(--c-cobalt-900)', textAlign: 'center', marginTop: 4, letterSpacing: '0.04em'}}>ISO 27001:2022</div>
+      </div>
+    </div>
+    <div style={{display: 'flex', flexDirection: 'column', gap: 8}}>
+      <div style={{display: 'flex', alignItems: 'center', justifyContent: 'space-between', fontFamily: 'var(--conduction-typography-font-family-code)', fontSize: 11, color: 'rgba(255,255,255,0.85)'}}>
+        <span>pentest-tools.com · wekelijkse scan</span>
+        <span style={{background: 'var(--c-mint-500)', color: 'var(--c-cobalt-900)', padding: '2px 8px', borderRadius: 3, fontWeight: 700, fontSize: 9, letterSpacing: '0.05em'}}>SCHOON</span>
+      </div>
+      <div style={{display: 'flex', alignItems: 'center', justifyContent: 'space-between', fontFamily: 'var(--conduction-typography-font-family-code)', fontSize: 11, color: 'rgba(255,255,255,0.85)'}}>
+        <span>GitHub PR #482 · code- en security-review</span>
+        <span style={{background: 'var(--c-mint-500)', color: 'var(--c-cobalt-900)', padding: '2px 8px', borderRadius: 3, fontWeight: 700, fontSize: 9, letterSpacing: '0.05em'}}>GEMERGED</span>
+      </div>
+    </div>
+  </div>
+);
+
+<DetailHero
+  background="cobalt"
+  crumb={[{label: 'Over ons', href: '/about'}, 'Kwaliteit']}
+  locales="ISO 9001:2015 · ISO 27001:2022"
+  title="Kwaliteit."
+  tagline={<>Eén geïntegreerd kwaliteits- en informatiebeveiligingsmanagementsysteem. ISO 9001:2015 en ISO 27001:2022 verankeren de beleidskaders, pentest-tools.com verzorgt de doorlopende externe scans, en het volledige bouwproces staat publiek op GitHub. Samen leveren ze scope, audittrail en doorlopende borging voor elke Conduction-app.</>}
+  primaryCta={{label: 'Lees de beleidsverklaring', href: '#iso-certifications', tone: 'orange'}}
+  secondaryCta={{label: 'Compliance FAQ', href: '#compliance-faq'}}
+  tertiaryCta={{label: 'Vraag een certificaat aan', href: 'mailto:info@conduction.nl?subject=Kwaliteitscertificaat%20aanvraag'}}
+  iconColor="var(--c-orange-knvb)"
+  icon={QualityIcon}
+  illustration={QualityHeroIllustration}
+/>
 
 <div id="quality-tools" />
 <Showcase
@@ -208,6 +267,7 @@ Heeft je inkoopdossier de echte certificaten, de Verklaring van Toepasselijkheid
 
 </Section>
 
+<div id="compliance-faq" />
 <FAQ title="Compliance FAQ.">
   <FAQItem question="Wat is het verschil tussen ISO 9001 en ISO 27001?" defaultOpen>
     ISO 9001:2015 dekt kwaliteitsmanagement: hoe we ons werk plannen, bouwen, leveren en verbeteren. ISO 27001:2022 dekt informatiebeveiliging: hoe we risico's voor de data die we onder ons hebben identificeren, mitigeren en auditen. De meeste inkoopdossiers vragen om beide. Wij zijn voor beide gecertificeerd door dezelfde externe auditor, op dezelfde jaarcyclus.

--- a/src/pages/quality.mdx
+++ b/src/pages/quality.mdx
@@ -4,16 +4,75 @@ description: Conduction's quality management system. ISO 9001:2015 and ISO 27001
 hide_table_of_contents: true
 ---
 
-import {Section, SectionHead, Showcase, FAQ, FAQItem} from '@conduction/docusaurus-preset/components';
+import {DetailHero, Section, SectionHead, Showcase, FAQ, FAQItem} from '@conduction/docusaurus-preset/components';
 
-<Section spacing="default">
-  <SectionHead
-    eyebrow="Quality management"
-    title="One system. Four tools that prove it works."
-    align="stack"
-    lede="Conduction operates one integrated quality and information-security management system. ISO 9001:2015 and ISO 27001:2022 anchor the policies, pentest-tools.com runs the continuous scans, and the entire build flow lives in public on GitHub. Together they cover scope, audit trail, and ongoing assurance for every Conduction app."
-  />
-</Section>
+export const QualityIcon = (
+  <svg viewBox="0 0 24 24">
+    <path d="M12 2 4 6v6c0 4.4 3.4 8.5 8 10 4.6-1.5 8-5.6 8-10V6l-8-4z" />
+    <path d="m9 12 2 2 4-4" />
+  </svg>
+);
+
+export const QualityHeroIllustration = (
+  <div style={{
+    background: 'rgba(255,255,255,0.06)',
+    border: '1px solid rgba(255,255,255,0.15)',
+    borderRadius: 12,
+    padding: 24,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 16,
+    minHeight: 320,
+  }}>
+    <div style={{
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      fontFamily: 'var(--conduction-typography-font-family-code)',
+      fontSize: 10,
+      letterSpacing: '0.08em',
+      textTransform: 'uppercase',
+      color: 'rgba(255,255,255,0.65)',
+    }}>
+      <span>Certificates · scans · workflow</span>
+      <span style={{color: 'var(--c-mint-300)'}}>● live</span>
+    </div>
+    <div style={{display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12}}>
+      <div style={{background: 'white', borderRadius: 4, padding: 6, boxShadow: '0 4px 12px rgba(0,0,0,0.2)'}}>
+        <img src="/img/certificates/iso-9001-2015.png" alt="ISO 9001:2015 certificate" style={{width: '100%', height: 'auto', display: 'block', borderRadius: 2}} />
+        <div style={{fontSize: 9, fontWeight: 700, color: 'var(--c-cobalt-900)', textAlign: 'center', marginTop: 4, letterSpacing: '0.04em'}}>ISO 9001:2015</div>
+      </div>
+      <div style={{background: 'white', borderRadius: 4, padding: 6, boxShadow: '0 4px 12px rgba(0,0,0,0.2)'}}>
+        <img src="/img/certificates/iso-27001-2022.png" alt="ISO 27001:2022 certificate" style={{width: '100%', height: 'auto', display: 'block', borderRadius: 2}} />
+        <div style={{fontSize: 9, fontWeight: 700, color: 'var(--c-cobalt-900)', textAlign: 'center', marginTop: 4, letterSpacing: '0.04em'}}>ISO 27001:2022</div>
+      </div>
+    </div>
+    <div style={{display: 'flex', flexDirection: 'column', gap: 8}}>
+      <div style={{display: 'flex', alignItems: 'center', justifyContent: 'space-between', fontFamily: 'var(--conduction-typography-font-family-code)', fontSize: 11, color: 'rgba(255,255,255,0.85)'}}>
+        <span>pentest-tools.com · weekly scan</span>
+        <span style={{background: 'var(--c-mint-500)', color: 'var(--c-cobalt-900)', padding: '2px 8px', borderRadius: 3, fontWeight: 700, fontSize: 9, letterSpacing: '0.05em'}}>CLEAN</span>
+      </div>
+      <div style={{display: 'flex', alignItems: 'center', justifyContent: 'space-between', fontFamily: 'var(--conduction-typography-font-family-code)', fontSize: 11, color: 'rgba(255,255,255,0.85)'}}>
+        <span>GitHub PR #482 · code + security review</span>
+        <span style={{background: 'var(--c-mint-500)', color: 'var(--c-cobalt-900)', padding: '2px 8px', borderRadius: 3, fontWeight: 700, fontSize: 9, letterSpacing: '0.05em'}}>MERGED</span>
+      </div>
+    </div>
+  </div>
+);
+
+<DetailHero
+  background="cobalt"
+  crumb={[{label: 'About', href: '/about'}, 'Quality']}
+  locales="ISO 9001:2015 · ISO 27001:2022"
+  title="Quality."
+  tagline={<>One integrated quality and information-security management system. ISO 9001:2015 and ISO 27001:2022 anchor the policies, pentest-tools.com runs the continuous scans, and the entire build flow lives in public on GitHub. Together they cover scope, audit trail, and ongoing assurance for every Conduction app.</>}
+  primaryCta={{label: 'Read the policy', href: '#iso-certifications', tone: 'orange'}}
+  secondaryCta={{label: 'Compliance FAQ', href: '#compliance-faq'}}
+  tertiaryCta={{label: 'Request a certificate', href: 'mailto:info@conduction.nl?subject=Quality%20certificate%20request'}}
+  iconColor="var(--c-orange-knvb)"
+  icon={QualityIcon}
+  illustration={QualityHeroIllustration}
+/>
 
 <div id="quality-tools" />
 <Showcase
@@ -205,6 +264,7 @@ If your procurement file needs the actual certificates, the Statement of Applica
 
 </Section>
 
+<div id="compliance-faq" />
 <FAQ title="Compliance FAQ.">
   <FAQItem question="What is the difference between ISO 9001 and ISO 27001?" defaultOpen>
     ISO 9001:2015 covers quality management: how we plan, build, deliver, and improve our work. ISO 27001:2022 covers information security: how we identify, mitigate, and audit risks to data we hold. Most procurement files want both. We are certified against both, by the same external auditor, on the same annual cycle.


### PR DESCRIPTION
Replaces the plain SectionHead at the top of /quality with the preset `<DetailHero background="cobalt">` — full-bleed cobalt panel, hex-icon + breadcrumb + metadata line, three CTAs, and a right-side illustration showing the two ISO cert thumbnails plus live pentest + GitHub status indicators. Brings /quality in line with the visual identity used on the per-app docs landings (openregister.conduction.nl is the reference).

- Title: "Quality." (NL: "Kwaliteit.")
- Crumb: About / Quality (NL: Over ons / Kwaliteit)
- Metadata line: ISO 9001:2015 · ISO 27001:2022
- CTAs: Read the policy (orange) · Compliance FAQ · Request a certificate
- Illustration: cert thumbnails + pentest CLEAN + GitHub MERGED rows
- Adds `id="compliance-faq"` anchor for the secondary CTA target

Production build green for both EN and NL; visual verified against served build on both locales.