### PR TITLE
chore(deps): bump @conduction/docusaurus-preset to ^3.15.0 (hash-anchor hover-orange)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@conduction/docusaurus-preset": "^3.11.0",
+        "@conduction/docusaurus-preset": "^3.15.0",
         "@docusaurus/core": "^3.5.0",
         "@docusaurus/plugin-client-redirects": "^3.5.0",
         "@docusaurus/preset-classic": "^3.5.0",
@@ -1989,9 +1989,9 @@
       }
     },
     "node_modules/@conduction/docusaurus-preset": {
-      "version": "3.11.1",
-      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-3.11.1.tgz",
-      "integrity": "sha512-uye0DP5t6n11Sxz+HuFG6gcfmusRWS+ObijPKY8Da69TlcMIHX7t4FySgHB62OhxfkVZcI4SUuKL3RYvw10dHA==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-3.15.0.tgz",
+      "integrity": "sha512-NqJriH3kNIn4V93B/yBPz+3to8wa3ly8BqAYokLGJo4mPh5gwn8/xITR4jIdZENKGznLhmapvPFmnPgbJ8VclQ==",
       "license": "EUPL-1.2",
       "bin": {
         "validate-ai-baseline": "bin/validate-ai-baseline.mjs"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "ci": "npm ci --legacy-peer-deps && npm run build"
   },
   "dependencies": {
-    "@conduction/docusaurus-preset": "^3.11.0",
+    "@conduction/docusaurus-preset": "^3.15.0",
     "@docusaurus/core": "^3.5.0",
     "@docusaurus/plugin-client-redirects": "^3.5.0",
     "@docusaurus/preset-classic": "^3.5.0",


### PR DESCRIPTION
Pulls in the preset's hash-anchor hover-orange rule (design-system [#23](https://github.com/ConductionNL/design-system/pull/23) → @conduction/docusaurus-preset@3.15.0). The hidden '#' glyph that appears on h2-h6 hover now lights up in KNVB orange the moment the cursor touches it, instead of staying cobalt.

No site code changes — purely a preset bump.