### PR TITLE
feat(quality): drop 'Asking for the proof' section

### DIFF
--- a/i18n/nl/docusaurus-plugin-content-pages/quality.mdx
+++ b/i18n/nl/docusaurus-plugin-content-pages/quality.mdx
@@ -260,10 +260,6 @@ Naast de twee ISO-certificeringen, de pentest-scans en de GitHub-workflow ziet h
 - **BIO.** De afstemming op de Baseline Informatiebeveiliging Overheid loopt. Statusupdates komen hier zodra die rond is.
 - **DigiD.** Buiten de scope van onze huidige portfolio. We integreren met DigiD-systemen, maar hebben zelf geen DigiD-assessment.
 
-## Bewijs opvragen
-
-De certificaten hierboven zijn de originele ISO 9001:2015- en ISO 27001:2022-documenten — klik op de afbeeldingen voor de scans in volle resolutie. Heeft je inkoopdossier de Verklaring van Toepasselijkheid, een recent pentestrapport of een interne auditrapportage nodig, mail dan naar [info@conduction.nl](mailto:info@conduction.nl) met je contract- of aanbestedingsreferentie. Die stukken sturen we direct toe.
-
 </Section>
 
 <div id="compliance-faq" />

--- a/src/pages/quality.mdx
+++ b/src/pages/quality.mdx
@@ -294,10 +294,6 @@ Beyond the two ISO certifications, pentest scans, and the GitHub workflow, the p
 - **BIO** — Baseline Informatiebeveiliging Overheid alignment is in progress. Status updates land here when complete.
 - **DigiD** — out of scope for our current portfolio. We integrate with DigiD-using systems but do not hold a DigiD assessment ourselves.
 
-## Asking for the proof
-
-The certificates above are the original ISO 9001:2015 and ISO 27001:2022 documents — open the images for the full-resolution scans. If your procurement file needs the Statement of Applicability, a recent pentest report, or a copy of an internal audit, write to [info@conduction.nl](mailto:info@conduction.nl) with the contract or tender reference. We send those directly.
-
 </Section>
 
 <div id="compliance-faq" />


### PR DESCRIPTION
The certificates are on the page (clickable for full-res scans), and the SoA / pentest report / audit summary request flow already lives in the Compliance FAQ's 'Can I get a copy of the Statement of Applicability or a pentest report?' entry. The standalone 'Asking for the proof' section was redundant.