### PR TITLE
feat(quality): fold How We Work heading into the WidgetShelf

### DIFF
--- a/i18n/nl/docusaurus-plugin-content-pages/quality.mdx
+++ b/i18n/nl/docusaurus-plugin-content-pages/quality.mdx
@@ -467,18 +467,11 @@ Voor meer informatie over ons kwaliteits- en informatieveiligheidssysteem kunt u
 </Section>
 
 <div id="how-we-work" />
-<Section spacing="default">
-
-## How We Work — operationeel handboek
-
-Het ISO-beleid zegt waartoe Conduction zich verbindt. Het handboek op **[docs.conduction.nl](https://docs.conduction.nl/)** vertaalt die toezeggingen naar de procedures die elke (digitale) medewerker dagelijks volgt — hoe we onboarden, hoe we software bouwen, hoe we customer support draaien, hoe de Hydra-pipeline loopt, hoe de Claude-workflow elke wijziging beoordeelt. Het is de operationele laag die het managementsysteem in praktijk brengt.
-
-</Section>
 
 <WidgetShelf
   eyebrow="docs.conduction.nl"
-  title="Zes onderdelen, één bron."
-  lede="Elke procedure staat in versiebeheer op GitHub en loopt door hetzelfde PR-+-reviewproces dat hieronder onder Kwaliteitsworkflow op GitHub staat. Auditors lezen dezelfde bron als elke medewerker — geen parallel handboek om bij te houden."
+  title="How We Work — operationeel handboek."
+  lede="Het ISO-beleid zegt waartoe Conduction zich verbindt. Het handboek op docs.conduction.nl vertaalt die toezeggingen naar de procedures die elke (digitale) medewerker dagelijks volgt — onboarding, software bouwen, customer support, de Hydra-pipeline, de Claude-workflow. Elke procedure staat in versiebeheer op GitHub en loopt door hetzelfde PR-+-reviewproces dat hieronder onder Kwaliteitsworkflow op GitHub staat; auditors lezen dezelfde bron als elke medewerker."
   widgets={[
     {
       title: 'Identity',

--- a/src/pages/quality.mdx
+++ b/src/pages/quality.mdx
@@ -528,18 +528,11 @@ The privacy side of the ISMS is described in the [privacy policy](/privacy).
 </Section>
 
 <div id="how-we-work" />
-<Section spacing="default">
-
-## How We Work — operating handbook
-
-The ISO policies say what Conduction is committed to. The handbook at **[docs.conduction.nl](https://docs.conduction.nl/)** translates those commitments into the procedures every (digital) employee actually follows day to day — how we onboard, how we build software, how we run customer support, how the Hydra pipeline operates, how the Claude workflow gates change. It is the operational layer that makes the management system real.
-
-</Section>
 
 <WidgetShelf
   eyebrow="docs.conduction.nl"
-  title="Six sections, one source of truth."
-  lede="Every procedure lives in version control on GitHub and follows the same PR + review process described under Quality workflow below. Auditors read the same source every employee does — there is no parallel handbook to keep in sync."
+  title="How We Work — operating handbook."
+  lede="The ISO policies say what Conduction is committed to. The handbook at docs.conduction.nl translates those commitments into the procedures every (digital) employee follows day to day — onboarding, building software, customer support, the Hydra pipeline, the Claude workflow. Every procedure lives in version control on GitHub and follows the same PR + review process described under Quality workflow below; auditors read the same source every employee does."
   widgets={[
     {
       title: 'Identity',


### PR DESCRIPTION
Two headings + two paragraphs (the outer h2 'How We Work — operating handbook' + the WidgetShelf's 'Six sections, one source of truth.') were stacked back-to-back with a wide visual gap between them. Merged into a single WidgetShelf header — 'How We Work — operating handbook.' — with a combined lede that covers both:

- the 'translates ISO commitments into the procedures every employee follows' framing
- the 'lives in version control / same PR + review' guarantee

Outer Section wrapper dropped (the WidgetShelf supplies its own padding). Both locales updated. Build green.