### PR TITLE
feat(quality): drop request-cert CTA, restructure policy text for readability

### DIFF
--- a/i18n/nl/docusaurus-plugin-content-pages/quality.mdx
+++ b/i18n/nl/docusaurus-plugin-content-pages/quality.mdx
@@ -68,7 +68,6 @@ export const QualityHeroIllustration = (
   tagline={<>Eén geïntegreerd kwaliteits- en informatiebeveiligingsmanagementsysteem. ISO 9001:2015 en ISO 27001:2022 verankeren de beleidskaders, pentest-tools.com verzorgt de doorlopende externe scans, en het volledige bouwproces staat publiek op GitHub. Samen leveren ze scope, audittrail en doorlopende borging voor elke Conduction-app.</>}
   primaryCta={{label: 'Lees de beleidsverklaring', href: '#iso-certifications', tone: 'orange'}}
   secondaryCta={{label: 'Compliance FAQ', href: '#compliance-faq'}}
-  tertiaryCta={{label: 'Vraag een certificaat aan', href: 'mailto:info@conduction.nl?subject=Kwaliteitscertificaat%20aanvraag'}}
   iconColor="var(--c-orange-knvb)"
   icon={QualityIcon}
   illustration={QualityHeroIllustration}
@@ -192,7 +191,7 @@ export const QualityHeroIllustration = (
 
 ### Beleidsverklaring kwaliteits- en informatieveiligheidsmanagementsysteem
 
-_Conduction B.V. — vastgesteld januari 2025. ISO 9001:2015 en ISO 27001:2022 certificaten afgegeven 24 juli 2025._
+_Conduction B.V. — vastgesteld januari 2025. ISO 9001:2015 en ISO 27001:2022 certificaten afgegeven 24 juli 2025. Tekst overgenomen uit de ondertekende beleidsverklaring._
 
 Conduction, opgericht in 2018, streeft naar een betere digitale wereld door democratische, inclusieve en transparante software te ontwikkelen volgens de Common Ground-principes. Als Digital Socials richten we ons op het creëren van digitale oplossingen voor maatschappelijke vraagstukken, met 'Tech to serve people' als leidraad.
 
@@ -263,7 +262,7 @@ Naast de twee ISO-certificeringen, de pentest-scans en de GitHub-workflow ziet h
 
 ## Bewijs opvragen
 
-Heeft je inkoopdossier de echte certificaten, de Verklaring van Toepasselijkheid, een recent pentestrapport of een interne auditrapportage nodig, mail dan naar [info@conduction.nl](mailto:info@conduction.nl) met je contract- of aanbestedingsreferentie. We sturen de stukken direct toe.
+De certificaten hierboven zijn de originele ISO 9001:2015- en ISO 27001:2022-documenten — klik op de afbeeldingen voor de scans in volle resolutie. Heeft je inkoopdossier de Verklaring van Toepasselijkheid, een recent pentestrapport of een interne auditrapportage nodig, mail dan naar [info@conduction.nl](mailto:info@conduction.nl) met je contract- of aanbestedingsreferentie. Die stukken sturen we direct toe.
 
 </Section>
 
@@ -287,7 +286,7 @@ Heeft je inkoopdossier de echte certificaten, de Verklaring van Toepasselijkheid
   <FAQItem question="Wat dekt het ISO 27001-certificaat op commonground.nu?">
     De managed Common Ground-omgeving draait op infrastructuur van Cyso onder ISAE 3402 Type II. Het ISO 27001-certificaat van Conduction dekt de applicatielaag (de Conduction-apps, de ontwikkelpipeline, de operatieworkflows), de ISAE van Cyso dekt de hostinglaag (datacenters, netwerk, hypervisor). Samen dekken ze de volledige stack die een overheidsklant op commonground.nu afneemt.
   </FAQItem>
-  <FAQItem question="Krijg ik een kopie van het certificaat, de Verklaring van Toepasselijkheid of een pentestrapport?">
-    Ja. Mail naar info@conduction.nl met je contract- of aanbestedingsreferentie. We sturen de actuele certificaten, de VvT, het meest recente interne auditrapport en de relevante pentest-samenvatting direct toe. We publiceren deze stukken niet standaard op de publieke site, omdat we willen vastleggen wie ze opvraagt.
+  <FAQItem question="Krijg ik een kopie van de Verklaring van Toepasselijkheid of een pentestrapport?">
+    De ISO 9001:2015- en ISO 27001:2022-certificaten zelf staan op deze pagina — klik op de afbeeldingen voor de scans in volle resolutie. Voor de VvT, het meest recente interne auditrapport of de relevante pentest-samenvatting kun je mailen naar info@conduction.nl met je contract- of aanbestedingsreferentie. Die stukken sturen we direct toe, omdat we willen vastleggen wie ze opvraagt.
   </FAQItem>
 </FAQ>

--- a/src/pages/quality.mdx
+++ b/src/pages/quality.mdx
@@ -68,7 +68,6 @@ export const QualityHeroIllustration = (
   tagline={<>One integrated quality and information-security management system. ISO 9001:2015 and ISO 27001:2022 anchor the policies, pentest-tools.com runs the continuous scans, and the entire build flow lives in public on GitHub. Together they cover scope, audit trail, and ongoing assurance for every Conduction app.</>}
   primaryCta={{label: 'Read the policy', href: '#iso-certifications', tone: 'orange'}}
   secondaryCta={{label: 'Compliance FAQ', href: '#compliance-faq'}}
-  tertiaryCta={{label: 'Request a certificate', href: 'mailto:info@conduction.nl?subject=Quality%20certificate%20request'}}
   iconColor="var(--c-orange-knvb)"
   icon={QualityIcon}
   illustration={QualityHeroIllustration}
@@ -196,11 +195,27 @@ _ISO 9001:2015 §5.2 — Quality Policy. Certificates first issued 24 July 2025.
 
 Conduction is committed to delivering high-quality open-source software and services for digital government infrastructure. Our Quality Management System (QMS) is designed to consistently meet customer requirements and applicable regulatory requirements, and to enhance customer satisfaction.
 
-**Scope.** The design, development, implementation, and support of open-source software solutions for digital government infrastructure, delivered from the Netherlands by Conduction B.V. employees and contractors — including remote workers. Excluded: hardware manufacturing, physical product distribution.
+#### Scope
 
-**Quality objectives.** Support tickets acknowledged within one business day. Every pull request passes the automated quality gates before merge. At least two process improvements implemented per quarter. Every employee reviewed annually against the competence matrix.
+The design, development, implementation, and support of open-source software solutions for digital government infrastructure, delivered from the Netherlands by Conduction B.V. employees and contractors — including remote workers.
 
-**Commitment.** Conduction's management commits to (1) providing the resources necessary to establish, implement, maintain, and continually improve the QMS, (2) communicating the importance of effective quality management and conforming to QMS requirements, (3) ensuring this policy is understood, implemented, and maintained at all levels of the organisation, and (4) reviewing this policy at least annually as part of the management review cycle.
+Excluded: hardware manufacturing, physical product distribution.
+
+#### Quality objectives
+
+- Support tickets acknowledged within one business day.
+- Every pull request passes the automated quality gates before merge.
+- At least two process improvements implemented per quarter.
+- Every employee reviewed annually against the competence matrix.
+
+#### Management commitment
+
+Conduction's management commits to:
+
+1. Providing the resources necessary to establish, implement, maintain, and continually improve the QMS.
+2. Communicating the importance of effective quality management and conforming to QMS requirements.
+3. Ensuring this policy is understood, implemented, and maintained at all levels of the organisation.
+4. Reviewing this policy at least annually as part of the management review cycle.
 
 ### Information-security policy statement
 
@@ -208,11 +223,32 @@ _ISO 27001:2022 §5.2 — Information Security Policy; Annex A.5.1. Last review:
 
 Conduction protects the confidentiality, integrity, and availability of the information it handles — including customer data, internal systems, and the open-source software it develops and operates. This policy establishes the framework for Conduction's Information Security Management System (ISMS) in accordance with ISO 27001:2022.
 
-**Scope.** All information assets related to the design, development, implementation, and support of our open-source software for digital government infrastructure, including source code and repositories on GitHub, customer data processed via Conduction's software and hosting, internal systems (Google Workspace, Jira, Passwork, development environments), and employee devices (BYOD) used for company work.
+#### Scope
 
-**Security objectives.** Zero unauthorised access incidents per year. Critical systems ≥ 99.5% uptime ([status.commonground.nu](https://status.commonground.nu)). Security incidents acknowledged within four business hours. Critical and high CVEs patched within 30 days. Every employee completes the annual security awareness session.
+All information assets related to the design, development, implementation, and support of our open-source software for digital government infrastructure, including:
 
-**Key Annex A controls.** Access control (A.5.15) is role-based and granted on a need-to-know basis. Cryptography (A.8.24) protects sensitive data in transit and at rest. Supplier relationships (A.5.19) are assessed and contractually bound. Incident management (A.6.8) covers all suspected incidents. Business continuity (A.5.29) is documented for every critical service. The privacy side of the ISMS is described in the [privacy policy](/privacy).
+- Source code and repositories on GitHub.
+- Customer data processed via Conduction's software and hosting.
+- Internal systems (Google Workspace, Jira, Passwork, development environments).
+- Employee devices (BYOD) used for company work.
+
+#### Security objectives
+
+- Zero unauthorised access incidents per year.
+- Critical systems ≥ 99.5% uptime ([status.commonground.nu](https://status.commonground.nu)).
+- Security incidents acknowledged within four business hours.
+- Critical and high CVEs patched within 30 days.
+- Every employee completes the annual security awareness session.
+
+#### Key Annex A controls
+
+- **Access control (A.5.15)** — role-based, granted on a need-to-know basis.
+- **Cryptography (A.8.24)** — protects sensitive data in transit and at rest.
+- **Supplier relationships (A.5.19)** — assessed and contractually bound.
+- **Incident management (A.6.8)** — covers all suspected incidents.
+- **Business continuity (A.5.29)** — documented for every critical service.
+
+The privacy side of the ISMS is described in the [privacy policy](/privacy).
 
 </Section>
 
@@ -260,7 +296,7 @@ Beyond the two ISO certifications, pentest scans, and the GitHub workflow, the p
 
 ## Asking for the proof
 
-If your procurement file needs the actual certificates, the Statement of Applicability, a recent pentest report, or a copy of an internal audit, write to [info@conduction.nl](mailto:info@conduction.nl) with the contract or tender reference. We send the documents directly.
+The certificates above are the original ISO 9001:2015 and ISO 27001:2022 documents — open the images for the full-resolution scans. If your procurement file needs the Statement of Applicability, a recent pentest report, or a copy of an internal audit, write to [info@conduction.nl](mailto:info@conduction.nl) with the contract or tender reference. We send those directly.
 
 </Section>
 
@@ -284,7 +320,7 @@ If your procurement file needs the actual certificates, the Statement of Applica
   <FAQItem question="What does the ISO 27001 certification cover at commonground.nu?">
     The managed Common Ground tenant runs on infrastructure operated by Cyso under ISAE 3402 Type II. Conduction's ISO 27001 covers the application layer (the Conduction apps, the development pipeline, the operations workflows), Cyso's ISAE covers the hosting layer (data centres, network, hypervisor). Together they cover the full stack a public-sector client buys at commonground.nu.
   </FAQItem>
-  <FAQItem question="Can I get a copy of the certificate, the Statement of Applicability, or a pentest report?">
-    Yes. Write to info@conduction.nl with your contract or tender reference. We send the current certificates, the SoA, the most recent internal-audit report, and the relevant pentest summary directly. We do not publish these on the public site by default because we want a record of who is requesting them.
+  <FAQItem question="Can I get a copy of the Statement of Applicability or a pentest report?">
+    The ISO 9001:2015 and ISO 27001:2022 certificates themselves are on this page — open the cert images for the full-resolution scans. For the SoA, the most recent internal-audit report, or the relevant pentest summary, write to info@conduction.nl with your contract or tender reference. We send those directly because we want a record of who is requesting them.
   </FAQItem>
 </FAQ>


### PR DESCRIPTION
Two cleanups on /quality:

1. The certificates are already on the page (clickable to view the original signed PDFs), so the 'Request a certificate' tertiary CTA was redundant — dropped on both locales.
2. The Quality and Information-Security policy statements were one dense block of inline-bold lead-ins. Broken out into proper h4 subsections (Scope / Quality objectives / Management commitment in 9001; Scope / Security objectives / Key Annex A controls in 27001) with bullet lists and a numbered commitment list.

The NL beleidsverklaring is kept verbatim from the signed January-2025 document (no injected h4 headings, since it's the original policy text as-adopted) — added a note that the text is the signed policy as-adopted.

'Asking for the proof' + the corresponding FAQ item are updated to reflect that the certificates themselves are on the page; only the SoA, pentest report, and internal audit summary remain by-request.

Production build green for both locales; visual verified against served build.