### PR TITLE
feat(pages): cobalt hero + intro lede across apps, solutions, sidecars

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@conduction/docusaurus-preset": "^3.6.0",
+        "@conduction/docusaurus-preset": "^3.11.0",
         "@docusaurus/core": "^3.5.0",
         "@docusaurus/plugin-client-redirects": "^3.5.0",
         "@docusaurus/preset-classic": "^3.5.0",
@@ -1989,9 +1989,9 @@
       }
     },
     "node_modules/@conduction/docusaurus-preset": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-3.10.0.tgz",
-      "integrity": "sha512-wFjmNtjON+ks0Aqzql1wGy6TCQPLsJTzMY1C8uwNnj+jTpGVGZ3QVqd6I/0oVDYhdgAjgdrijRhyN3L2Er4U7Q==",
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-3.11.1.tgz",
+      "integrity": "sha512-uye0DP5t6n11Sxz+HuFG6gcfmusRWS+ObijPKY8Da69TlcMIHX7t4FySgHB62OhxfkVZcI4SUuKL3RYvw10dHA==",
       "license": "EUPL-1.2",
       "bin": {
         "validate-ai-baseline": "bin/validate-ai-baseline.mjs"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "ci": "npm ci --legacy-peer-deps && npm run build"
   },
   "dependencies": {
-    "@conduction/docusaurus-preset": "^3.6.0",
+    "@conduction/docusaurus-preset": "^3.11.0",
     "@docusaurus/core": "^3.5.0",
     "@docusaurus/plugin-client-redirects": "^3.5.0",
     "@docusaurus/preset-classic": "^3.5.0",

--- a/src/pages/apps/app-versions.mdx
+++ b/src/pages/apps/app-versions.mdx
@@ -7,6 +7,7 @@ hide_table_of_contents: true
 import {DetailHero, Section, SectionHead, FeatureList, FeatureItem, CtaBanner} from '@conduction/docusaurus-preset/components';
 
 <DetailHero
+  background="cobalt"
   appId="app-versions"
   crumb={[{label: 'Apps', href: '/apps'}, 'App Versions']}
   status={{label: 'In development', color: 'var(--c-cobalt-400)'}}

--- a/src/pages/apps/decidesk.mdx
+++ b/src/pages/apps/decidesk.mdx
@@ -7,6 +7,7 @@ hide_table_of_contents: true
 import {DetailHero, Section, SectionHead, FeatureList, FeatureItem, PairRow, PairCard, CtaBanner, AppMock, RotatingCards, WidgetShelf, Showcase, AgentTrace, McpToolShelf, AppCrossLinks} from '@conduction/docusaurus-preset/components';
 
 <DetailHero
+  background="cobalt"
   appId="decidesk"
   crumb={[{label: 'Apps', href: '/apps'}, 'DeciDesk']}
   status={{label: 'Beta', color: 'var(--c-orange-knvb)'}}
@@ -14,6 +15,7 @@ import {DetailHero, Section, SectionHead, FeatureList, FeatureItem, PairRow, Pai
   locales="NL · EN"
   title="DeciDesk"
   tagline={<>Board and council decision-making on your <span className="next-blue">Nextcloud</span>. Agendas, council dossiers, motions, votes, an audit trail that understands the Wet open overheid. For municipal councils, executive boards, supervisory and management boards.</>}
+  intro={<>Decidesk is an open-source decision-making app for the Nextcloud workspace. It runs the full governance cycle in one place: scheduling meetings, building agendas, submitting motions and amendments, voting, publishing minutes, and tracking action items to completion. Workflows are configurable for legislative bodies, associations, corporate boards, management teams, and citizen-participation panels. All meetings, motions, and decisions live as typed OpenRegister objects with an audit trail, and a built-in AI chat companion exposes those records over MCP. Released under EUPL-1.2 and maintained by Conduction since 2019.</>}
   primaryCta={{label: 'Install from app store', href: '/install'}}
   secondaryCta={{label: 'Read the docs', href: 'https://docs.conduction.nl/decidesk'}}
   tertiaryCta={{label: 'View on GitHub', href: 'https://github.com/ConductionNL/decidesk'}}
@@ -21,8 +23,6 @@ import {DetailHero, Section, SectionHead, FeatureList, FeatureItem, PairRow, Pai
   icon={<svg viewBox="0 0 24 24"><path d="M9 11l3 3 8-8"/><path d="M20 12v6a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h9"/></svg>}
   illustration={<AppMock app="decidesk" />}
 />
-
-Decidesk is an open-source decision-making app for the Nextcloud workspace. It runs the full governance cycle in one place: scheduling meetings, building agendas, submitting motions and amendments, voting, publishing minutes, and tracking action items to completion. Workflows are configurable for legislative bodies, associations, corporate boards, management teams, and citizen-participation panels. All meetings, motions, and decisions live as typed OpenRegister objects with an audit trail, and a built-in AI chat companion exposes those records over MCP. Released under EUPL-1.2 and maintained by Conduction since 2019.
 
 <Section spacing="default">
   <div style={{display: 'grid', gridTemplateColumns: 'minmax(0, 1fr) 320px', gap: 'var(--space-8)', alignItems: 'start'}}>

--- a/src/pages/apps/docudesk.mdx
+++ b/src/pages/apps/docudesk.mdx
@@ -7,6 +7,7 @@ hide_table_of_contents: true
 import {DetailHero, Section, SectionHead, FeatureList, FeatureItem, PairRow, PairCard, CtaBanner, AppMock, RotatingCards, WidgetShelf, Showcase, AgentTrace, AppCrossLinks} from '@conduction/docusaurus-preset/components';
 
 <DetailHero
+  background="cobalt"
   appId="docudesk"
   crumb={[{label: 'Apps', href: '/apps'}, 'DocuDesk']}
   status={{label: 'Stable', color: 'var(--c-mint-500)'}}
@@ -14,6 +15,7 @@ import {DetailHero, Section, SectionHead, FeatureList, FeatureItem, PairRow, Pai
   locales="NL · EN"
   title="DocuDesk"
   tagline={<>Document creation, anonymisation, signing, and templating on <span className="next-blue">Nextcloud</span>. Twelve templates ship for the most-used Dutch government documents (beschikkingen, jaarverslagen, bezwaarbrieven). Pulls fields straight from your registers.</>}
+  intro={<>DocuDesk is an open-source document-processing app for the Nextcloud workspace. It generates PDF, Word, HTML, and Excel documents from templates, anonymizes personal data through Presidio entity detection, and keeps a full audit trail for GDPR and WOO publication consent. All processing runs locally on the customer's Nextcloud instance, so sensitive files never leave the premises while still integrating with SharePoint, Office 365, and case-management systems. Released under EUPL-1.2 and maintained by Conduction since 2019.</>}
   primaryCta={{label: 'Install from app store', href: '/install'}}
   secondaryCta={{label: 'Read the docs', href: 'https://docs.conduction.nl/docudesk'}}
   tertiaryCta={{label: 'View on GitHub', href: 'https://github.com/ConductionNL/docudesk'}}
@@ -21,8 +23,6 @@ import {DetailHero, Section, SectionHead, FeatureList, FeatureItem, PairRow, Pai
   icon={<svg viewBox="0 0 24 24"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6M16 13H8M16 17H8M10 9H8"/></svg>}
   illustration={<AppMock app="docudesk" />}
 />
-
-DocuDesk is an open-source document-processing app for the Nextcloud workspace. It generates PDF, Word, HTML, and Excel documents from templates, anonymizes personal data through Presidio entity detection, and keeps a full audit trail for GDPR and WOO publication consent. All processing runs locally on the customer's Nextcloud instance, so sensitive files never leave the premises while still integrating with SharePoint, Office 365, and case-management systems. Released under EUPL-1.2 and maintained by Conduction since 2019.
 
 <Section spacing="default">
   <div style={{display: 'grid', gridTemplateColumns: 'minmax(0, 1fr) 320px', gap: 'var(--space-8)', alignItems: 'start'}}>

--- a/src/pages/apps/doriath.mdx
+++ b/src/pages/apps/doriath.mdx
@@ -7,6 +7,7 @@ hide_table_of_contents: true
 import {DetailHero, Section, SectionHead, CtaBanner} from '@conduction/docusaurus-preset/components';
 
 <DetailHero
+  background="cobalt"
   appId="doriath"
   crumb={[{label: 'Apps', href: '/apps'}, 'Doriath']}
   status={{label: 'In development', color: 'var(--c-cobalt-400)'}}

--- a/src/pages/apps/larpingapp.mdx
+++ b/src/pages/apps/larpingapp.mdx
@@ -7,6 +7,7 @@ hide_table_of_contents: true
 import {DetailHero, Section, SectionHead, FeatureList, FeatureItem, PairRow, PairCard, CtaBanner, AppMock, RotatingCards, WidgetShelf, Showcase, AgentTrace, AppCrossLinks} from '@conduction/docusaurus-preset/components';
 
 <DetailHero
+  background="cobalt"
   appId="larpingapp"
   crumb={[{label: 'Apps', href: '/apps'}, 'LarpingApp']}
   status={{label: 'Beta', color: 'var(--c-orange-knvb)'}}
@@ -14,6 +15,7 @@ import {DetailHero, Section, SectionHead, FeatureList, FeatureItem, PairRow, Pai
   locales="NL · EN"
   title="LarpingApp"
   tagline={<>Characters, rules, scenes, and NPC stats for live-action role-play (LARP). Build a setting in <span className="next-blue">Nextcloud</span>, share it with your group, and run sessions without spreadsheets-with-six-tabs.</>}
+  intro={<>LarpingApp is an open-source live-action role-playing (LARP) management app for the Nextcloud workspace. Organizers design characters, skills, items, and conditions with custom attributes, and the app recalculates stats automatically as players gain experience or apply effects. It also handles event subscriptions, waiting lists, and background-approval workflows, giving game masters one place to run a campaign. Released under EUPL-1.2 and maintained by Conduction since 2019.</>}
   primaryCta={{label: 'Install from app store', href: '/install'}}
   secondaryCta={{label: 'Read the docs', href: 'https://docs.conduction.nl/larpingapp'}}
   tertiaryCta={{label: 'View on GitHub', href: 'https://github.com/ConductionNL/larpingapp'}}
@@ -21,8 +23,6 @@ import {DetailHero, Section, SectionHead, FeatureList, FeatureItem, PairRow, Pai
   icon={<svg viewBox="0 0 24 24"><path d="M3 12h6l3-7 3 14 3-7h3"/></svg>}
   illustration={<AppMock app="larpingapp" />}
 />
-
-LarpingApp is an open-source live-action role-playing (LARP) management app for the Nextcloud workspace. Organizers design characters, skills, items, and conditions with custom attributes, and the app recalculates stats automatically as players gain experience or apply effects. It also handles event subscriptions, waiting lists, and background-approval workflows, giving game masters one place to run a campaign. Released under EUPL-1.2 and maintained by Conduction since 2019.
 
 <Section spacing="default">
   <div style={{display: 'grid', gridTemplateColumns: 'minmax(0, 1fr) 320px', gap: 'var(--space-8)', alignItems: 'start'}}>

--- a/src/pages/apps/mydash.mdx
+++ b/src/pages/apps/mydash.mdx
@@ -7,6 +7,7 @@ hide_table_of_contents: true
 import {DetailHero, Section, SectionHead, FeatureList, FeatureItem, PairRow, PairCard, CtaBanner, RotatingCards, AppMock, WidgetShelf, Showcase, AgentTrace, AppCrossLinks} from '@conduction/docusaurus-preset/components';
 
 <DetailHero
+  background="cobalt"
   appId="mydash"
   crumb={[{label: 'Apps', href: '/apps'}, 'MyDash']}
   status={{label: 'Beta', color: 'var(--c-orange-knvb)'}}
@@ -14,6 +15,7 @@ import {DetailHero, Section, SectionHead, FeatureList, FeatureItem, PairRow, Pai
   locales="NL · EN"
   title="MyDash"
   tagline={<>Personal and team dashboards, built directly on your <span className="next-blue">Nextcloud</span>. No separate BI tool, no extra login, no ETL. Whatever you have in <span className="next-blue">Nextcloud</span>, you can visualise in MyDash.</>}
+  intro={<>MyDash is an open-source dashboard app for the Nextcloud workspace. It lets each user compose multiple personal dashboards from drag-and-drop widgets and shortcut tiles on a responsive GridStack canvas, and supports both the v1 and v2 Nextcloud Dashboard widget APIs out of the box. Administrators can ship pre-configured templates to user groups, pin compulsory widgets, and set conditional visibility rules based on group, time of day, or date range. Released under EUPL-1.2 and maintained by Conduction since 2019.</>}
   primaryCta={{label: 'Install from app store', href: '/install'}}
   secondaryCta={{label: 'Read the docs', href: 'https://docs.conduction.nl/mydash'}}
   tertiaryCta={{label: 'View on GitHub', href: 'https://github.com/ConductionNL/mydash'}}
@@ -21,8 +23,6 @@ import {DetailHero, Section, SectionHead, FeatureList, FeatureItem, PairRow, Pai
   icon={<svg viewBox="0 0 24 24"><rect x="3" y="3" width="7" height="9"/><rect x="14" y="3" width="7" height="5"/><rect x="14" y="12" width="7" height="9"/><rect x="3" y="16" width="7" height="5"/></svg>}
   illustration={<AppMock app="mydash" />}
 />
-
-MyDash is an open-source dashboard app for the Nextcloud workspace. It lets each user compose multiple personal dashboards from drag-and-drop widgets and shortcut tiles on a responsive GridStack canvas, and supports both the v1 and v2 Nextcloud Dashboard widget APIs out of the box. Administrators can ship pre-configured templates to user groups, pin compulsory widgets, and set conditional visibility rules based on group, time of day, or date range. Released under EUPL-1.2 and maintained by Conduction since 2019.
 
 <Section spacing="default">
   <div style={{display: 'grid', gridTemplateColumns: 'minmax(0, 1fr) 320px', gap: 'var(--space-8)', alignItems: 'start'}}>

--- a/src/pages/apps/nldesign.mdx
+++ b/src/pages/apps/nldesign.mdx
@@ -7,6 +7,7 @@ hide_table_of_contents: true
 import {DetailHero, Section, SectionHead, FeatureList, FeatureItem, PairRow, PairCard, CtaBanner, AppMock, RotatingCards, WidgetShelf, Showcase, AppCrossLinks} from '@conduction/docusaurus-preset/components';
 
 <DetailHero
+  background="cobalt"
   appId="nldesign"
   crumb={[{label: 'Apps', href: '/apps'}, 'NLDesign']}
   status={{label: 'Beta', color: 'var(--c-orange-knvb)'}}
@@ -14,6 +15,7 @@ import {DetailHero, Section, SectionHead, FeatureList, FeatureItem, PairRow, Pai
   locales="NL · EN"
   title="NLDesign"
   tagline={<>The NL Design System (NLDS) as a drop-in theme for your <span className="next-blue">Nextcloud</span>. One install and your interface follows the Dutch government house style, with Conduction component variants on top.</>}
+  intro={<>NL Design is an open-source theming app for the Nextcloud workspace. Administrators pick their organisation from a list of 39 pre-built themes (Rijkshuisstijl, Gemeente Utrecht, Amsterdam, Den Haag, Rotterdam, and more) and the workspace adopts that house style instantly. A token editor lets teams fine-tune individual colours, and customisations export to a file for sharing across instances. Released under EUPL-1.2 and maintained by Conduction since 2019.</>}
   primaryCta={{label: 'Install from app store', href: '/install'}}
   secondaryCta={{label: 'Read the docs', href: 'https://docs.conduction.nl/nldesign'}}
   tertiaryCta={{label: 'View on GitHub', href: 'https://github.com/ConductionNL/nldesign'}}
@@ -21,8 +23,6 @@ import {DetailHero, Section, SectionHead, FeatureList, FeatureItem, PairRow, Pai
   icon={<svg viewBox="0 0 24 24"><path d="M4 4h16v6H4z"/><path d="M4 14h7v6H4z"/><path d="M14 14h6v6h-6z"/></svg>}
   illustration={<AppMock app="nldesign" />}
 />
-
-NL Design is an open-source theming app for the Nextcloud workspace. Administrators pick their organisation from a list of 39 pre-built themes (Rijkshuisstijl, Gemeente Utrecht, Amsterdam, Den Haag, Rotterdam, and more) and the workspace adopts that house style instantly. A token editor lets teams fine-tune individual colours, and customisations export to a file for sharing across instances. Released under EUPL-1.2 and maintained by Conduction since 2019.
 
 <Section spacing="default">
   <div style={{display: 'grid', gridTemplateColumns: 'minmax(0, 1fr) 320px', gap: 'var(--space-8)', alignItems: 'start'}}>

--- a/src/pages/apps/openbuilt.mdx
+++ b/src/pages/apps/openbuilt.mdx
@@ -7,6 +7,7 @@ hide_table_of_contents: true
 import {DetailHero, Section, SectionHead, FeatureList, FeatureItem, PairRow, PairCard, CtaBanner, AgentTrace, McpToolShelf, AppCrossLinks} from '@conduction/docusaurus-preset/components';
 
 <DetailHero
+  background="cobalt"
   appId="openbuilt"
   crumb={[{label: 'Apps', href: '/apps'}, 'OpenBuilt']}
   status={{label: 'Beta', color: 'var(--c-orange-knvb)'}}
@@ -14,14 +15,13 @@ import {DetailHero, Section, SectionHead, FeatureList, FeatureItem, PairRow, Pai
   locales="NL · EN"
   title="OpenBuilt"
   tagline={<>An app builder for citizen developers on <span className="next-blue">Nextcloud</span>. Compose your own app from OpenRegister schemas, OpenConnector APIs, Procest workflows, and DocuDesk documents. No PHP, no scaffolding.</>}
+  intro={<>OpenBuilt is an open-source citizen-developer app builder for the Nextcloud workspace. Users compose a working app from typed OpenRegister registers, OpenConnector connectors, n8n workflows, and DocuDesk templates, then lay out list, detail, and form pages in a browser-based designer. Version snapshots roll back bad edits, ZIP exports move apps between instances, and RBAC keeps per-record access enforced through OpenRegister. Released under EUPL-1.2 and maintained by Conduction since 2019.</>}
   primaryCta={{label: 'Install from app store', href: '/install'}}
   secondaryCta={{label: 'Read the docs', href: 'https://docs.conduction.nl/openbuilt'}}
   tertiaryCta={{label: 'View on GitHub', href: 'https://github.com/ConductionNL/openbuilt'}}
   iconColor="var(--c-blue-cobalt)"
   icon={<svg viewBox="0 0 24 24"><path d="M3 12l9-9 9 9-9 9z"/><path d="M9 12h6M12 9v6"/></svg>}
 />
-
-OpenBuilt is an open-source citizen-developer app builder for the Nextcloud workspace. Users compose a working app from typed OpenRegister registers, OpenConnector connectors, n8n workflows, and DocuDesk templates, then lay out list, detail, and form pages in a browser-based designer. Version snapshots roll back bad edits, ZIP exports move apps between instances, and RBAC keeps per-record access enforced through OpenRegister. Released under EUPL-1.2 and maintained by Conduction since 2019.
 
 <Section spacing="default">
   <div style={{display: 'grid', gridTemplateColumns: 'minmax(0, 1fr) 320px', gap: 'var(--space-8)', alignItems: 'start'}}>

--- a/src/pages/apps/opencatalogi.mdx
+++ b/src/pages/apps/opencatalogi.mdx
@@ -7,6 +7,7 @@ hide_table_of_contents: true
 import {DetailHero, Section, SectionHead, FeatureList, FeatureItem, FeatureGrid, PairRow, PairCard, Pipeline, CtaBanner, AppMock, RotatingCards, WidgetShelf, Showcase, AppCrossLinks} from '@conduction/docusaurus-preset/components';
 
 <DetailHero
+  background="cobalt"
   appId="opencatalogi"
   crumb={[{label: 'Apps', href: '/apps'}, 'OpenCatalogi']}
   status={{label: 'Stable', color: 'var(--c-mint-500)'}}
@@ -14,6 +15,7 @@ import {DetailHero, Section, SectionHead, FeatureList, FeatureItem, FeatureGrid,
   locales="NL · EN"
   title="OpenCatalogi"
   tagline={<>The public-facing software, dataset, and API catalogue. Drops into your <span className="next-blue">Nextcloud</span>, surfaces every register as a searchable entry, federates to data.overheid.nl out of the box.</>}
+  intro={<>OpenCatalogi is an open-source publication catalog app for the Nextcloud workspace. It lets government bodies publish, index, and share catalogs of software, services, and data through a single user interface, and ingests metadata from GitHub, GitLab, and external APIs via PublicCode.yml. The app supports WOO compliance (Public Access to Government Information Act) and standardized organization profiles, making public-sector information discoverable to citizens, businesses, and other agencies. Released under EUPL-1.2 and maintained by Conduction since 2019.</>}
   primaryCta={{label: 'Install from app store', href: '/install'}}
   secondaryCta={{label: 'Read the docs', href: 'https://docs.conduction.nl/opencatalogi'}}
   tertiaryCta={{label: 'View on GitHub', href: 'https://github.com/ConductionNL/opencatalogi'}}
@@ -21,8 +23,6 @@ import {DetailHero, Section, SectionHead, FeatureList, FeatureItem, FeatureGrid,
   icon={<svg viewBox="0 0 24 24"><path d="M3 7l9-4 9 4-9 4-9-4z"/><path d="M3 12l9 4 9-4M3 17l9 4 9-4"/></svg>}
   illustration={<AppMock app="opencatalogi" />}
 />
-
-OpenCatalogi is an open-source publication catalog app for the Nextcloud workspace. It lets government bodies publish, index, and share catalogs of software, services, and data through a single user interface, and ingests metadata from GitHub, GitLab, and external APIs via PublicCode.yml. The app supports WOO compliance (Public Access to Government Information Act) and standardized organization profiles, making public-sector information discoverable to citizens, businesses, and other agencies. Released under EUPL-1.2 and maintained by Conduction since 2019.
 
 <Section spacing="default">
   <div style={{display: 'grid', gridTemplateColumns: 'minmax(0, 1fr) 320px', gap: 'var(--space-8)', alignItems: 'start'}}>

--- a/src/pages/apps/openconnector.mdx
+++ b/src/pages/apps/openconnector.mdx
@@ -7,6 +7,7 @@ hide_table_of_contents: true
 import {DetailHero, Section, SectionHead, FeatureList, FeatureItem, FeatureGrid, PairRow, PairCard, CtaBanner, AppMock, RotatingCards, WidgetShelf, Showcase, AgentTrace, AppCrossLinks} from '@conduction/docusaurus-preset/components';
 
 <DetailHero
+  background="cobalt"
   appId="openconnector"
   crumb={[{label: 'Apps', href: '/apps'}, 'OpenConnector']}
   status={{label: 'Beta', color: 'var(--c-orange-knvb)'}}
@@ -14,6 +15,7 @@ import {DetailHero, Section, SectionHead, FeatureList, FeatureItem, FeatureGrid,
   locales="NL · EN"
   title="OpenConnector"
   tagline={<>The integration layer for <span className="next-blue">Nextcloud</span>. REST, SOAP, GraphQL, file drops, message queues. Pulls data from your existing systems into typed registers without writing glue code.</>}
+  intro={<>OpenConnector is an open-source data-synchronization app for the Nextcloud workspace. It connects APIs, databases, file systems, and external services to OpenRegister, transforms payloads through configurable mappings, and schedules automated sync jobs with event and webhook triggers. It also exposes endpoints, consumers, and business rules, so government teams can build integrations without a separate ESB. Released under EUPL-1.2 and maintained by Conduction since 2019.</>}
   primaryCta={{label: 'Install from app store', href: '/install'}}
   secondaryCta={{label: 'Read the docs', href: 'https://docs.conduction.nl/openconnector'}}
   tertiaryCta={{label: 'View on GitHub', href: 'https://github.com/ConductionNL/openconnector'}}
@@ -21,8 +23,6 @@ import {DetailHero, Section, SectionHead, FeatureList, FeatureItem, FeatureGrid,
   icon={<svg viewBox="0 0 24 24"><circle cx="6" cy="12" r="3"/><circle cx="18" cy="6" r="3"/><circle cx="18" cy="18" r="3"/><path d="M9 12h9M9 12l9-6M9 12l9 6"/></svg>}
   illustration={<AppMock app="openconnector" />}
 />
-
-OpenConnector is an open-source data-synchronization app for the Nextcloud workspace. It connects APIs, databases, file systems, and external services to OpenRegister, transforms payloads through configurable mappings, and schedules automated sync jobs with event and webhook triggers. It also exposes endpoints, consumers, and business rules, so government teams can build integrations without a separate ESB. Released under EUPL-1.2 and maintained by Conduction since 2019.
 
 <Section spacing="default">
   <div style={{display: 'grid', gridTemplateColumns: 'minmax(0, 1fr) 320px', gap: 'var(--space-8)', alignItems: 'start'}}>

--- a/src/pages/apps/openregister.mdx
+++ b/src/pages/apps/openregister.mdx
@@ -7,6 +7,7 @@ hide_table_of_contents: true
 import {DetailHero, Section, SectionHead, FeatureList, FeatureItem, FeatureGrid, PairRow, PairCard, CtaBanner, AppMock, RotatingCards, WidgetShelf, Showcase, AgentTrace, McpToolShelf, AppCrossLinks} from '@conduction/docusaurus-preset/components';
 
 <DetailHero
+  background="cobalt"
   appId="openregister"
   crumb={[{label: 'Apps', href: '/apps'}, 'OpenRegister']}
   status={{label: 'Stable', color: 'var(--c-mint-500)'}}
@@ -14,6 +15,7 @@ import {DetailHero, Section, SectionHead, FeatureList, FeatureItem, FeatureGrid,
   locales="NL · EN"
   title="OpenRegister"
   tagline={<>Schemas, registers, structured data objects. The typed-data backbone underneath every other Conduction app, and the install you reach for first.</>}
+  intro={<>OpenRegister is an open-source data register app for the Nextcloud workspace. It stores domain-specific objects (client records, social-security entries, custom registers) validated against JSON Schema, with full version history, audit trails, soft deletion, and object-level locking. Schemas can be authored by hand or imported from Schema.org and the Dutch GGM (Gemeentelijk Gegevensmodel), and objects persist into Nextcloud, MySQL, PostgreSQL, or MongoDB without changing application logic. Released under EUPL-1.2 and maintained by Conduction since 2019.</>}
   primaryCta={{label: 'Install from app store', href: '/install'}}
   secondaryCta={{label: 'Read the docs', href: 'https://docs.conduction.nl/openregister'}}
   tertiaryCta={{label: 'View on GitHub', href: 'https://github.com/ConductionNL/openregister'}}
@@ -21,8 +23,6 @@ import {DetailHero, Section, SectionHead, FeatureList, FeatureItem, FeatureGrid,
   icon={<svg viewBox="0 0 24 24"><ellipse cx="12" cy="6" rx="8" ry="3"/><path d="M4 6v12c0 1.7 3.6 3 8 3s8-1.3 8-3V6"/><path d="M4 12c0 1.7 3.6 3 8 3s8-1.3 8-3"/></svg>}
   illustration={<AppMock app="openregister" />}
 />
-
-OpenRegister is an open-source data register app for the Nextcloud workspace. It stores domain-specific objects (client records, social-security entries, custom registers) validated against JSON Schema, with full version history, audit trails, soft deletion, and object-level locking. Schemas can be authored by hand or imported from Schema.org and the Dutch GGM (Gemeentelijk Gegevensmodel), and objects persist into Nextcloud, MySQL, PostgreSQL, or MongoDB without changing application logic. Released under EUPL-1.2 and maintained by Conduction since 2019.
 
 <Section spacing="default">
   <div style={{display: 'grid', gridTemplateColumns: 'minmax(0, 1fr) 320px', gap: 'var(--space-8)', alignItems: 'start'}}>

--- a/src/pages/apps/pipelinq.mdx
+++ b/src/pages/apps/pipelinq.mdx
@@ -7,6 +7,7 @@ hide_table_of_contents: true
 import {DetailHero, Section, SectionHead, FeatureList, FeatureItem, PairRow, PairCard, CtaBanner, AppMock, RotatingCards, WidgetShelf, Showcase, AgentTrace, AppCrossLinks} from '@conduction/docusaurus-preset/components';
 
 <DetailHero
+  background="cobalt"
   appId="pipelinq"
   crumb={[{label: 'Apps', href: '/apps'}, 'PipelinQ']}
   status={{label: 'Beta', color: 'var(--c-orange-knvb)'}}
@@ -14,6 +15,7 @@ import {DetailHero, Section, SectionHead, FeatureList, FeatureItem, PairRow, Pai
   locales="NL · EN"
   title="PipelinQ"
   tagline={<>CRM on your <span className="next-blue">Nextcloud</span>. Customers, prospects, deals, quotes. Everything as a typed register, no separate sales database, no second login. Your sales team works where your delivery team already is.</>}
+  intro={<>Pipelinq is an open-source CRM and pipeline-management app for the Nextcloud workspace. It runs a kanban deal-flow with configurable stages, per-team filters via Nextcloud groups, and KPI cards on top. Customers, contacts, and deals are typed OpenRegister schemas with citation-stable IDs and a per-record audit trail. Quotes are generated through DocuDesk templates, and OpenConnector links to accounting systems such as Exact, Twinfield, and AFAS. Released under EUPL-1.2 and maintained by Conduction since 2019.</>}
   primaryCta={{label: 'Install from app store', href: '/install'}}
   secondaryCta={{label: 'Read the docs', href: 'https://docs.conduction.nl/pipelinq'}}
   tertiaryCta={{label: 'View on GitHub', href: 'https://github.com/ConductionNL/pipelinq'}}
@@ -21,8 +23,6 @@ import {DetailHero, Section, SectionHead, FeatureList, FeatureItem, PairRow, Pai
   icon={<svg viewBox="0 0 24 24"><path d="M3 12h4l3-9 4 18 3-9h4"/></svg>}
   illustration={<AppMock app="pipelinq" />}
 />
-
-Pipelinq is an open-source CRM and pipeline-management app for the Nextcloud workspace. It runs a kanban deal-flow with configurable stages, per-team filters via Nextcloud groups, and KPI cards on top. Customers, contacts, and deals are typed OpenRegister schemas with citation-stable IDs and a per-record audit trail. Quotes are generated through DocuDesk templates, and OpenConnector links to accounting systems such as Exact, Twinfield, and AFAS. Released under EUPL-1.2 and maintained by Conduction since 2019.
 
 <Section spacing="default">
   <div style={{display: 'grid', gridTemplateColumns: 'minmax(0, 1fr) 320px', gap: 'var(--space-8)', alignItems: 'start'}}>

--- a/src/pages/apps/procest.mdx
+++ b/src/pages/apps/procest.mdx
@@ -7,6 +7,7 @@ hide_table_of_contents: true
 import {DetailHero, Section, SectionHead, FeatureList, FeatureItem, PairRow, PairCard, CtaBanner, AppMock, RotatingCards, WidgetShelf, Showcase, AgentTrace} from '@conduction/docusaurus-preset/components';
 
 <DetailHero
+  background="cobalt"
   appId="procest"
   crumb={[{label: 'Apps', href: '/apps'}, 'Procest']}
   status={{label: 'Stable', color: 'var(--c-mint-500)'}}
@@ -14,6 +15,7 @@ import {DetailHero, Section, SectionHead, FeatureList, FeatureItem, PairRow, Pai
   locales="NL · EN"
   title="Procest"
   tagline={<>Case management for VTH (permits, supervision, enforcement) and citizen processes on your <span className="next-blue">Nextcloud</span>. A workflow engine plus typed registers plus an audit trail that meets the Wet kwaliteitsborging and Algemene wet bestuursrecht.</>}
+  intro={<>Procest is an open-source case-management app for the Nextcloud workspace, built for Dutch government organisations. Case workers list and filter cases, drive them through ZGW-compliant case-type definitions, and pick up tasks from a personal work queue. The app maps ZGW API fields onto OpenRegister, so cases interoperate with national exchange standards without a second database. It targets zaakgericht werken scenarios such as complaints, consultations, and WOO disclosure requests. Released under EUPL-1.2 and maintained by Conduction since 2019.</>}
   primaryCta={{label: 'Install from app store', href: '/install'}}
   secondaryCta={{label: 'Read the docs', href: 'https://docs.conduction.nl/procest'}}
   tertiaryCta={{label: 'View on GitHub', href: 'https://github.com/ConductionNL/procest'}}
@@ -21,8 +23,6 @@ import {DetailHero, Section, SectionHead, FeatureList, FeatureItem, PairRow, Pai
   icon={<svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 3"/></svg>}
   illustration={<AppMock app="procest" />}
 />
-
-Procest is an open-source case-management app for the Nextcloud workspace, built for Dutch government organisations. Case workers list and filter cases, drive them through ZGW-compliant case-type definitions, and pick up tasks from a personal work queue. The app maps ZGW API fields onto OpenRegister, so cases interoperate with national exchange standards without a second database. It targets zaakgericht werken scenarios such as complaints, consultations, and WOO disclosure requests. Released under EUPL-1.2 and maintained by Conduction since 2019.
 
 <Section spacing="default">
   <SectionHead

--- a/src/pages/apps/scholiq.mdx
+++ b/src/pages/apps/scholiq.mdx
@@ -7,6 +7,7 @@ hide_table_of_contents: true
 import {DetailHero, Section, SectionHead, FeatureList, FeatureItem, PairRow, PairCard, CtaBanner, AppCrossLinks} from '@conduction/docusaurus-preset/components';
 
 <DetailHero
+  background="cobalt"
   appId="scholiq"
   crumb={[{label: 'Apps', href: '/apps'}, 'Scholiq']}
   status={{label: 'Beta', color: 'var(--c-orange-knvb)'}}
@@ -14,14 +15,13 @@ import {DetailHero, Section, SectionHead, FeatureList, FeatureItem, PairRow, Pai
   locales="NL · EN"
   title="Scholiq"
   tagline={<>Leerlingvolgsysteem en LMS op <span className="next-blue">Nextcloud</span>. Cursussen, inschrijvingen, aanwezigheid, nakijken, certificaten. Voor scholen, opleiders en compliance-teams die hun leerproces niet bij een externe SaaS willen parkeren.</>}
+  intro={<>Scholiq is an open-source education app for the Nextcloud workspace. It runs as a leerlingvolgsysteem (LVS) for Dutch primary and secondary schools, as a full LMS for higher education, and as a compliance-training engine for MKB and government bodies. Scholiq connects natively to DUO BRON/ROD, OSO transfer, SURFconext, IMS QTI 3.0, and EDCI / Open-Badges 3.0, with EU AI Act gating built in from day one. Released under EUPL-1.2 and maintained by Conduction since 2019.</>}
   primaryCta={{label: 'Install from app store', href: '/install'}}
   secondaryCta={{label: 'Read the docs', href: 'https://scholiq.conduction.nl/'}}
   tertiaryCta={{label: 'View on GitHub', href: 'https://github.com/ConductionNL/scholiq'}}
   iconColor="var(--c-blue-cobalt)"
   icon={<svg viewBox="0 0 24 24"><path d="M3 9l9-5 9 5-9 5z"/><path d="M7 11v5c0 1 2.2 2 5 2s5-1 5-2v-5"/><path d="M21 9v6"/></svg>}
 />
-
-Scholiq is an open-source education app for the Nextcloud workspace. It runs as a leerlingvolgsysteem (LVS) for Dutch primary and secondary schools, as a full LMS for higher education, and as a compliance-training engine for MKB and government bodies. Scholiq connects natively to DUO BRON/ROD, OSO transfer, SURFconext, IMS QTI 3.0, and EDCI / Open-Badges 3.0, with EU AI Act gating built in from day one. Released under EUPL-1.2 and maintained by Conduction since 2019.
 
 <Section spacing="default">
   <div style={{display: 'grid', gridTemplateColumns: 'minmax(0, 1fr) 320px', gap: 'var(--space-8)', alignItems: 'start'}}>

--- a/src/pages/apps/shillinq.mdx
+++ b/src/pages/apps/shillinq.mdx
@@ -7,6 +7,7 @@ hide_table_of_contents: true
 import {DetailHero, Section, SectionHead, FeatureList, FeatureItem, PairRow, PairCard, CtaBanner, AppCrossLinks} from '@conduction/docusaurus-preset/components';
 
 <DetailHero
+  background="cobalt"
   appId="shillinq"
   crumb={[{label: 'Apps', href: '/apps'}, 'Shillinq']}
   status={{label: 'Beta', color: 'var(--c-orange-knvb)'}}
@@ -14,14 +15,13 @@ import {DetailHero, Section, SectionHead, FeatureList, FeatureItem, PairRow, Pai
   locales="NL · EN"
   title="Shillinq"
   tagline={<>Business administration on <span className="next-blue">Nextcloud</span>. Invoices, contracts, procurement on shared registers. Built for the MKB that already runs Nextcloud and wants its finance, sales, and procurement in the same workspace.</>}
+  intro={<>Shillinq is an open-source business administration app for the Nextcloud workspace. It covers double-entry bookkeeping, sales and purchase invoicing (UBL, Peppol, NLCIUS), procurement workflows, contract lifecycle management, and bank reconciliation over SEPA / ISO 20022. Dutch government compliance ships in the box: BBV, IV3, SiSa, and DigiInkoop. Released under EUPL-1.2 and maintained by Conduction since 2019.</>}
   primaryCta={{label: 'Install from app store', href: '/install'}}
   secondaryCta={{label: 'Read the docs', href: 'https://docs.conduction.nl/shillinq'}}
   tertiaryCta={{label: 'View on GitHub', href: 'https://github.com/ConductionNL/shillinq'}}
   iconColor="var(--c-blue-cobalt)"
   icon={<svg viewBox="0 0 24 24"><path d="M3 6h18M3 12h18M3 18h12"/><circle cx="19" cy="18" r="2"/></svg>}
 />
-
-Shillinq is an open-source business administration app for the Nextcloud workspace. It covers double-entry bookkeeping, sales and purchase invoicing (UBL, Peppol, NLCIUS), procurement workflows, contract lifecycle management, and bank reconciliation over SEPA / ISO 20022. Dutch government compliance ships in the box: BBV, IV3, SiSa, and DigiInkoop. Released under EUPL-1.2 and maintained by Conduction since 2019.
 
 <Section spacing="default">
   <div style={{display: 'grid', gridTemplateColumns: 'minmax(0, 1fr) 320px', gap: 'var(--space-8)', alignItems: 'start'}}>

--- a/src/pages/apps/softwarecatalog.mdx
+++ b/src/pages/apps/softwarecatalog.mdx
@@ -7,6 +7,7 @@ hide_table_of_contents: true
 import {DetailHero, Section, SectionHead, FeatureList, FeatureItem, PairRow, PairCard, CtaBanner, AppMock, RotatingCards, WidgetShelf, Showcase, AgentTrace} from '@conduction/docusaurus-preset/components';
 
 <DetailHero
+  background="cobalt"
   appId="softwarecatalog"
   crumb={[{label: 'Apps', href: '/apps'}, 'SoftwareCatalog']}
   status={{label: 'Stable', color: 'var(--c-mint-500)'}}
@@ -14,6 +15,7 @@ import {DetailHero, Section, SectionHead, FeatureList, FeatureItem, PairRow, Pai
   locales="NL · EN"
   title="SoftwareCatalog"
   tagline={<>IT-asset management on your <span className="next-blue">Nextcloud</span>. A central register of every application, licence, contract, and dependency in your organisation. Ideal for the IT department that wants to know what runs where.</>}
+  intro={<>SoftwareCatalog is an open-source IT-asset-management app for the Nextcloud workspace. It keeps a central register of every application, licence, contract, and dependency the organisation runs, with renewal alerts before the auto-renewal date. Dashboard widgets surface upcoming renewals, an inventory snapshot by category, and discovery deltas showing newly added or removed apps. Built for the IT department that needs to know what runs where, without a separate asset database or second login. Released under EUPL-1.2 and maintained by Conduction since 2019.</>}
   primaryCta={{label: 'Install from app store', href: '/install'}}
   secondaryCta={{label: 'Read the docs', href: 'https://docs.conduction.nl/softwarecatalog'}}
   tertiaryCta={{label: 'View on GitHub', href: 'https://github.com/ConductionNL/softwarecatalog'}}
@@ -21,8 +23,6 @@ import {DetailHero, Section, SectionHead, FeatureList, FeatureItem, PairRow, Pai
   icon={<svg viewBox="0 0 24 24"><rect x="3" y="3" width="7" height="9"/><rect x="14" y="3" width="7" height="5"/><rect x="14" y="12" width="7" height="9"/><rect x="3" y="16" width="7" height="5"/></svg>}
   illustration={<AppMock app="softwarecatalog" />}
 />
-
-SoftwareCatalog is an open-source IT-asset-management app for the Nextcloud workspace. It keeps a central register of every application, licence, contract, and dependency the organisation runs, with renewal alerts before the auto-renewal date. Dashboard widgets surface upcoming renewals, an inventory snapshot by category, and discovery deltas showing newly added or removed apps. Built for the IT department that needs to know what runs where, without a separate asset database or second login. Released under EUPL-1.2 and maintained by Conduction since 2019.
 
 <Section spacing="default">
   <SectionHead

--- a/src/pages/apps/zaakafhandelapp.mdx
+++ b/src/pages/apps/zaakafhandelapp.mdx
@@ -7,6 +7,7 @@ hide_table_of_contents: true
 import {DetailHero, Section, SectionHead, FeatureList, FeatureItem, PairRow, PairCard, CtaBanner, AppMock, RotatingCards, WidgetShelf, Showcase, AgentTrace} from '@conduction/docusaurus-preset/components';
 
 <DetailHero
+  background="cobalt"
   appId="zaakafhandelapp"
   crumb={[{label: 'Apps', href: '/apps'}, 'ZaakAfhandelApp']}
   status={{label: 'Stable', color: 'var(--c-mint-500)'}}
@@ -14,6 +15,7 @@ import {DetailHero, Section, SectionHead, FeatureList, FeatureItem, PairRow, Pai
   locales="NL · EN"
   title="ZaakAfhandelApp"
   tagline={<>The citizen-facing case-status portal on your <span className="next-blue">Nextcloud</span>. Citizens follow their cases, request status, upload documents. ZGW APIs, archief-koppelvlakken, audit trail. No separate SaaS, no second login for case-workers.</>}
+  intro={<>Zaak Afhandel App (ZAA) is an open-source case-handling app for the Nextcloud workspace. It manages Dutch zaakafhandeling end-to-end: intake, defined status workflows, work queues, tasks, attached documents, and a record of every besluit. The app follows Zaakgericht Werken (ZGW) terminology and patterns used by Dutch municipalities, and bundles gateway functions for routing API calls between systems. Released under EUPL-1.2 and maintained by Conduction since 2019. ZAA has been superseded by Procest and Pipelinq for new deployments.</>}
   primaryCta={{label: 'Install from app store', href: '/install'}}
   secondaryCta={{label: 'Read the docs', href: 'https://docs.conduction.nl/zaakafhandelapp'}}
   tertiaryCta={{label: 'View on GitHub', href: 'https://github.com/ConductionNL/zaakafhandelapp'}}
@@ -21,8 +23,6 @@ import {DetailHero, Section, SectionHead, FeatureList, FeatureItem, PairRow, Pai
   icon={<svg viewBox="0 0 24 24"><rect x="4" y="4" width="16" height="16" rx="2"/><path d="M9 9h6v6H9z"/></svg>}
   illustration={<AppMock app="zaakafhandelapp" />}
 />
-
-Zaak Afhandel App (ZAA) is an open-source case-handling app for the Nextcloud workspace. It manages Dutch zaakafhandeling end-to-end: intake, defined status workflows, work queues, tasks, attached documents, and a record of every besluit. The app follows Zaakgericht Werken (ZGW) terminology and patterns used by Dutch municipalities, and bundles gateway functions for routing API calls between systems. Released under EUPL-1.2 and maintained by Conduction since 2019. ZAA has been superseded by Procest and Pipelinq for new deployments.
 
 <Section spacing="default">
   <SectionHead

--- a/src/pages/sidecars/keycloak.mdx
+++ b/src/pages/sidecars/keycloak.mdx
@@ -7,6 +7,7 @@ hide_table_of_contents: true
 import {DetailHero, Section, SectionHead, CtaBanner} from '@conduction/docusaurus-preset/components';
 
 <DetailHero
+  background="cobalt"
   appId="keycloak"
   crumb={[{label: 'Sidecars', href: '/sidecars'}, 'Keycloak']}
   status={{label: 'Sidecar', color: 'var(--c-cobalt-400)'}}

--- a/src/pages/sidecars/n8n.mdx
+++ b/src/pages/sidecars/n8n.mdx
@@ -7,6 +7,7 @@ hide_table_of_contents: true
 import {DetailHero, Section, SectionHead, CtaBanner} from '@conduction/docusaurus-preset/components';
 
 <DetailHero
+  background="cobalt"
   appId="n8n"
   crumb={[{label: 'Sidecars', href: '/sidecars'}, 'n8n']}
   status={{label: 'Sidecar', color: 'var(--c-cobalt-400)'}}

--- a/src/pages/sidecars/ollama.mdx
+++ b/src/pages/sidecars/ollama.mdx
@@ -7,6 +7,7 @@ hide_table_of_contents: true
 import {DetailHero, Section, SectionHead, CtaBanner} from '@conduction/docusaurus-preset/components';
 
 <DetailHero
+  background="cobalt"
   appId="ollama"
   crumb={[{label: 'Sidecars', href: '/sidecars'}, 'Ollama']}
   status={{label: 'Sidecar', color: 'var(--c-cobalt-400)'}}

--- a/src/pages/sidecars/open-webui.mdx
+++ b/src/pages/sidecars/open-webui.mdx
@@ -7,6 +7,7 @@ hide_table_of_contents: true
 import {DetailHero, Section, SectionHead, CtaBanner} from '@conduction/docusaurus-preset/components';
 
 <DetailHero
+  background="cobalt"
   appId="open-webui"
   crumb={[{label: 'Sidecars', href: '/sidecars'}, 'Open WebUI']}
   status={{label: 'Sidecar', color: 'var(--c-cobalt-400)'}}

--- a/src/pages/sidecars/openklant.mdx
+++ b/src/pages/sidecars/openklant.mdx
@@ -7,6 +7,7 @@ hide_table_of_contents: true
 import {DetailHero, Section, SectionHead, CtaBanner} from '@conduction/docusaurus-preset/components';
 
 <DetailHero
+  background="cobalt"
   appId="openklant"
   crumb={[{label: 'Sidecars', href: '/sidecars'}, 'OpenKlant']}
   status={{label: 'Sidecar', color: 'var(--c-cobalt-400)'}}

--- a/src/pages/sidecars/opentalk.mdx
+++ b/src/pages/sidecars/opentalk.mdx
@@ -7,6 +7,7 @@ hide_table_of_contents: true
 import {DetailHero, Section, SectionHead, CtaBanner} from '@conduction/docusaurus-preset/components';
 
 <DetailHero
+  background="cobalt"
   appId="opentalk"
   crumb={[{label: 'Sidecars', href: '/sidecars'}, 'OpenTalk']}
   status={{label: 'Sidecar', color: 'var(--c-cobalt-400)'}}

--- a/src/pages/sidecars/openzaak.mdx
+++ b/src/pages/sidecars/openzaak.mdx
@@ -7,6 +7,7 @@ hide_table_of_contents: true
 import {DetailHero, Section, SectionHead, CtaBanner} from '@conduction/docusaurus-preset/components';
 
 <DetailHero
+  background="cobalt"
   appId="openzaak"
   crumb={[{label: 'Sidecars', href: '/sidecars'}, 'OpenZaak']}
   status={{label: 'Sidecar', color: 'var(--c-cobalt-400)'}}

--- a/src/pages/sidecars/valtimo.mdx
+++ b/src/pages/sidecars/valtimo.mdx
@@ -7,6 +7,7 @@ hide_table_of_contents: true
 import {DetailHero, Section, SectionHead, CtaBanner} from '@conduction/docusaurus-preset/components';
 
 <DetailHero
+  background="cobalt"
   appId="valtimo"
   crumb={[{label: 'Sidecars', href: '/sidecars'}, 'Valtimo']}
   status={{label: 'Sidecar', color: 'var(--c-cobalt-400)'}}

--- a/src/pages/solutions/archief.mdx
+++ b/src/pages/solutions/archief.mdx
@@ -7,6 +7,7 @@ hide_table_of_contents: true
 import {DetailHero, Section, SectionHead, FeatureList, FeatureItem, PairRow, PairCard, CtaBanner} from '@conduction/docusaurus-preset/components';
 
 <DetailHero
+  background="cobalt"
   crumb={[{label: 'Solutions', href: '/solutions'}, 'Archief']}
   status={{label: 'Productie-ready', color: 'var(--c-mint-500)'}}
   version="Sector: Publieke sector + zorg"

--- a/src/pages/solutions/mkb-workspace.mdx
+++ b/src/pages/solutions/mkb-workspace.mdx
@@ -7,6 +7,7 @@ hide_table_of_contents: true
 import {DetailHero, Section, SectionHead, FeatureList, FeatureItem, HowSteps, HowStep, PairRow, PairCard, CtaBanner} from '@conduction/docusaurus-preset/components';
 
 <DetailHero
+  background="cobalt"
   crumb={[{label: 'Solutions', href: '/solutions'}, 'MKB workspace']}
   status={{label: 'Productie-ready', color: 'var(--c-mint-500)'}}
   version="Sector: MKB"

--- a/src/pages/solutions/zaakafhandeling.mdx
+++ b/src/pages/solutions/zaakafhandeling.mdx
@@ -7,6 +7,7 @@ hide_table_of_contents: true
 import {DetailHero, Section, SectionHead, FeatureList, FeatureItem, PairRow, PairCard, CtaBanner} from '@conduction/docusaurus-preset/components';
 
 <DetailHero
+  background="cobalt"
   crumb={[{label: 'Solutions', href: '/solutions'}, 'ZaakAfhandelApp']}
   status={{label: 'Productie-ready', color: 'var(--c-mint-500)'}}
   version="Sector: Publieke sector"


### PR DESCRIPTION
## Summary

Applies the cobalt-bg hero treatment (already in use on the per-app docs sites at `{slug}.conduction.nl`) to the marketing site's app, solution, and sidecar pages.

- Adds `background=\"cobalt\"` to `<DetailHero/>` on all 17 app pages, all 3 remaining solution pages, and all 8 sidecar pages.
- Moves the Wikipedia-style intro paragraph that PR #55 introduced under each app's `<DetailHero/>` into the new `intro={<>...</>}` prop on the hero. Previously that prose sat at MDX-root and stretched edge-to-edge (the marketing-page MDXPage swizzle has no width container by design); inside the hero, the preset's `.intro` rule constrains it to a 70ch read-measure with cobalt-100 text on the cobalt panel.
- Bumps `@conduction/docusaurus-preset` to `^3.11.0` (ships the new `intro` prop, released 2026-05-19).

Locally verified against `openregister.conduction.nl` styling on `/apps/openregister/`, `/solutions/woo/`, `/sidecars/n8n/`.

## Test plan

- [ ] Build passes (`npm run build`)
- [ ] AI-baseline gate passes
- [ ] CodeQL pass
- [ ] Visual check on a deploy preview matches the per-app docs hero