### PR TITLE
chore(deps): bump @conduction/docusaurus-preset to ^3.15.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@conduction/docusaurus-preset": "^3.15.2",
+        "@conduction/docusaurus-preset": "^3.15.3",
         "@docusaurus/core": "^3.5.0",
         "@docusaurus/plugin-client-redirects": "^3.5.0",
         "@docusaurus/preset-classic": "^3.5.0",
@@ -1989,9 +1989,9 @@
       }
     },
     "node_modules/@conduction/docusaurus-preset": {
-      "version": "3.15.2",
-      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-3.15.2.tgz",
-      "integrity": "sha512-3y7bD99CYsFCbUVawgq0MK9/kJ5Xrv6FFEJSjQ/z+NmPqyZzEYOYwUucrCSGm5z3RGN4I/VnPEq9yYBNXH52Nw==",
+      "version": "3.15.3",
+      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-3.15.3.tgz",
+      "integrity": "sha512-ef9++93TPUBdEoJlVBu15IczX4OLttVD60azae9m4yNaQVDrJJNPU1c5Z4W4GP8n8t+98/6G/dTJ06DtnklY+g==",
       "license": "EUPL-1.2",
       "bin": {
         "validate-ai-baseline": "bin/validate-ai-baseline.mjs"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "ci": "npm ci --legacy-peer-deps && npm run build"
   },
   "dependencies": {
-    "@conduction/docusaurus-preset": "^3.15.2",
+    "@conduction/docusaurus-preset": "^3.15.3",
     "@docusaurus/core": "^3.5.0",
     "@docusaurus/plugin-client-redirects": "^3.5.0",
     "@docusaurus/preset-classic": "^3.5.0",


### PR DESCRIPTION
Follow-up to PR #94 — the bare-state hash-anchor colour was being stripped by cssnano's mergeRules pass. Preset 3.15.3 (design-system [#25](https://github.com/ConductionNL/design-system/pull/25)) puts `!important` on the colour + text-decoration + border-bottom so the bare `.hash-link` selector survives through to the compiled CSS.