### PR TITLE
i18n: fill remaining NL translations to 100%

### DIFF
--- a/i18n/nl/code.json
+++ b/i18n/nl/code.json
@@ -44,7 +44,7 @@
     "description": "The label of the link targeting the tag list page"
   },
   "theme.colorToggle.ariaLabel.mode.system": {
-    "message": "system mode",
+    "message": "systeemmodus",
     "description": "The name for the system color mode"
   },
   "theme.colorToggle.ariaLabel.mode.light": {
@@ -175,11 +175,11 @@
     "description": "The ARIA label to collapse the sidebar category"
   },
   "theme.IconExternalLink.ariaLabel": {
-    "message": "(opens in new tab)",
+    "message": "(opent in nieuw tabblad)",
     "description": "The ARIA label for the external link icon"
   },
   "theme.NavBar.navAriaLabel": {
-    "message": "Main",
+    "message": "Hoofdnavigatie",
     "description": "The ARIA label for the main navigation"
   },
   "theme.navbar.mobileLanguageDropdown.label": {
@@ -255,11 +255,11 @@
     "description": "The ARIA label for hamburger menu button of mobile navigation"
   },
   "theme.navbar.mobileDropdown.collapseButton.expandAriaLabel": {
-    "message": "Expand the dropdown",
+    "message": "Klap het dropdown-menu uit",
     "description": "The ARIA label of the button to expand the mobile dropdown navbar item"
   },
   "theme.navbar.mobileDropdown.collapseButton.collapseAriaLabel": {
-    "message": "Collapse the dropdown",
+    "message": "Klap het dropdown-menu in",
     "description": "The ARIA label of the button to collapse the mobile dropdown navbar item"
   },
   "theme.docs.sidebar.expandButtonTitle": {
@@ -385,5 +385,177 @@
   "theme.academy.newsletter.fineprint": {
     "message": "We mailen vanuit info@conduction.nl. Geen lijstverkoop.",
     "description": "Small-print line below the newsletter form"
+  },
+  "preset.footer.game.ariaLabel": {
+    "message": "Mini-game: bootjes zinken",
+    "description": "Accessible name for the footer minigame region"
+  },
+  "preset.footer.game.boatsLeft": {
+    "message": "Boten over",
+    "description": "HUD label counting boats remaining"
+  },
+  "preset.footer.game.seconds": {
+    "message": "Seconden",
+    "description": "HUD label for the seconds-remaining timer"
+  },
+  "preset.footer.game.overAriaLabel": {
+    "message": "Mini-game afgelopen",
+    "description": "Accessible name for the game-over dialog"
+  },
+  "preset.footer.game.timesUp": {
+    "message": "Tijd is om",
+    "description": "Default headline shown when the minigame timer hits zero"
+  },
+  "preset.footer.game.sunk": {
+    "message": "gezonken",
+    "description": "Suffix after the number of boats sunk in the game-over stat"
+  },
+  "preset.footer.game.playAgain": {
+    "message": "Opnieuw spelen",
+    "description": "Button label to restart the minigame"
+  },
+  "preset.footer.brandBlurb": {
+    "message": "Open-source apps voor {nextcloud}. Gebouwd en onderhouden door Conduction in Amsterdam, uitgegeven onder EUPL-1.2.",
+    "description": "Footer brand-citation paragraph. {nextcloud} is the styled Nextcloud word."
+  },
+  "preset.navbar.github.ariaLabel": {
+    "message": "GitHub-repository",
+    "description": "Default accessible label for the icon-only GitHub link in the navbar"
+  },
+  "preset.navbar.apiDocs.label": {
+    "message": "API-documentatie",
+    "description": "Default label for the API Documentation navbar link when the consuming site does not set one"
+  },
+  "preset.navbar.logoAlt": {
+    "message": "{title}-avatar",
+    "description": "Default alt text for the navbar logo. {title} is the site title."
+  },
+  "preset.featuredCard.minRead": {
+    "message": "{minutes} min lezen",
+    "description": "Duration label for text content"
+  },
+  "preset.featuredCard.minWatch": {
+    "message": "{minutes} min kijken",
+    "description": "Duration label for video content"
+  },
+  "preset.featuredCard.cta": {
+    "message": "Lees meer",
+    "description": "Default CTA label on FeaturedCard when the consuming MDX does not pass ctaLabel"
+  },
+  "preset.featuredCard.modulePart": {
+    "message": "Deel {position}",
+    "description": "Module-position label when total parts is unknown"
+  },
+  "preset.featuredCard.modulePartOf": {
+    "message": "Deel {position} van {total}",
+    "description": "Module-position label, e.g. 'Part 2 of 4'"
+  },
+  "preset.featuredCard.audienceFor": {
+    "message": "Voor: {list}",
+    "description": "Audience line under the FeaturedCard meta row"
+  },
+  "preset.contentCard.minLabel": {
+    "message": "{minutes} min",
+    "description": "Duration label for content cards"
+  },
+  "preset.contentCard.audienceFor": {
+    "message": "Voor: {list}",
+    "description": "Audience line under the ContentCard meta row"
+  },
+  "preset.moduleCard.minLabel": {
+    "message": "{minutes} min",
+    "description": "Duration label for module cards"
+  },
+  "preset.moduleCard.moduleLabel": {
+    "message": "MODULE",
+    "description": "Eyebrow label on a ModuleCard"
+  },
+  "preset.moduleCard.singlePart": {
+    "message": "1 DEEL",
+    "description": "Parts count on a single-part ModuleCard"
+  },
+  "preset.moduleCard.multipleParts": {
+    "message": "{count} DELEN",
+    "description": "Parts count on a multi-part ModuleCard"
+  },
+  "preset.moduleCard.audienceFor": {
+    "message": "Voor: {list}",
+    "description": "Audience line under the ModuleCard meta row"
+  },
+  "preset.contentTypeFilter.all": {
+    "message": "Alles",
+    "description": "Default label on the 'all' chip of the content type filter"
+  },
+  "preset.nextSteps.title": {
+    "message": "Volgende stappen",
+    "description": "Default section heading on NextSteps"
+  },
+  "preset.nextSteps.step.cta": {
+    "message": "Lees meer",
+    "description": "Default CTA label on a NextStep card"
+  },
+  "preset.gameModal.eyebrow.won": {
+    "message": "Mini-game voltooid",
+    "description": "Eyebrow above the game-over heading when the player won"
+  },
+  "preset.gameModal.eyebrow.lost": {
+    "message": "Game over",
+    "description": "Eyebrow above the game-over heading when the player lost"
+  },
+  "preset.gameModal.title.won": {
+    "message": "Mooi gespeeld.",
+    "description": "Default headline on the game-over modal when the player won"
+  },
+  "preset.gameModal.title.lost": {
+    "message": "Dat waren ze allemaal.",
+    "description": "Default headline on the game-over modal when the player lost"
+  },
+  "preset.gameModal.subtitle.won": {
+    "message": "Je hebt een verborgen Conduction-mini-game uitgespeeld.",
+    "description": "Default subtitle on the game-over modal when the player won"
+  },
+  "preset.gameModal.subtitle.lost": {
+    "message": "Probeer het opnieuw, de regen stopt niet.",
+    "description": "Default subtitle on the game-over modal when the player lost"
+  },
+  "preset.gameModal.close": {
+    "message": "Sluiten",
+    "description": "Accessible label for the close (×) button on the game-over modal"
+  },
+  "preset.gameModal.scorePill": {
+    "message": "score: {score}",
+    "description": "Default score pill text. {score} is the numeric score."
+  },
+  "preset.gameModal.progress.found": {
+    "message": "{found} / {total} mini-games gevonden",
+    "description": "Progress label below the game-over copy"
+  },
+  "preset.gameModal.cta.remaining": {
+    "message": "{remaining, plural, one {# game nog verstopt ergens. Blijf klikken.} other {# games nog verstopt ergens. Blijf klikken.}}",
+    "description": "CTA text on the game-over modal when at least one game is still hidden"
+  },
+  "preset.gameModal.cta.allFound": {
+    "message": "Alle vijf gevonden. Je hebt de kit gelezen.",
+    "description": "CTA text on the game-over modal when the player has discovered every mini-game"
+  },
+  "preset.gameModal.action.close": {
+    "message": "Sluiten",
+    "description": "Close button label on the game-over modal"
+  },
+  "preset.gameModal.action.replay": {
+    "message": "Opnieuw spelen",
+    "description": "Replay button label on the game-over modal"
+  },
+  "preset.audience.short.mkb": {
+    "message": "MKB",
+    "description": "Short audience label used in the 'For: ...' line. Slug: mkb."
+  },
+  "preset.audience.short.government": {
+    "message": "Overheid",
+    "description": "Short audience label used in the 'For: ...' line. Slug: government."
+  },
+  "preset.audience.short.developer": {
+    "message": "Developer",
+    "description": "Short audience label used in the 'For: ...' line. Slug: developer."
   }
 }

