### PR TITLE
feat(quality): pentest section — daily cadence, drop ISMS-fit + contracting

### DIFF
--- a/i18n/nl/docusaurus-plugin-content-pages/quality.mdx
+++ b/i18n/nl/docusaurus-plugin-content-pages/quality.mdx
@@ -244,7 +244,7 @@ export const QualityHeroIllustration = (
         <span style={{background: 'var(--c-mint-500)', color: 'var(--c-cobalt-900)', padding: '2px 8px', borderRadius: 3, fontWeight: 700, fontSize: 9, letterSpacing: '0.05em'}}>LIVE</span>
       </div>
       <div style={{display: 'flex', alignItems: 'center', justifyContent: 'space-between', fontFamily: 'var(--conduction-typography-font-family-code)', fontSize: 11, color: 'rgba(255,255,255,0.85)'}}>
-        <span>pentest-tools.com · wekelijkse scan</span>
+        <span>pentest-tools.com · dagelijkse scan</span>
         <span style={{background: 'var(--c-mint-500)', color: 'var(--c-cobalt-900)', padding: '2px 8px', borderRadius: 3, fontWeight: 700, fontSize: 9, letterSpacing: '0.05em'}}>SCHOON</span>
       </div>
       <div style={{display: 'flex', alignItems: 'center', justifyContent: 'space-between', fontFamily: 'var(--conduction-typography-font-family-code)', fontSize: 11, color: 'rgba(255,255,255,0.85)'}}>
@@ -335,7 +335,7 @@ export const QualityHeroIllustration = (
     {
       id: 'pentest',
       title: 'Pentest-tools.com — Doorlopende externe scans.',
-      summary: "Conduction gebruikt het commerciële SaaS-platform pentest-tools.com om geplande penetratietesten te draaien tegen onze publieke vlakken en de managed Common Ground-omgeving. De scans dekken de OWASP Top 10, bekende CVE's, TLS-hygiëne en kwetsbaarheden in webapplicaties af. Bevindingen lopen via ons standaard incidentproces, met kritieke en hoge CVE's binnen 30 dagen gepatcht conform ISO 27001:2022 Annex A.8.8.",
+      summary: "Conduction draait dagelijks penetratietests tegen elke applicatie via het commerciële SaaS-scanplatform pentest-tools.com. De dekking beslaat de OWASP Top 10, bekende CVE's, TLS-hygiëne, netwerk-exposure en subdomain enumeration. Komt er een bevinding boven, dan triëren we hem en starten de opvolging binnen 8 werkuren.",
       cta: {label: 'Bekijk hoe we scannen', href: '#pentest-tools'},
       panel: (
         <div style={{padding: 20, background: 'var(--c-cobalt-50)', borderRadius: 8, minHeight: 280, fontFamily: 'var(--conduction-typography-font-family-code)', fontSize: 12, color: 'var(--c-cobalt-900)'}}>
@@ -524,11 +524,9 @@ Voor meer informatie over ons kwaliteits- en informatieveiligheidssysteem kunt u
 
 ## Pentest-tools
 
-Doorlopende externe borging. Conduction heeft een abonnement op het commerciële SaaS-scanplatform **[pentest-tools.com](https://app.pentest-tools.com/)** en draait daarop geplande tests tegen de productievlakken van onze apps, de managed Common Ground-omgeving op commonground.nu en de marketingvlakken onder conduction.nl.
+Conduction draait **dagelijks** penetratietests tegen elke applicatie via het commerciële SaaS-scanplatform **[pentest-tools.com](https://app.pentest-tools.com/)**. De dekking beslaat de OWASP Top 10, bekende CVE's, TLS-hygiëne, netwerk-exposure en subdomain enumeration — tegen onze apps, de managed Common Ground-omgeving op commonground.nu en de marketingvlakken onder conduction.nl.
 
-Het platform combineert een website-vulnerabilityscanner, een netwerkscanner, een CVE-check op de draaiende stack, TLS-configuratie-audits en subdomain enumeration. De dekking volgt de OWASP Top 10 en de controls in ISO 27001:2022 Annex A.8 (technologische maatregelen).
-
-**Hoe past dit in het ISMS?** Bevindingen lopen via hetzelfde incidentproces dat in het beleid staat. Kritieke en hoge CVE's activeren de 30-dagen-patch-SLA uit Annex A.8.8. Elke scanrun wordt vastgelegd; de samenvatting van de laatste scan wordt besproken in de maandelijkse MT-kwaliteits­vergadering. Volledige pentestrapporten zijn beschikbaar voor klanten onder NDA — mail naar [info@conduction.nl](mailto:info@conduction.nl) met je contract- of aanbestedingsreferentie.
+Komt er een bevinding boven, dan triëren we hem en starten de opvolging **binnen 8 werkuren**.
 
 </Section>
 
@@ -580,7 +578,7 @@ Naast de twee ISO-certificeringen, het operationele handboek, de pentest-scans e
     Nee. Zelf hosten betekent jouw Nextcloud-instance, jouw infrastructuur, jouw data. Ons ISO 27001-certificaat dekt de eigen systemen van Conduction en de apps die we ontwikkelen. De beveiliging van de data die je in OpenRegister op je eigen server zet, is jouw verantwoordelijkheid. Wil je dat onze certificering ook de hosting dekt, gebruik dan onze managed Common Ground-omgeving op commonground.nu.
   </FAQItem>
   <FAQItem question="Hoe vaak draaien jullie de pentests?">
-    De pentest-tools.com scans lopen op een doorlopend schema tegen de productievlakken. De volledige multi-vector scan loopt minimaal maandelijks; de gerichte scans (TLS, CVE, OWASP Top 10) lopen wekelijks. Bevindingen boven het medium-niveau worden binnen dezelfde week opgepakt, en kritieke of hoge CVE's activeren de 30-dagen-patch-SLA uit ISO 27001:2022 Annex A.8.8.
+    Dagelijks, tegen elke applicatie. De pentest-tools.com-scans dekken de OWASP Top 10, bekende CVE's, TLS-hygiëne, netwerk-exposure en subdomain enumeration af. Komt er een bevinding boven, dan triëren we hem en starten de opvolging binnen 8 werkuren.
   </FAQItem>
   <FAQItem question="Is Conduction BIO-compliant?">
     De afstemming op de Baseline Informatiebeveiliging Overheid loopt. We gebruiken de BIO-controleset als gap-analyse tegen onze bestaande ISO 27001-controls en publiceren hier een status­update zodra die rond is. ISO 27001:2022 dekt het grootste deel van de BIO-vereisten al af, daarom beschouwen de meeste overheidsklanten Conduction nu al als inkoop-klaar.

--- a/src/pages/quality.mdx
+++ b/src/pages/quality.mdx
@@ -244,7 +244,7 @@ export const QualityHeroIllustration = (
         <span style={{background: 'var(--c-mint-500)', color: 'var(--c-cobalt-900)', padding: '2px 8px', borderRadius: 3, fontWeight: 700, fontSize: 9, letterSpacing: '0.05em'}}>LIVE</span>
       </div>
       <div style={{display: 'flex', alignItems: 'center', justifyContent: 'space-between', fontFamily: 'var(--conduction-typography-font-family-code)', fontSize: 11, color: 'rgba(255,255,255,0.85)'}}>
-        <span>pentest-tools.com · weekly scan</span>
+        <span>pentest-tools.com · daily scan</span>
         <span style={{background: 'var(--c-mint-500)', color: 'var(--c-cobalt-900)', padding: '2px 8px', borderRadius: 3, fontWeight: 700, fontSize: 9, letterSpacing: '0.05em'}}>CLEAN</span>
       </div>
       <div style={{display: 'flex', alignItems: 'center', justifyContent: 'space-between', fontFamily: 'var(--conduction-typography-font-family-code)', fontSize: 11, color: 'rgba(255,255,255,0.85)'}}>
@@ -335,7 +335,7 @@ export const QualityHeroIllustration = (
     {
       id: 'pentest',
       title: 'Pentest-tools.com — Continuous external scans.',
-      summary: "Conduction uses the commercial pentest-tools.com SaaS platform to run external penetration tests against our public surfaces and the managed Common Ground tenant. Scheduled scans cover the OWASP Top 10, common CVEs, TLS hygiene, and web-application vulnerabilities. Findings flow into our standard incident-management process, with critical and high CVEs patched within 30 days per ISO 27001:2022 Annex A.8.8.",
+      summary: "Conduction runs penetration tests against every application daily, using the commercial pentest-tools.com SaaS scanning platform. Coverage spans the OWASP Top 10, common CVEs, TLS hygiene, network exposure, and subdomain enumeration. When a finding appears, we triage and start handling it within 8 business hours.",
       cta: {label: 'See how we scan', href: '#pentest-tools'},
       panel: (
         <div style={{padding: 20, background: 'var(--c-cobalt-50)', borderRadius: 8, minHeight: 280, fontFamily: 'var(--conduction-typography-font-family-code)', fontSize: 12, color: 'var(--c-cobalt-900)'}}>
@@ -585,11 +585,9 @@ The privacy side of the ISMS is described in the [privacy policy](/privacy).
 
 ## Pentest tools
 
-Continuous external assurance. Conduction subscribes to the commercial **[pentest-tools.com](https://app.pentest-tools.com/)** SaaS scanning platform and runs scheduled tests against the production surfaces of our apps, the managed Common Ground tenant at commonground.nu, and the marketing surfaces under conduction.nl.
+Conduction runs penetration tests against every application **daily**, using the commercial **[pentest-tools.com](https://app.pentest-tools.com/)** SaaS scanning platform. Coverage spans the OWASP Top 10, common CVEs, TLS hygiene, network exposure, and subdomain enumeration — across our apps, the managed Common Ground tenant at commonground.nu, and the marketing surfaces under conduction.nl.
 
-The platform combines a website vulnerability scanner, a network scanner, a CVE checker against the running stack, TLS configuration auditing, and subdomain enumeration. Coverage maps to the OWASP Top 10 and the controls in ISO 27001:2022 Annex A.8 (technological controls).
-
-**How it fits the ISMS.** Findings flow into the same incident-management process described in the security policy. Critical and high CVEs trigger the 30-day patch SLA in Annex A.8.8. Every scan run is recorded; the last-scan summary is reviewed at the monthly MT quality meeting. The full pentest reports are available to clients under NDA — write to [info@conduction.nl](mailto:info@conduction.nl) with your contract or tender reference.
+If a finding pops up we triage and start handling it **within 8 business hours**.
 
 </Section>
 
@@ -641,7 +639,7 @@ Beyond the two ISO certifications, the operating handbook, the pentest scans, an
     No. Self-hosted means your Nextcloud instance, your infrastructure, your data. Our ISO 27001 covers Conduction's own systems and the apps we develop. The security of the data you store in OpenRegister on your own server is your responsibility. If you want our certification to cover hosting too, use our managed Common Ground tenant at commonground.nu.
   </FAQItem>
   <FAQItem question="How often do you run the pentests?">
-    The pentest-tools.com scans run on a continuous schedule against the production surfaces. The full multi-vector scan runs at least monthly; the targeted scans (TLS, CVE, OWASP Top 10) run weekly. Findings above the medium threshold are triaged within the same week, and critical or high CVEs trigger the 30-day patch SLA in ISO 27001:2022 Annex A.8.8.
+    Daily, against every application. The pentest-tools.com scans cover the OWASP Top 10, common CVEs, TLS hygiene, network exposure, and subdomain enumeration. When a finding appears, we triage and start handling it within 8 business hours.
   </FAQItem>
   <FAQItem question="Is Conduction BIO compliant?">
     BIO (Baseline Informatiebeveiliging Overheid) alignment is in progress. We use the BIO control set as the gap analysis against our existing ISO 27001 controls, and we publish a status update on this page once the alignment is complete. ISO 27001:2022 covers the majority of BIO requirements already, which is why most government clients consider Conduction procurement-ready today.


### PR DESCRIPTION
Rewrites the Pentest tools section to lead with the actual cadence: pentests against every application **daily**, findings triaged within **8 business hours**. Drops the 'How it fits the ISMS' paragraph and the 'available under NDA — write to info@conduction.nl with your contract reference' bit — contracting belongs on /support, not on a quality overview page.

## Consistency updates

- Hero illustration row: 'weekly scan' → 'daily scan'
- Showcase tile summary: same daily / 8-business-hours framing
- FAQ 'How often do you run the pentests': rewritten to daily + 8 BH SLA

Both locales updated; production build green.