### PR TITLE
feat(quality): 'Around the pipeline' as bullet list (identity-kit Troubleshooting visual)

### DIFF
--- a/i18n/nl/docusaurus-plugin-content-pages/quality.mdx
+++ b/i18n/nl/docusaurus-plugin-content-pages/quality.mdx
@@ -477,13 +477,10 @@ Elke Conduction-app staat publiek op GitHub onder de [ConductionNL](https://gith
 
 ### Om de pipeline heen
 
-**Branch protection.** Drie organisatie-brede rulesets dwingen overal dezelfde regels af: ten minste één goedkeurende review om naar `development` te mergen, ten minste twee reviews om naar `main` te mergen. Directe pushes naar beschermde branches zijn geblokkeerd.
-
-**Tweesporen-review.** Pull requests krijgen de juiste reviewer via labels — `code-review:queued` start de code-review tegen PHPCS / PHPMD / Psalm / PHPStan (of `ruff`/`mypy`/ESLint per stack); `security-review:queued` start een informatiebeveiligingsreview tegen de relevante ISO 27001:2022 Annex A-controls.
-
-**Hydra-automatisering.** Routinematig review-werk loopt via Hydra — kijkt naar PR-labels, stuurt review-jobs naar gespecialiseerde agents en schrijft bevindingen terug als PR-comments. Een menselijke reviewer keurt goed voor de merge.
-
-**Spec-gedreven wijzigingen.** Grotere wijzigingen dragen een OpenSpec change-folder en een ADR. Spec naast de code, ADR voor de architecturale beslissing, PR verwijst naar beide. Dat levert de documentatiesporen die ISO 9001:2015 §7.5 vraagt — zonder een parallel kwaliteitshandboek bij te houden.
+- **Branch protection** — drie organisatie-brede rulesets dwingen overal dezelfde regels af: ten minste één goedkeurende review om naar `development` te mergen, ten minste twee reviews om naar `main` te mergen. Directe pushes naar beschermde branches zijn geblokkeerd.
+- **Tweesporen-review** — pull requests krijgen de juiste reviewer via labels: `code-review:queued` start de code-review tegen PHPCS / PHPMD / Psalm / PHPStan (of `ruff` / `mypy` / ESLint per stack); `security-review:queued` start een informatiebeveiligingsreview tegen de relevante ISO 27001:2022 Annex A-controls.
+- **Hydra-automatisering** — routinematig review-werk loopt via Hydra, die naar PR-labels kijkt, review-jobs naar gespecialiseerde agents stuurt en bevindingen terugschrijft als PR-comments. Een menselijke reviewer keurt goed voor de merge.
+- **Spec-gedreven wijzigingen** — grotere wijzigingen dragen een OpenSpec change-folder en een ADR mee. Spec naast de code, ADR voor de architecturale beslissing, PR verwijst naar beide — de documentatiesporen die ISO 9001:2015 §7.5 vraagt, zonder een parallel kwaliteitshandboek bij te houden.
 
 </Section>
 

--- a/src/pages/quality.mdx
+++ b/src/pages/quality.mdx
@@ -538,13 +538,10 @@ Every Conduction app lives in public on GitHub under the [ConductionNL](https://
 
 ### Around the pipeline
 
-**Branch protection.** Three org-wide rulesets enforce the same rules everywhere: at least one approving review to merge into `development`, at least two reviews to merge into `main`. Direct pushes to protected branches are blocked.
-
-**Two-track review.** Pull requests pick up the right reviewer through labels — `code-review:queued` triggers the code-quality review against PHPCS / PHPMD / Psalm / PHPStan (or `ruff`/`mypy`/ESLint per stack); `security-review:queued` triggers an information-security review against the relevant ISO 27001:2022 Annex A controls.
-
-**Hydra automation.** Routine review runs through Hydra — it watches PR labels, dispatches review jobs to specialised agents, and writes findings back as PR comments. Human reviewers approve before merge.
-
-**Spec-driven changes.** Larger changes carry an OpenSpec change folder and an ADR. Spec next to the code, ADR for the architectural decision, PR cites both. That gives the documentation trail required by ISO 9001:2015 §7.5 without a parallel quality-handbook to keep in sync.
+- **Branch protection** — three org-wide rulesets enforce the same rules everywhere: at least one approving review to merge into `development`, at least two reviews to merge into `main`. Direct pushes to protected branches are blocked.
+- **Two-track review** — pull requests pick up the right reviewer through labels: `code-review:queued` triggers the code-quality review against PHPCS / PHPMD / Psalm / PHPStan (or `ruff` / `mypy` / ESLint per stack); `security-review:queued` triggers an information-security review against the relevant ISO 27001:2022 Annex A controls.
+- **Hydra automation** — routine review runs through Hydra, which watches PR labels, dispatches review jobs to specialised agents, and writes findings back as PR comments. Human reviewers approve before merge.
+- **Spec-driven changes** — larger changes carry an OpenSpec change folder and an ADR. Spec next to the code, ADR for the architectural decision, PR cites both — the documentation trail required by ISO 9001:2015 §7.5 without a parallel quality handbook to keep in sync.
 
 </Section>
 


### PR DESCRIPTION
Mirrors the h2 + ul + li-with-strong-prefix Troubleshooting pattern from identity.conduction.nl/product-pages/integrations.html. Converts the four prose paragraphs (Branch protection, Two-track review, Hydra automation, Spec-driven changes) into a tight bulleted list with bold lead-ins and em-dash separators.

**Follow-up (not in this PR):** Lifting this into a dedicated `<NamedList>` / `<Practices>` design-system component is a @conduction/docusaurus-preset release task — the npm-published preset (v3.x) and the local design-system source (v0.1.1) are on different version trains. Filed as follow-up rather than blocking this rewrite. The markdown form already matches the screenshot visually.