### PR TITLE
feat(quality): present policy statements as paper-card documents

### DIFF
--- a/i18n/nl/docusaurus-plugin-content-pages/quality.mdx
+++ b/i18n/nl/docusaurus-plugin-content-pages/quality.mdx
@@ -189,9 +189,30 @@ export const QualityHeroIllustration = (
   </figure>
 </div>
 
-### Beleidsverklaring kwaliteits- en informatieveiligheidsmanagementsysteem
+<div style={{background: 'white', border: '1px solid var(--c-cobalt-100)', borderRadius: 8, boxShadow: '0 2px 16px rgba(33, 70, 139, 0.06)', padding: '40px clamp(20px, 4vw, 56px)', maxWidth: 820, margin: '40px auto 0'}}>
 
-_Conduction B.V. — vastgesteld januari 2025. ISO 9001:2015 en ISO 27001:2022 certificaten afgegeven 24 juli 2025. Tekst overgenomen uit de ondertekende beleidsverklaring._
+<div style={{borderBottom: '2px solid var(--c-cobalt-100)', paddingBottom: 24, marginBottom: 28}}>
+  <div style={{fontFamily: 'var(--conduction-typography-font-family-code)', fontSize: 10, fontWeight: 700, letterSpacing: '0.12em', textTransform: 'uppercase', color: 'var(--c-orange-knvb)', marginBottom: 6}}>Beleidsverklaring</div>
+  <h3 style={{margin: 0, marginBottom: 18, fontSize: 28}} id="beleidsverklaring">Kwaliteits- en informatieveiligheidsmanagementsysteem</h3>
+  <dl style={{display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))', gap: '14px 28px', margin: 0}}>
+    <div>
+      <dt style={{fontSize: 10, fontWeight: 700, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--c-cobalt-500, #6f7da3)', marginBottom: 4}}>Norm</dt>
+      <dd style={{margin: 0, fontFamily: 'var(--conduction-typography-font-family-code)', fontSize: 13, color: 'var(--c-cobalt-900)', fontWeight: 600}}>ISO 9001:2015 · ISO 27001:2022</dd>
+    </div>
+    <div>
+      <dt style={{fontSize: 10, fontWeight: 700, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--c-cobalt-500, #6f7da3)', marginBottom: 4}}>Vastgesteld</dt>
+      <dd style={{margin: 0, fontFamily: 'var(--conduction-typography-font-family-code)', fontSize: 13, color: 'var(--c-cobalt-900)', fontWeight: 600}}>januari 2025</dd>
+    </div>
+    <div>
+      <dt style={{fontSize: 10, fontWeight: 700, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--c-cobalt-500, #6f7da3)', marginBottom: 4}}>Certificaten</dt>
+      <dd style={{margin: 0, fontFamily: 'var(--conduction-typography-font-family-code)', fontSize: 13, color: 'var(--c-cobalt-900)', fontWeight: 600}}>24 juli 2025</dd>
+    </div>
+    <div>
+      <dt style={{fontSize: 10, fontWeight: 700, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--c-cobalt-500, #6f7da3)', marginBottom: 4}}>Volgende review</dt>
+      <dd style={{margin: 0, fontFamily: 'var(--conduction-typography-font-family-code)', fontSize: 13, color: 'var(--c-cobalt-900)', fontWeight: 600}}>februari 2027</dd>
+    </div>
+  </dl>
+</div>
 
 Conduction, opgericht in 2018, streeft naar een betere digitale wereld door democratische, inclusieve en transparante software te ontwikkelen volgens de Common Ground-principes. Als Digital Socials richten we ons op het creëren van digitale oplossingen voor maatschappelijke vraagstukken, met 'Tech to serve people' als leidraad.
 
@@ -215,6 +236,12 @@ De scope van het kwaliteits- en informatieveiligheidssysteem betreft productontw
 Kwaliteit, informatiebeveiliging, continue evaluatie en klanttevredenheid staan centraal bij Conduction. Op 24 juli 2025 zijn de certificaten voor ISO 9001:2015 en ISO 27001:2022 verkregen.
 
 Voor meer informatie over ons kwaliteits- en informatieveiligheidssysteem kunt u contact met ons opnemen via [info@conduction.nl](mailto:info@conduction.nl).
+
+<div style={{marginTop: 36, paddingTop: 20, borderTop: '2px solid var(--c-cobalt-100)', fontSize: 13, color: 'var(--c-cobalt-700)', fontStyle: 'italic'}}>
+  Vastgesteld door de directie van Conduction B.V. — Amsterdam. Tekst overgenomen uit de ondertekende beleidsverklaring van januari 2025.
+</div>
+
+</div>
 
 </Section>
 

--- a/src/pages/quality.mdx
+++ b/src/pages/quality.mdx
@@ -189,9 +189,30 @@ export const QualityHeroIllustration = (
   </figure>
 </div>
 
-### Quality policy statement
+<div style={{background: 'white', border: '1px solid var(--c-cobalt-100)', borderRadius: 8, boxShadow: '0 2px 16px rgba(33, 70, 139, 0.06)', padding: '40px clamp(20px, 4vw, 56px)', maxWidth: 820, margin: '40px auto 0'}}>
 
-_ISO 9001:2015 §5.2 — Quality Policy. Certificates first issued 24 July 2025. Last policy review: April 2026. Next review: annual management review cycle, February 2027._
+<div style={{borderBottom: '2px solid var(--c-cobalt-100)', paddingBottom: 24, marginBottom: 28}}>
+  <div style={{fontFamily: 'var(--conduction-typography-font-family-code)', fontSize: 10, fontWeight: 700, letterSpacing: '0.12em', textTransform: 'uppercase', color: 'var(--c-orange-knvb)', marginBottom: 6}}>Policy statement</div>
+  <h3 style={{margin: 0, marginBottom: 18, fontSize: 28}} id="quality-policy-statement">Quality policy</h3>
+  <dl style={{display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))', gap: '14px 28px', margin: 0}}>
+    <div>
+      <dt style={{fontSize: 10, fontWeight: 700, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--c-cobalt-500, #6f7da3)', marginBottom: 4}}>Reference</dt>
+      <dd style={{margin: 0, fontFamily: 'var(--conduction-typography-font-family-code)', fontSize: 13, color: 'var(--c-cobalt-900)', fontWeight: 600}}>ISO 9001:2015 §5.2</dd>
+    </div>
+    <div>
+      <dt style={{fontSize: 10, fontWeight: 700, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--c-cobalt-500, #6f7da3)', marginBottom: 4}}>First issued</dt>
+      <dd style={{margin: 0, fontFamily: 'var(--conduction-typography-font-family-code)', fontSize: 13, color: 'var(--c-cobalt-900)', fontWeight: 600}}>24 July 2025</dd>
+    </div>
+    <div>
+      <dt style={{fontSize: 10, fontWeight: 700, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--c-cobalt-500, #6f7da3)', marginBottom: 4}}>Last review</dt>
+      <dd style={{margin: 0, fontFamily: 'var(--conduction-typography-font-family-code)', fontSize: 13, color: 'var(--c-cobalt-900)', fontWeight: 600}}>April 2026</dd>
+    </div>
+    <div>
+      <dt style={{fontSize: 10, fontWeight: 700, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--c-cobalt-500, #6f7da3)', marginBottom: 4}}>Next review</dt>
+      <dd style={{margin: 0, fontFamily: 'var(--conduction-typography-font-family-code)', fontSize: 13, color: 'var(--c-cobalt-900)', fontWeight: 600}}>February 2027</dd>
+    </div>
+  </dl>
+</div>
 
 Conduction is committed to delivering high-quality open-source software and services for digital government infrastructure. Our Quality Management System (QMS) is designed to consistently meet customer requirements and applicable regulatory requirements, and to enhance customer satisfaction.
 
@@ -217,9 +238,36 @@ Conduction's management commits to:
 3. Ensuring this policy is understood, implemented, and maintained at all levels of the organisation.
 4. Reviewing this policy at least annually as part of the management review cycle.
 
-### Information-security policy statement
+<div style={{marginTop: 36, paddingTop: 20, borderTop: '2px solid var(--c-cobalt-100)', fontSize: 13, color: 'var(--c-cobalt-700)', fontStyle: 'italic'}}>
+  Adopted by the management of Conduction B.V. — Amsterdam, the Netherlands.
+</div>
 
-_ISO 27001:2022 §5.2 — Information Security Policy; Annex A.5.1. Last review: April 2026. Next review: annual management review cycle, February 2027._
+</div>
+
+<div style={{background: 'white', border: '1px solid var(--c-cobalt-100)', borderRadius: 8, boxShadow: '0 2px 16px rgba(33, 70, 139, 0.06)', padding: '40px clamp(20px, 4vw, 56px)', maxWidth: 820, margin: '40px auto 0'}}>
+
+<div style={{borderBottom: '2px solid var(--c-cobalt-100)', paddingBottom: 24, marginBottom: 28}}>
+  <div style={{fontFamily: 'var(--conduction-typography-font-family-code)', fontSize: 10, fontWeight: 700, letterSpacing: '0.12em', textTransform: 'uppercase', color: 'var(--c-orange-knvb)', marginBottom: 6}}>Policy statement</div>
+  <h3 style={{margin: 0, marginBottom: 18, fontSize: 28}} id="information-security-policy-statement">Information-security policy</h3>
+  <dl style={{display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))', gap: '14px 28px', margin: 0}}>
+    <div>
+      <dt style={{fontSize: 10, fontWeight: 700, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--c-cobalt-500, #6f7da3)', marginBottom: 4}}>Reference</dt>
+      <dd style={{margin: 0, fontFamily: 'var(--conduction-typography-font-family-code)', fontSize: 13, color: 'var(--c-cobalt-900)', fontWeight: 600}}>ISO 27001:2022 §5.2 · Annex A.5.1</dd>
+    </div>
+    <div>
+      <dt style={{fontSize: 10, fontWeight: 700, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--c-cobalt-500, #6f7da3)', marginBottom: 4}}>First issued</dt>
+      <dd style={{margin: 0, fontFamily: 'var(--conduction-typography-font-family-code)', fontSize: 13, color: 'var(--c-cobalt-900)', fontWeight: 600}}>24 July 2025</dd>
+    </div>
+    <div>
+      <dt style={{fontSize: 10, fontWeight: 700, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--c-cobalt-500, #6f7da3)', marginBottom: 4}}>Last review</dt>
+      <dd style={{margin: 0, fontFamily: 'var(--conduction-typography-font-family-code)', fontSize: 13, color: 'var(--c-cobalt-900)', fontWeight: 600}}>April 2026</dd>
+    </div>
+    <div>
+      <dt style={{fontSize: 10, fontWeight: 700, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--c-cobalt-500, #6f7da3)', marginBottom: 4}}>Next review</dt>
+      <dd style={{margin: 0, fontFamily: 'var(--conduction-typography-font-family-code)', fontSize: 13, color: 'var(--c-cobalt-900)', fontWeight: 600}}>February 2027</dd>
+    </div>
+  </dl>
+</div>
 
 Conduction protects the confidentiality, integrity, and availability of the information it handles — including customer data, internal systems, and the open-source software it develops and operates. This policy establishes the framework for Conduction's Information Security Management System (ISMS) in accordance with ISO 27001:2022.
 
@@ -249,6 +297,12 @@ All information assets related to the design, development, implementation, and s
 - **Business continuity (A.5.29)** — documented for every critical service.
 
 The privacy side of the ISMS is described in the [privacy policy](/privacy).
+
+<div style={{marginTop: 36, paddingTop: 20, borderTop: '2px solid var(--c-cobalt-100)', fontSize: 13, color: 'var(--c-cobalt-700)', fontStyle: 'italic'}}>
+  Adopted by the management of Conduction B.V. — Amsterdam, the Netherlands.
+</div>
+
+</div>
 
 </Section>
 


### PR DESCRIPTION
Each policy now renders inside a white paper card on the tinted page section:

- Orange POLICY STATEMENT eyebrow + h3 title
- Four-column metadata grid (Reference / First issued / Last review / Next review) in mono type
- Top + bottom dividers
- Italic attribution footer

Gives the statements an official, document-on-desk feel without changing any of the body text. The EN policy keeps the same prose; the NL card wraps the verbatim signed January-2025 beleidsverklaring with an attribution footer noting the source.