### PR TITLE
feat(quality): add 'How We Work' (docs.conduction.nl) as 5th tool

### DIFF
--- a/i18n/nl/docusaurus-plugin-content-pages/quality.mdx
+++ b/i18n/nl/docusaurus-plugin-content-pages/quality.mdx
@@ -34,7 +34,7 @@ export const QualityHeroIllustration = (
       textTransform: 'uppercase',
       color: 'rgba(255,255,255,0.65)',
     }}>
-      <span>Certificaten · scans · workflow</span>
+      <span>Certificaten · handboek · scans · workflow</span>
       <span style={{color: 'var(--c-mint-300)'}}>● live</span>
     </div>
     <div style={{display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12}}>
@@ -48,6 +48,10 @@ export const QualityHeroIllustration = (
       </div>
     </div>
     <div style={{display: 'flex', flexDirection: 'column', gap: 8}}>
+      <div style={{display: 'flex', alignItems: 'center', justifyContent: 'space-between', fontFamily: 'var(--conduction-typography-font-family-code)', fontSize: 11, color: 'rgba(255,255,255,0.85)'}}>
+        <span>docs.conduction.nl · operationeel handboek</span>
+        <span style={{background: 'var(--c-mint-500)', color: 'var(--c-cobalt-900)', padding: '2px 8px', borderRadius: 3, fontWeight: 700, fontSize: 9, letterSpacing: '0.05em'}}>LIVE</span>
+      </div>
       <div style={{display: 'flex', alignItems: 'center', justifyContent: 'space-between', fontFamily: 'var(--conduction-typography-font-family-code)', fontSize: 11, color: 'rgba(255,255,255,0.85)'}}>
         <span>pentest-tools.com · wekelijkse scan</span>
         <span style={{background: 'var(--c-mint-500)', color: 'var(--c-cobalt-900)', padding: '2px 8px', borderRadius: 3, fontWeight: 700, fontSize: 9, letterSpacing: '0.05em'}}>SCHOON</span>
@@ -65,7 +69,7 @@ export const QualityHeroIllustration = (
   crumb={[{label: 'Over ons', href: '/about'}, 'Kwaliteit']}
   locales="ISO 9001:2015 · ISO 27001:2022"
   title={<>Kwaliteit,<br/>met een K.</>}
-  tagline={<>Eén geïntegreerd kwaliteits- en informatiebeveiligingsmanagementsysteem. ISO 9001:2015 en ISO 27001:2022 verankeren de beleidskaders, pentest-tools.com verzorgt de doorlopende externe scans, en het volledige bouwproces staat publiek op GitHub. Samen leveren ze scope, audittrail en doorlopende borging voor elke Conduction-app.</>}
+  tagline={<>Eén managementsysteem, vijf tools die het waarmaken. ISO 9001:2015 en ISO 27001:2022 leggen vast hoe Conduction moet werken en wat we meten. Het <strong>How We Work</strong>-handboek op docs.conduction.nl vertaalt dat naar de uitvoering. pentest-tools.com en de GitHub-native kwaliteitsworkflow toetsen de uitkomst. Elke regel code, elke dienst — dezelfde voorspelbare kwaliteit.</>}
   primaryCta={{label: 'Lees de beleidsverklaring', href: '#iso-certifications', tone: 'orange'}}
   secondaryCta={{label: 'Compliance FAQ', href: '#compliance-faq'}}
   iconColor="var(--c-orange-knvb)"
@@ -76,8 +80,8 @@ export const QualityHeroIllustration = (
 <div id="quality-tools" />
 <Showcase
   eyebrow="Kwaliteitstools"
-  title="Waarmee we kwaliteit meetbaar houden."
-  lede="De vier pijlers onder ons KMS en ISMS. De twee ISO-certificaten verankeren het managementsysteem, het commerciële pentest-platform levert continue externe borging en de GitHub-workflow houdt elke codewijziging in dezelfde audittrail."
+  title="Waarmee we kwaliteit voorspelbaar houden."
+  lede="Vijf tools, gelaagd. ISO 9001 en 27001 leggen vast wat goed is en hoe we meten. Het How We Work-handboek vertaalt dat naar de dagelijkse uitvoering. pentest-tools.com en de GitHub-workflow toetsen de uitkomst — extern én intern — bij elke release."
   layout="side"
   defaultOpen="iso-9001"
   items={[
@@ -108,6 +112,32 @@ export const QualityHeroIllustration = (
             alt="ISO 27001:2022 certificaat, Conduction B.V."
             style={{maxWidth: 220, width: '100%', height: 'auto', boxShadow: '0 8px 24px rgba(0,0,0,0.15)', borderRadius: 4}}
           />
+        </div>
+      ),
+    },
+    {
+      id: 'how-we-work',
+      title: 'How We Work — operationeel handboek.',
+      summary: "docs.conduction.nl is de operationele laag onder het managementsysteem. Het vertaalt het ISO-beleid naar de dagelijkse procedures die elke (digitale) medewerker volgt: onboarding, rollen, software bouwen, klantondersteuning, de Hydra-pipeline en ISO-mapping clause voor clause. Publiek, in versiebeheer, en dezelfde bron die elke reviewer en auditor leest.",
+      cta: {label: 'Open het handboek', href: 'https://docs.conduction.nl/'},
+      panel: (
+        <div style={{padding: 20, background: 'var(--c-cobalt-50)', borderRadius: 8, minHeight: 280, fontFamily: 'var(--conduction-typography-font-family-code)', fontSize: 11, color: 'var(--c-cobalt-900)'}}>
+          <div style={{fontWeight: 700, marginBottom: 12, color: 'var(--c-cobalt-700)'}}>docs.conduction.nl — handboek-onderdelen</div>
+          <div style={{display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8}}>
+            {[
+              {hex: 'var(--c-blue-cobalt)', label: 'Identity'},
+              {hex: 'var(--c-orange-knvb)', label: 'Way of Work'},
+              {hex: 'var(--c-mint-500)', label: 'Hydra-pipeline'},
+              {hex: 'var(--c-lavender-300)', label: 'Claude-workflow'},
+              {hex: 'var(--c-cobalt-700)', label: 'ISO-compliance'},
+              {hex: 'var(--c-forest-300)', label: 'Roadmap'},
+            ].map((s, i) => (
+              <div key={i} style={{display: 'flex', alignItems: 'center', gap: 8, background: 'white', padding: '8px 10px', borderRadius: 4, border: '1px solid var(--c-cobalt-100)'}}>
+                <span style={{width: 14, height: 16, clipPath: 'polygon(50% 0%, 100% 25%, 100% 75%, 50% 100%, 0% 75%, 0% 25%)', background: s.hex, flexShrink: 0}} />
+                <span style={{fontWeight: 600}}>{s.label}</span>
+              </div>
+            ))}
+          </div>
         </div>
       ),
     },
@@ -245,12 +275,25 @@ Voor meer informatie over ons kwaliteits- en informatieveiligheidssysteem kunt u
 
 </Section>
 
-<div id="pentest-tools" />
+<div id="how-we-work" />
 <Section spacing="default">
+
+## How We Work — operationeel handboek
+
+Het ISO-beleid zegt waartoe Conduction zich verbindt. Het handboek op **[docs.conduction.nl](https://docs.conduction.nl/)** vertaalt die toezeggingen naar de procedures die elke (digitale) medewerker dagelijks volgt — hoe we onboarden, hoe we software bouwen, hoe we customer support draaien, hoe de Hydra-pipeline loopt, hoe de Claude-workflow elke wijziging beoordeelt. Het is de operationele laag die het managementsysteem in praktijk brengt.
+
+**Onderdelen.** _Way of Work_ (het handboek zelf), _Hydra_ (onze spec-gedreven CI/CD-pipeline), _Claude-workflow_ (de conventies en skills die de dagelijkse ontwikkeling sturen), _ISO-compliance_ (clause-by-clause-mapping van de normen naar onze engineering-pipeline), _Identity_ (brand en visuele regels) en de publieke _Roadmap_.
+
+**Hoe past het in het managementsysteem.** Elke operationele procedure staat in versiebeheer op GitHub en loopt door hetzelfde PR-+-reviewproces dat hieronder onder [Kwaliteitsworkflow op GitHub](#github-workflow) beschreven staat. Auditors lezen dezelfde bron als elke medewerker — geen parallel handboek om bij te houden.
+
+</Section>
+
+<div id="pentest-tools" />
+<Section spacing="default" background="tinted">
 
 ## Pentest-tools
 
-Doorlopende externe borging is de derde pijler van het managementsysteem. Conduction heeft een abonnement op het commerciële SaaS-scanplatform **[pentest-tools.com](https://app.pentest-tools.com/)** en draait daarop geplande tests tegen de productievlakken van onze apps, de managed Common Ground-omgeving op commonground.nu en de marketingvlakken onder conduction.nl.
+Doorlopende externe borging. Conduction heeft een abonnement op het commerciële SaaS-scanplatform **[pentest-tools.com](https://app.pentest-tools.com/)** en draait daarop geplande tests tegen de productievlakken van onze apps, de managed Common Ground-omgeving op commonground.nu en de marketingvlakken onder conduction.nl.
 
 Het platform combineert een website-vulnerabilityscanner, een netwerkscanner, een CVE-check op de draaiende stack, TLS-configuratie-audits en subdomain enumeration. De dekking volgt de OWASP Top 10 en de controls in ISO 27001:2022 Annex A.8 (technologische maatregelen).
 
@@ -259,7 +302,7 @@ Het platform combineert een website-vulnerabilityscanner, een netwerkscanner, ee
 </Section>
 
 <div id="github-workflow" />
-<Section spacing="default" background="tinted">
+<Section spacing="default">
 
 ## Kwaliteitsworkflow op GitHub
 
@@ -281,7 +324,7 @@ Elke Conduction-app staat publiek op GitHub onder de [ConductionNL](https://gith
 
 ## Aanverwante compliance-signalen
 
-Naast de twee ISO-certificeringen, de pentest-scans en de GitHub-workflow ziet het inkooprelevante compliance-beeld voor Conduction er zo uit:
+Naast de twee ISO-certificeringen, het operationele handboek, de pentest-scans en de GitHub-workflow ziet het inkooprelevante compliance-beeld voor Conduction er zo uit:
 
 - **ISAE 3402.** De managed hosting op commonground.nu draait op infrastructuur van [Cyso](https://www.cyso.nl/) onder ISAE 3402 Type II. Hun verklaring sturen we op verzoek toe.
 - **BIO.** De afstemming op de Baseline Informatiebeveiliging Overheid loopt. Statusupdates komen hier zodra die rond is.

--- a/src/pages/quality.mdx
+++ b/src/pages/quality.mdx
@@ -34,7 +34,7 @@ export const QualityHeroIllustration = (
       textTransform: 'uppercase',
       color: 'rgba(255,255,255,0.65)',
     }}>
-      <span>Certificates · scans · workflow</span>
+      <span>Certificates · handbook · scans · workflow</span>
       <span style={{color: 'var(--c-mint-300)'}}>● live</span>
     </div>
     <div style={{display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12}}>
@@ -48,6 +48,10 @@ export const QualityHeroIllustration = (
       </div>
     </div>
     <div style={{display: 'flex', flexDirection: 'column', gap: 8}}>
+      <div style={{display: 'flex', alignItems: 'center', justifyContent: 'space-between', fontFamily: 'var(--conduction-typography-font-family-code)', fontSize: 11, color: 'rgba(255,255,255,0.85)'}}>
+        <span>docs.conduction.nl · operating handbook</span>
+        <span style={{background: 'var(--c-mint-500)', color: 'var(--c-cobalt-900)', padding: '2px 8px', borderRadius: 3, fontWeight: 700, fontSize: 9, letterSpacing: '0.05em'}}>LIVE</span>
+      </div>
       <div style={{display: 'flex', alignItems: 'center', justifyContent: 'space-between', fontFamily: 'var(--conduction-typography-font-family-code)', fontSize: 11, color: 'rgba(255,255,255,0.85)'}}>
         <span>pentest-tools.com · weekly scan</span>
         <span style={{background: 'var(--c-mint-500)', color: 'var(--c-cobalt-900)', padding: '2px 8px', borderRadius: 3, fontWeight: 700, fontSize: 9, letterSpacing: '0.05em'}}>CLEAN</span>
@@ -65,7 +69,7 @@ export const QualityHeroIllustration = (
   crumb={[{label: 'About', href: '/about'}, 'Quality']}
   locales="ISO 9001:2015 · ISO 27001:2022"
   title={<>Quality,<br/>with a Q.</>}
-  tagline={<>One integrated quality and information-security management system. ISO 9001:2015 and ISO 27001:2022 anchor the policies, pentest-tools.com runs the continuous scans, and the entire build flow lives in public on GitHub. Together they cover scope, audit trail, and ongoing assurance for every Conduction app.</>}
+  tagline={<>One management system, five tools that prove it works. ISO 9001:2015 and ISO 27001:2022 set how Conduction should run and what we measure. The <strong>How We Work</strong> handbook at docs.conduction.nl translates that into operations. pentest-tools.com and the GitHub-native quality workflow test the outcome. Every line of code, every service we deliver — the same predictable quality.</>}
   primaryCta={{label: 'Read the policy', href: '#iso-certifications', tone: 'orange'}}
   secondaryCta={{label: 'Compliance FAQ', href: '#compliance-faq'}}
   iconColor="var(--c-orange-knvb)"
@@ -76,8 +80,8 @@ export const QualityHeroIllustration = (
 <div id="quality-tools" />
 <Showcase
   eyebrow="Quality tools"
-  title="What we use to keep quality measurable."
-  lede="The four pillars our QMS and ISMS lean on. The two ISO certificates anchor the management system, the commercial pentest platform supplies continuous external assurance, and the GitHub workflow keeps every code change inside the same audit trail."
+  title="What we use to keep quality predictable."
+  lede="Five tools, layered. ISO 9001 and 27001 define what good looks like and how we measure it. The How We Work handbook turns that into day-to-day operations. pentest-tools.com and the GitHub workflow test the outcome — externally and internally — every release."
   layout="side"
   defaultOpen="iso-9001"
   items={[
@@ -108,6 +112,32 @@ export const QualityHeroIllustration = (
             alt="ISO 27001:2022 certificate, Conduction B.V."
             style={{maxWidth: 220, width: '100%', height: 'auto', boxShadow: '0 8px 24px rgba(0,0,0,0.15)', borderRadius: 4}}
           />
+        </div>
+      ),
+    },
+    {
+      id: 'how-we-work',
+      title: 'How We Work — operating handbook.',
+      summary: "docs.conduction.nl is the operational layer of the management system. It translates the ISO policies into the day-to-day procedures every (digital) employee follows: onboarding, roles, building software, customer support, the Hydra pipeline, and clause-by-clause ISO mapping. Public, version-controlled, and the same source every reviewer and auditor reads.",
+      cta: {label: 'Open the handbook', href: 'https://docs.conduction.nl/'},
+      panel: (
+        <div style={{padding: 20, background: 'var(--c-cobalt-50)', borderRadius: 8, minHeight: 280, fontFamily: 'var(--conduction-typography-font-family-code)', fontSize: 11, color: 'var(--c-cobalt-900)'}}>
+          <div style={{fontWeight: 700, marginBottom: 12, color: 'var(--c-cobalt-700)'}}>docs.conduction.nl — handbook sections</div>
+          <div style={{display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8}}>
+            {[
+              {hex: 'var(--c-blue-cobalt)', label: 'Identity'},
+              {hex: 'var(--c-orange-knvb)', label: 'Way of Work'},
+              {hex: 'var(--c-mint-500)', label: 'Hydra pipeline'},
+              {hex: 'var(--c-lavender-300)', label: 'Claude workflow'},
+              {hex: 'var(--c-cobalt-700)', label: 'ISO compliance'},
+              {hex: 'var(--c-forest-300)', label: 'Roadmap'},
+            ].map((s, i) => (
+              <div key={i} style={{display: 'flex', alignItems: 'center', gap: 8, background: 'white', padding: '8px 10px', borderRadius: 4, border: '1px solid var(--c-cobalt-100)'}}>
+                <span style={{width: 14, height: 16, clipPath: 'polygon(50% 0%, 100% 25%, 100% 75%, 50% 100%, 0% 75%, 0% 25%)', background: s.hex, flexShrink: 0}} />
+                <span style={{fontWeight: 600}}>{s.label}</span>
+              </div>
+            ))}
+          </div>
         </div>
       ),
     },
@@ -306,12 +336,25 @@ The privacy side of the ISMS is described in the [privacy policy](/privacy).
 
 </Section>
 
-<div id="pentest-tools" />
+<div id="how-we-work" />
 <Section spacing="default">
+
+## How We Work — operating handbook
+
+The ISO policies say what Conduction is committed to. The handbook at **[docs.conduction.nl](https://docs.conduction.nl/)** translates those commitments into the procedures every (digital) employee actually follows day to day — how we onboard, how we build software, how we run customer support, how the Hydra pipeline operates, how the Claude workflow gates change. It is the operational layer that makes the management system real.
+
+**Sections.** _Way of Work_ (the handbook itself), _Hydra_ (our spec-driven CI/CD pipeline), _Claude workflow_ (the conventions and skills that drive day-to-day development), _ISO compliance_ (clause-by-clause mapping from the standards to our engineering pipeline), _Identity_ (brand and visual rules), and the public _Roadmap_.
+
+**How it fits the management system.** Every operating procedure is in version control on GitHub and follows the same PR + review process described under [Quality workflow on GitHub](#github-workflow) below. Auditors read the same source every employee does — there is no parallel handbook to keep in sync.
+
+</Section>
+
+<div id="pentest-tools" />
+<Section spacing="default" background="tinted">
 
 ## Pentest tools
 
-Continuous external assurance is the third leg of the management system. Conduction subscribes to the commercial **[pentest-tools.com](https://app.pentest-tools.com/)** SaaS scanning platform and runs scheduled tests against the production surfaces of our apps, the managed Common Ground tenant at commonground.nu, and the marketing surfaces under conduction.nl.
+Continuous external assurance. Conduction subscribes to the commercial **[pentest-tools.com](https://app.pentest-tools.com/)** SaaS scanning platform and runs scheduled tests against the production surfaces of our apps, the managed Common Ground tenant at commonground.nu, and the marketing surfaces under conduction.nl.
 
 The platform combines a website vulnerability scanner, a network scanner, a CVE checker against the running stack, TLS configuration auditing, and subdomain enumeration. Coverage maps to the OWASP Top 10 and the controls in ISO 27001:2022 Annex A.8 (technological controls).
 
@@ -320,7 +363,7 @@ The platform combines a website vulnerability scanner, a network scanner, a CVE 
 </Section>
 
 <div id="github-workflow" />
-<Section spacing="default" background="tinted">
+<Section spacing="default">
 
 ## Quality workflow on GitHub
 
@@ -342,7 +385,7 @@ Every Conduction app lives in public on GitHub under the [ConductionNL](https://
 
 ## Related compliance signals
 
-Beyond the two ISO certifications, pentest scans, and the GitHub workflow, the procurement-relevant compliance picture for Conduction is:
+Beyond the two ISO certifications, the operating handbook, the pentest scans, and the GitHub workflow, the procurement-relevant compliance picture for Conduction is:
 
 - **ISAE 3402** — managed hosting at commonground.nu runs on infrastructure operated by [Cyso](https://www.cyso.nl/) under ISAE 3402 Type II. Their attestation is available on request.
 - **BIO** — Baseline Informatiebeveiliging Overheid alignment is in progress. Status updates land here when complete.


### PR DESCRIPTION
Reframes /quality around five layered tools, one management system:

| Layer | Tool | Role |
|---|---|---|
| Define | ISO 9001:2015 + ISO 27001:2022 | What good looks like, what we measure |
| Operate | **How We Work** (docs.conduction.nl) | Translates policy into day-to-day procedures |
| Verify externally | pentest-tools.com | Continuous scans against production |
| Verify internally | GitHub-native workflow | Code + security review, audit trail |

Every line of code, every service we deliver — same predictable quality.

## Changes

- **Hero** tagline rewritten around the five-tools framing; the right-side illustration adds a `docs.conduction.nl · operating handbook · LIVE` status row alongside the existing pentest CLEAN and GitHub MERGED rows.
- **Showcase** accordion: new 'How We Work' item between ISO 27001 and Pentest, with a panel that mocks the handbook section grid (Identity, Way of Work, Hydra, Claude workflow, ISO compliance, Roadmap).
- New 'How We Work — operating handbook' section between ISO and Pentest, explaining the operational layer and pointing to the handbook live at docs.conduction.nl.
- Tinted/white section alternation reshuffled to keep visual rhythm with the new section inserted.
- Related-compliance intro updated to include the handbook in the list.
- NL mirrors all of the above (handbook brand kept as 'How We Work', body copy translated, panel labels Dutch).

Production build green both locales; visual verified against served build.