### PR TITLE
chore(deps): bump @conduction/docusaurus-preset to ^3.15.2 (hash-anchor always-orange)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@conduction/docusaurus-preset": "^3.15.0",
+        "@conduction/docusaurus-preset": "^3.15.2",
         "@docusaurus/core": "^3.5.0",
         "@docusaurus/plugin-client-redirects": "^3.5.0",
         "@docusaurus/preset-classic": "^3.5.0",
@@ -1989,9 +1989,9 @@
       }
     },
     "node_modules/@conduction/docusaurus-preset": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-3.15.0.tgz",
-      "integrity": "sha512-NqJriH3kNIn4V93B/yBPz+3to8wa3ly8BqAYokLGJo4mPh5gwn8/xITR4jIdZENKGznLhmapvPFmnPgbJ8VclQ==",
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-3.15.2.tgz",
+      "integrity": "sha512-3y7bD99CYsFCbUVawgq0MK9/kJ5Xrv6FFEJSjQ/z+NmPqyZzEYOYwUucrCSGm5z3RGN4I/VnPEq9yYBNXH52Nw==",
       "license": "EUPL-1.2",
       "bin": {
         "validate-ai-baseline": "bin/validate-ai-baseline.mjs"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "ci": "npm ci --legacy-peer-deps && npm run build"
   },
   "dependencies": {
-    "@conduction/docusaurus-preset": "^3.15.0",
+    "@conduction/docusaurus-preset": "^3.15.2",
     "@docusaurus/core": "^3.5.0",
     "@docusaurus/plugin-client-redirects": "^3.5.0",
     "@docusaurus/preset-classic": "^3.5.0",


### PR DESCRIPTION
Pulls in design-system [#24](https://github.com/ConductionNL/design-system/pull/24) → @conduction/docusaurus-preset@3.15.2.

Hash-anchor glyph is now KNVB orange the moment Docusaurus reveals it on heading-hover. No more cobalt default; no underline ever; same orange on hover/focus/visited.