--- a/i18n/nl/docusaurus-theme-classic/footer.json
+++ b/i18n/nl/docusaurus-theme-classic/footer.json
@@ -4,7 +4,7 @@
     "description": "The title of the footer links column with title=Apps in the footer"
   },
   "link.title.Solutions": {
-    "message": "Solutions",
+    "message": "Oplossingen",
     "description": "The title of the footer links column with title=Solutions in the footer"
   },
   "link.title.Resources": {
@@ -88,7 +88,7 @@
     "description": "The label of footer link with label=Blogs linking to /academy?type=blog"
   },
   "link.item.label.Guides": {
-    "message": "Guides",
+    "message": "Gidsen",
     "description": "The label of footer link with label=Guides linking to /academy?type=guide"
   },
   "link.item.label.Tutorials": {
@@ -100,7 +100,7 @@
     "description": "The label of footer link with label=Webinars linking to /academy?type=webinar"
   },
   "link.item.label.Case studies": {
-    "message": "Case studies",
+    "message": "Klantcases",
     "description": "The label of footer link with label=Case studies linking to /academy?type=case-study"
   }
 }

--- a/i18n/nl/docusaurus-theme-classic/navbar.json
+++ b/i18n/nl/docusaurus-theme-classic/navbar.json
@@ -12,7 +12,7 @@
     "description": "Navbar item with label Apps"
   },
   "item.label.Solutions": {
-    "message": "Solutions",
+    "message": "Oplossingen",
     "description": "Navbar item with label Solutions"
   },
   "item.label.Support": {


### PR DESCRIPTION
## Summary

Brings NL translation coverage to 100% across the three theme catalogs.

### `code.json`
- Translated 5 aria-labels still in English (color toggle / NavBar / external-link icon / mobile dropdown collapse+expand).
- Added Dutch for 43 `preset.*` IDs introduced by `@conduction/docusaurus-preset@3.17.0`:
  - Footer minigame HUD (`Boats left` → `Boten over`, `Time's up` → `Tijd is om`, etc.)
  - Footer brand citation paragraph (`Open-source apps for {nextcloud}…`)
  - Navbar fallbacks (`API Documentation` → `API-documentatie`, etc.)
  - `FeaturedCard`, `ContentCard`, `ModuleCard` (audience-for line, min-read/watch, module-part counts, MODULE + N DELEN)
  - `ContentTypeFilter` (`Everything` → `Alles`)
  - `NextSteps` (default title + step CTA)
  - `GameModal` — all visible strings including ICU-plural CTA
  - `preset.audience.short.{mkb,government,developer}` for the audience-list line on cards
- 31 of those `preset.*` keys aren't extracted by `write-translations` because they live inside `node_modules/@conduction/docusaurus-preset/src/`; written manually so Docusaurus still picks them up at build time.

### `navbar.json` + `footer.json`
- `Solutions` → `Oplossingen` (both files, kept consistent).
- `Guides` → `Gidsen`, `Case studies` → `Klantcases`.

### Loanwords kept (by convention)
`Apps`, `Academy`, `Support`, `Partners`, `Team`, `Tutorials`, `Webinars`, `Blogs`, `Open source` — these are widely-used Dutch loanwords in tech contexts and stay untranslated.

## Test plan
- [ ] CI green
- [ ] On `/nl/`, footer column reads `Oplossingen` (was `Solutions`)
- [ ] On `/nl/`, navbar `Oplossingen` (was `Solutions`)
- [ ] On `/nl/academy/`, `Read more` CTAs render as `Lees meer`
- [ ] Trigger a Footer minigame on `/nl/` — HUD reads `Boten over` / `Seconden`, modal reads `Mini-game voltooid` / `Opnieuw spelen`

🤖 Generated with [Claude Code](https://claude.com/claude-code)