### PR TITLE
academy: Tutorial 0 (Three paths) + Tutorial 5 (Advanced manifest) + v2.7.0 refresh

### DIFF
--- a/academy/2026-04-20-build-an-app/index.mdx
+++ b/academy/2026-04-20-build-an-app/index.mdx
@@ -30,3 +30,9 @@ A small "incident reporter" app: one register, two schemas, a public form that p
 ## When you are done
 
 You have an installable Nextcloud app, a published API, and a working form. Total time: about half an hour if Nextcloud is already running.
+
+## Want the proper tour?
+
+This is the 30-minute teaser. The **[DeskDesk tutorial series](/academy/deskdesk-tutorial-0-three-paths)** is the four-part walkthrough that builds a real app on the same stack — starting with [Part 0: Three paths, one curriculum](/academy/deskdesk-tutorial-0-three-paths) which is the honest map of the three ways to build Conduction apps (traditional Nextcloud / OpenRegister + nextcloud-vue / full manifest), and why we teach the manifest path in the rest of the series.
+
+If this 30-minute tutorial felt like it skipped over how `App.vue`, the router, and the page components actually came together, that's because it does — Part 0 names the trade-off and Parts 1–5 walk it from the chassis up.

--- a/academy/2026-05-05-tutorial-0-three-paths/index.mdx
+++ b/academy/2026-05-05-tutorial-0-three-paths/index.mdx
@@ -1,0 +1,161 @@
+---
+slug: deskdesk-tutorial-0-three-paths
+title: "Build a Nextcloud app on the Conduction stack — Part 0: Three paths, one curriculum"
+contentType: tutorial
+authors: [conduction]
+date: 2026-05-05
+summary: Before you write a line of code, decide which of the three Conduction app-building paths fits the app you have in mind. Traditional Nextcloud, OpenRegister + nextcloud-vue, or full manifest — each one builds on what the previous gives you, and the rest of the DeskDesk series teaches the manifest path because that is where the curve becomes steep in our favour.
+tags: [App development, Architecture, OpenRegister, nextcloud-vue, Manifest, Tutorial series]
+apps: [openregister]
+durationMinutes: 15
+series: deskdesk-tutorial
+partNumber: 0
+---
+
+import {
+  Outcomes,
+  Outcome,
+  Prerequisites,
+  PrerequisiteItem,
+  NextSteps,
+  NextStep,
+  HexCard,
+} from '@conduction/docusaurus-preset/components';
+
+This is **Part 0** of the four-part DeskDesk tutorial — the orientation lap. Before scaffolds, schemas, or manifests, the most useful thing we can hand a new developer is an honest map of the three ways Conduction apps actually get built, what each one costs, and what each one gives back. The rest of the series picks one path and shows the receipts. Part 0 explains why.
+
+A second thing matters from minute one: **the manifest system and the `@conduction/nextcloud-vue` component library are two different surfaces**. The manifest is the *declarative what* — a single `manifest.json` that describes navigation, pages, configuration. `nextcloud-vue` is the *rendering how* — the `Cn*` components the manifest dispatches to (`CnAppRoot`, `CnPageRenderer`, `CnIndexPage`, `CnDetailPage`, `CnDashboardPage`, and the rest). They are technically separable. They are also so intertwined in practice that the rest of this series teaches them together, and every lesson names which surface it is touching.
+
+{/* truncate */}
+
+<Outcomes title="What you'll have at the end of Part 0">
+  <Outcome>A clear picture of the <strong>three Conduction app-building paths</strong> — traditional Nextcloud, OpenRegister + nextcloud-vue, and full manifest — with honest trade-offs for each.</Outcome>
+  <Outcome>A mental model for <strong>which path to choose</strong> based on app scope, team size, and how much of your behaviour is genuinely bespoke.</Outcome>
+  <Outcome>An understanding that <strong>OpenRegister alone</strong> already gives you RBAC, audit logging, GraphQL, and cross-app integrations — even if you write no manifest at all.</Outcome>
+  <Outcome>A clear sense of how the <strong>manifest and nextcloud-vue</strong> relate as two surfaces of the same curriculum.</Outcome>
+</Outcomes>
+
+## The three paths at a glance
+
+The same DeskDesk feature — a list of desks with a detail page, a booking dialog, and a sidebar showing audit history — can be built three ways. Pick the table cell that sounds like your team.
+
+| | **Path 1: Traditional Nextcloud** | **Path 2: OpenRegister + nextcloud-vue** | **Path 3: Manifest + nextcloud-vue** |
+|---|---|---|---|
+| **What you write** | PHP controllers, Doctrine entities + migrations, hand-rolled Vue views, custom routes, your own CRUD endpoints | Schemas in JSON, register configuration, hand-rolled Vue views built from `Cn*` components, your own `App.vue` + router | Schemas in JSON, **one `manifest.json`** describing pages + config, only the genuinely bespoke views as `type: 'custom'` |
+| **Per-app code for the DeskDesk feature above** | ~1500 LOC | ~600 LOC | ~30 LOC + the manifest |
+| **Where the data lives** | App-private database tables you defined | A shared OpenRegister register — every other app on the same Nextcloud can read/write it through the registry | Same as Path 2 |
+| **RBAC, audit log, GraphQL, cross-app references, file attachments, calendar/contacts integrations** | Build each one yourself | **Free** — OpenRegister ships them. See "What OpenRegister gives you regardless" below | **Free** — same as Path 2 |
+| **Listing pages, detail pages, filter sidebars, mass-action dialogs** | Build each one yourself | Reuse `CnIndexPage`, `CnDetailPage`, `CnDashboardPage` — schema drives the columns and forms | Reuse the same components, dispatched declaratively by `CnPageRenderer` from your `manifest.json` |
+| **Adding a `priority` field to bookings** | New migration, new controller code, new Vue field, new validation | Add field to schema → forms and tables pick it up automatically | Same as Path 2 — schema-driven all the way through |
+| **Adding a kanban board (genuinely bespoke)** | Build it | Build it as a Vue component, mount it in your router | Build it as a Vue component, declare `{type:'custom', component:'PipelineBoard'}` in the manifest |
+| **Maintenance burden across 10 similar apps** | Each app drifts. 10 list pages, 10 detail pages, all slightly different. | The Vue surface still drifts — every app's `App.vue` and router are hand-written. Schema migrations stay clean. | One manifest shape across the fleet. A lib bump fixes every app at once. |
+| **Learning curve to first working page** | Lowest if you already know Nextcloud app dev. The patterns are documented. | Medium — schemas + `Cn*` components are new but well-trodden. | Steepest *initially* — you have to grok manifest dispatch first. After Part 2 the curve inverts. |
+| **Ceiling** | Whatever you can build in PHP + Vue. No ceiling but no leverage either. | Schema-driven CRUD scales beautifully. Bespoke flows are still hand-coded Vue. | Same as Path 2 plus: every Conduction app upgrades together when the manifest schema or `nextcloud-vue` evolves. |
+
+### When each path is the right pick
+
+**Path 1 — Traditional Nextcloud** is the right pick when:
+- You're shipping a Nextcloud-native feature with no use of cross-app shared data (e.g. a Talk command extension, an OAuth provider, a calendar provider plugin).
+- You need behaviour that lives below the data layer — file storage hooks, dav endpoints, sharing extensions.
+- You're maintaining a legacy app whose patterns predate OpenRegister and a rewrite isn't justified.
+- You explicitly need the freedom to depart from the Conduction stack — bring-your-own-database, bring-your-own-frontend-framework, anything where the constraints would slow you down.
+
+**Path 2 — OpenRegister + nextcloud-vue** is the right pick when:
+- Your data is fundamentally CRUD against a small set of schemas, but you want to keep the *page composition* hand-written for now — maybe because the existing app already has a custom `App.vue`, or because you want to migrate incrementally.
+- You're prototyping and you want to feel out a few hand-rolled views before committing to a manifest-driven shape.
+- The team has not yet learned the manifest mechanics and you have a deadline.
+
+**Path 3 — Manifest + nextcloud-vue** is the right pick when:
+- The app is mostly a set of register-backed CRUD surfaces with a few bespoke flows on top — which describes the overwhelming majority of Conduction apps.
+- You want the app to stay on the upgrade train: lib bumps, schema enhancements, accessibility improvements all flow in without per-app work.
+- You're starting fresh. The total time to a working app on Path 3 is *less* than on Path 2 once you've done it once, even though the first hour is steeper.
+- You want to be able to redesign the navigation, swap a list for a dashboard, or add a wiki section by editing JSON instead of rewriting Vue.
+
+The DeskDesk tutorial series teaches **Path 3**. Part 1 lays the chassis. Part 2 introduces the manifest. Part 3 shows how a single schema annotation makes bookings appear in Nextcloud Calendar with no glue code. Part 4 adds a knowledge sidebar fed from xWiki and ships the app.
+
+## What OpenRegister gives you regardless of path
+
+This part surprises people. OpenRegister is not just "a register with CRUD endpoints" — it's a data platform that ships several Nextcloud-native superpowers the moment you put a schema in it. Whether you build on Path 2 or Path 3, you inherit all of these without writing them:
+
+<HexCard title="RBAC by schema + property">
+  Schemas declare per-property read/write permissions, group restrictions, and ownership rules. The OpenRegister API enforces them; <code>CnIndexPage</code> and <code>CnDetailPage</code> respect them; <code>CnFormDialog</code> hides fields the current user cannot write. Add a property to a schema, mark it <code>readOnly: true</code> for the <code>users</code> group, and every surface in every app respects that rule.
+</HexCard>
+
+<HexCard title="Audit log for every change">
+  Every create, update, and delete writes an audit entry. The audit trail is visible in the standard <code>CnObjectSidebar</code> tab on every detail page. Querying the audit trail is a normal OR API call — your manifest can compose audit views without writing logging code.
+</HexCard>
+
+<HexCard title="GraphQL endpoint, automatically">
+  Each register exposes a GraphQL schema generated from the JSON Schema. Cross-app queries (<em>"give me every booking where the desk is on floor 2 and the booker is in the engineering group"</em>) are one query, not a controller. The endpoint is enabled at the register level.
+</HexCard>
+
+<HexCard title="Cross-app references (schema relations)">
+  A booking schema can reference a desk schema in a different app's register. The reference is a typed UUID relation that OR resolves on read. <code>CnDetailGrid</code> renders the related object's title as a link to the other app's detail page. No HTTP roundtrip in your code.
+</HexCard>
+
+<HexCard title="Files attached to objects">
+  Every register-backed object can have files attached, stored in the user's Nextcloud Files. <code>CnObjectSidebar</code>'s built-in Files tab handles upload, preview, and download. Your schema declares the attachment property; you write zero file-handling code.
+</HexCard>
+
+<HexCard title="Calendar / Contacts / Talk integrations">
+  Annotate a schema property as <code>format: "calendar"</code> and bookings appear in the user's Nextcloud Calendar. Tag a person reference with <code>format: "contact"</code> and the linked vCard becomes a click-through. Pluggable integration registry (ADR-019) lets you add Talk threads, signed documents, or any other Nextcloud surface to a register without touching the apps that consume the register.
+</HexCard>
+
+<HexCard title="Multi-tenant defaults">
+  OR's register lifecycle handles tenant isolation at the register level. Object visibility, user scoping, and group-based read filters are configuration, not code. Apps inherit the tenant model from their register.
+</HexCard>
+
+Paths 2 and 3 both build on this foundation. Path 1 does not — every one of the bullets above is a separate engineering project if you start from raw Nextcloud.
+
+## Two surfaces, one curriculum
+
+A common confusion when reading the rest of this series: **the manifest is not the same thing as the component library**, even though we teach them together.
+
+- The **manifest** is `src/manifest.json`. It is a JSON document validated by a schema (`https://raw.githubusercontent.com/ConductionNL/nextcloud-vue/main/src/schemas/app-manifest-v2.schema.json`, currently version 2.7.0). It describes navigation entries, routes, and what each page renders. It has no runtime behaviour on its own.
+- The **component library** is `@conduction/nextcloud-vue`. It is a set of Vue 2 components prefixed `Cn*` — `CnAppRoot` mounts the app shell, `CnPageRenderer` reads the manifest and dispatches the right page component, `CnIndexPage`/`CnDetailPage`/`CnDashboardPage` render the actual page surfaces.
+
+You can use the library without the manifest. Path 2 in the table above does exactly that — a hand-rolled `App.vue` mounts `Cn*` components directly in a hand-written router. You write more Vue, but you keep the schema-driven listing/detail/form behaviour and you keep all the OpenRegister perks.
+
+You cannot use the manifest without the library. The manifest is meaningless until something reads it — `CnPageRenderer` is that something. So the manifest path is always a *manifest + library* curriculum.
+
+The implication for how to read this series:
+
+| Lesson | Manifest surface | Library surface |
+|---|---|---|
+| **Part 1: Scaffold** | none yet | `CnAppRoot` chassis |
+| **Part 2: Schemas + manifest** | introduce `manifest.json`, page types, `config` props | `CnPageRenderer` dispatch, `CnIndexPage` + `CnDetailPage` props |
+| **Part 3: Schema-driven integrations** | unchanged | calendar provider annotation flows through `CnDetailGrid` |
+| **Part 4: Knowledge tab + ship** | sidebar tabs in `config.sidebar`, `type: 'custom'` for the wiki view | host-app SFC registered as a custom component, `CnObjectSidebar` consumes manifest tabs |
+
+If you only remember one thing about the relationship: **the manifest answers "what should this app render"; the library answers "how does that get rendered". The library makes the manifest live.**
+
+## A note on choosing once vs choosing later
+
+You do not have to pick a path forever. Apps move between Path 2 and Path 3 routinely — a few of the Conduction apps started life on Path 2 and moved to Path 3 once the team learned the manifest. The migration is usually 1–2 days for an app with 5–10 schemas, because the schemas don't change at all; only `App.vue` + the router are replaced by `CnAppRoot` + a manifest.
+
+Moving from Path 1 to Path 2 or Path 3 is harder because you have to migrate the data layer to a register. Plan that as a real project, not as a refactor between sprints.
+
+## Where to go from here
+
+<NextSteps>
+  <NextStep
+    title="Part 1 — Scaffold the app"
+    href="/academy/deskdesk-tutorial-1-scaffold"
+    description="Clone the Conduction app template, rename it to DeskDesk, build, enable, see the canonical chassis. No data yet — just the bones."
+  />
+  <NextStep
+    title="Part 2 — Schemas + manifest"
+    href="/academy/deskdesk-tutorial-2-schemas-manifest"
+    description="Three JSON files become a CRUD app. Where Path 3 starts paying back the steeper initial curve."
+  />
+  <NextStep
+    title="OpenRegister documentation"
+    href="https://openregister.conduction.nl"
+    description="The data platform that powers Paths 2 and 3. Read the RBAC, audit, and GraphQL sections to see why those bullets are real."
+  />
+  <NextStep
+    title="App manifest reference"
+    href="https://nextcloud-vue.conduction.nl/docs/architecture/manifest/"
+    description="Full manifest spec — page types, slots, sidebar config, route-param sentinels, and the typed shapes introduced in schema 2.7.0."
+  />
+</NextSteps>

--- a/academy/2026-05-10-deskdesk-tutorial-1-scaffold/index.mdx
+++ b/academy/2026-05-10-deskdesk-tutorial-1-scaffold/index.mdx
@@ -23,7 +23,9 @@ import {
   HexCard,
 } from '@conduction/docusaurus-preset/components';
 
-This is **Part 1 of a four-part tutorial** that builds **DeskDesk**, a flexible desk-booking app for an open-office environment, on the full Conduction Nextcloud stack. The end product: pick a desk on a floor, book a slot, see your booking in your Nextcloud Calendar, and surface zone-specific knowledge articles from xWiki right next to the booking. Every piece reuses what `@conduction/nextcloud-vue` and OpenRegister already give you for free.
+This is **Part 1 of the DeskDesk tutorial series** — the hands-on chassis lap. If you haven't read [Part 0: Three paths, one curriculum](/academy/deskdesk-tutorial-0-three-paths) yet, that's the orientation that explains *why* we build on this stack rather than raw Nextcloud, and how the manifest and `@conduction/nextcloud-vue` work as two intertwined surfaces. Part 1 picks up after that decision is made.
+
+You'll build **DeskDesk**, a flexible desk-booking app for an open-office environment, on the full Conduction Nextcloud stack. The end product: pick a desk on a floor, book a slot, see your booking in your Nextcloud Calendar, and surface zone-specific knowledge articles from xWiki right next to the booking. Every piece reuses what `@conduction/nextcloud-vue` and OpenRegister already give you for free.
 
 In Part 1 you scaffold the app, rename it, build it, and see the canonical app chassis on screen. No data, no integrations yet. We get the bones right first.
 
@@ -36,14 +38,16 @@ In Part 1 you scaffold the app, rename it, build it, and see the canonical app c
   <Outcome>A clean foundation for Part 2, where the chassis starts holding real data.</Outcome>
 </Outcomes>
 
-## What we're building, across all four parts
+## What we're building, across the series
 
 | Part | Title | Adds |
 |---|---|---|
+| 0 | [Three paths, one curriculum](/academy/deskdesk-tutorial-0-three-paths) | The orientation lap — which path to pick and why |
 | 1 | Scaffold (you're here) | Empty app shell, chassis visible, navigable |
-| 2 | Schemas + manifest | Desk and booking schemas, full CRUD, dashboard |
-| 3 | Schema-driven integrations | Bookings appear in NC Calendar via the OpenRegister calendar provider |
-| 4 | External knowledge + ship | xWiki source via OpenConnector, sidebar tab, package, publish |
+| 2 | [Schemas + manifest](/academy/deskdesk-tutorial-2-schemas-manifest) | Desk and booking schemas, full CRUD, dashboard |
+| 3 | [Schema-driven integrations](/academy/deskdesk-tutorial-3-calendar) | Bookings appear in NC Calendar via the OpenRegister calendar provider |
+| 4 | [External knowledge + ship](/academy/deskdesk-tutorial-4-knowledge-and-ship) | xWiki source via OpenConnector, sidebar tab, package, publish |
+| 5 | [Advanced manifest features](/academy/deskdesk-tutorial-5-advanced-manifest) | actionToggles, fieldWidgets, public-mode pages, the other page types |
 
 Same shape, two repos:
 

--- a/academy/2026-05-13-deskdesk-tutorial-2-schemas-manifest/index.mdx
+++ b/academy/2026-05-13-deskdesk-tutorial-2-schemas-manifest/index.mdx
@@ -146,11 +146,11 @@ The matching path the SettingsService takes is **importFromFilePath** with a pat
 
 ## Step 4: The manifest
 
-`src/manifest.json` is the single declarative description of the app shell. Three top-level keys: `dependencies`, `menu`, `pages`.
+`src/manifest.json` is the single declarative description of the app shell. Four top-level keys you care about: `$schema`, `dependencies`, `menu`, `pages`.
 
 ```json title="src/manifest.json"
 {
-  "$schema": "https://raw.githubusercontent.com/ConductionNL/nextcloud-vue/main/src/schemas/app-manifest.schema.json",
+  "$schema": "https://raw.githubusercontent.com/ConductionNL/nextcloud-vue/main/src/schemas/app-manifest-v2.schema.json",
   "version": "1.0.0",
   "id": "deskdesk",
   "title": "DeskDesk",
@@ -162,9 +162,12 @@ The matching path the SettingsService takes is **importFromFilePath** with a pat
   ],
   "pages": [
     {"id": "desks-index",  "route": "/",          "type": "index",  "title": "deskdesk.desks.indexTitle",
-     "config": {"register": "deskdesk", "schema": "desk", "columns": ["label","floor","zone","equipment","capacity","accessibility"], "filters": ["floor","zone","equipment","accessibility"], "defaultSort": {"key": "label", "order": "asc"}}},
+     "config": {"register": "deskdesk", "schema": "desk",
+                "columns": ["label","floor","zone","equipment","capacity","accessibility"],
+                "filters": ["floor","zone","equipment","accessibility"],
+                "defaultSort": {"key": "label", "order": "asc"}}},
     {"id": "desks-detail", "route": "/desks/:id", "type": "detail", "title": "deskdesk.desks.detailTitle",
-     "config": {"register": "deskdesk", "schema": "desk"}}
+     "config": {"register": "deskdesk", "schema": "desk", "sidebar": true}}
     /* bookings + floors pages follow the same pattern */
   ]
 }
@@ -172,9 +175,11 @@ The matching path the SettingsService takes is **importFromFilePath** with a pat
 
 A few rules to note:
 
-- **`page.id` is the vue-router route name.** CnPageRenderer matches `$route.name === page.id` to pick the right page.
-- **`page.type` is closed.** `index | detail | dashboard | custom`. Use `custom` with a `component` registry entry for one-off pages.
-- **`page.config` is forwarded as props.** `register`, `schema`, `columns`, `filters`, `defaultSort` map to CnIndexPage props one-to-one.
+- **The `$schema` URL points at `app-manifest-v2.schema.json`.** This is the v2 schema (currently at version 2.7.0). It's the source of truth for what `manifest.json` is allowed to contain — your IDE picks up autocompletion and validation from it the moment the URL is present.
+- **`page.id` is the vue-router route name.** `CnPageRenderer` matches `$route.name === page.id` to pick the right page entry from `pages[]`.
+- **`page.type` is a closed enum.** The 13 supported types: `index | detail | dashboard | logs | settings | chat | files | form | wiki | map | search | roadmap | custom`. Most apps will use `index`, `detail`, `dashboard`, and `custom`; the others are there when you need them. See Part 5 for `form`/`wiki`/`search`/`map` examples.
+- **`page.config` is forwarded as props.** `register`, `schema`, `columns`, `filters`, `defaultSort` map to `CnIndexPage` props one-to-one. The renderer also forwards top-level page fields (`title`, `widgets`, `actions`, `sidebar`, `description`, `icon`) alongside `config`, and bridges `config.schema → objectType` plus `:id → objectId` for `type:'detail'` so the lib's external `CnObjectSidebar` activates automatically.
+- **`config.sidebar: true` on `type:'detail'`** activates the host's mounted `CnObjectSidebar` with its built-in tabs (Files, Notes, Tags, Tasks, Audit Trail) for the current object. Without it the detail page renders without a sidebar — useful for read-only views, but for DeskDesk every detail page wants the standard tabs, so we set it everywhere.
 
 ## Step 5: Replace App.vue and the router
 
@@ -225,12 +230,25 @@ export default new Router({
 })
 ```
 
-Every page in the manifest gets a route. Every route renders CnPageRenderer. CnPageRenderer reads the manifest, finds the matching page entry by route name, and dispatches by `page.type`:
+Every page in the manifest gets a route. Every route renders `CnPageRenderer`. `CnPageRenderer` reads the manifest, finds the matching page entry by route name, and dispatches by `page.type`. The most common dispatches:
 
-- `type: "index"` → CnIndexPage with the schema's columns + filters
-- `type: "detail"` → CnDetailPage with the schema's properties
-- `type: "dashboard"` → CnDashboardPage with the layout
-- `type: "custom"` → your registered component
+- `type: "index"` → `CnIndexPage` with the schema's columns + filters
+- `type: "detail"` → `CnDetailPage` with the schema's properties + the lib's external sidebar
+- `type: "dashboard"` → `CnDashboardPage` with the layout grid
+- `type: "form"` → `CnFormPage` for create/edit flows (supports public-mode token-scoped variant)
+- `type: "wiki"` → `CnWikiPage` for markdown-article surfaces
+- `type: "search"` → faceted cross-schema search
+- `type: "custom"` → your own SFC registered in `customComponents`
+
+Schema 2.7.0 (the current beta) introduces a few v2-only shapes worth flagging — full coverage lives in Part 5, but it's useful to know the names now:
+
+- **`config.actionToggles`** — typed object on `type:'index'` collapsing the nine `show*`/`selectable` flags into one place. `actionToggles: { showAdd: true, showEdit: false, showDelete: false }` reads cleaner than nine sibling booleans.
+- **`config.fieldWidgets[]`** — typed slot on `type:'form'` and `type:'detail'` for mounting a lib `Cn*` component as a single form field. e.g. `fieldWidgets: [{id: 'body', component: 'CnMarkdownEditor'}]`.
+- **`config.mode: 'public'`** — on `type:'form'` and `type:'detail'`, marks an unauthenticated token-scoped page. Pair with a route-param sentinel like `submitEndpoint: "/index.php/apps/myapp/api/public/:token"`.
+- **`config.sidebar: true | {...}`** — boolean or object form. Object form (`{enabled, show, register, schema, hiddenTabs, tabs}`) gives full control; the boolean is the shortcut for the common case.
+- **`_note` on `type:'custom'`** — required when the custom mounts a host-app SFC (no lib `Cn*` analogue); softened in 2.7.0 so that a custom with `component: 'CnSomething'` no longer needs it.
+
+You won't use most of those in Part 2 — three index pages, three detail pages, one dashboard, all schema-driven. They're listed here so when Part 5 reaches for them they're not surprises.
 
 ## Step 6: Delete the old views
 
@@ -289,6 +307,11 @@ This is the schema-driven discipline talked about on [nextcloud-vue.conduction.n
     title="Part 3 — Schema-driven integrations (NC Calendar)"
     href="/academy/deskdesk-tutorial-3-calendar"
     description="A single calendarProvider block on the booking schema. Bookings appear in the user's Nextcloud Calendar. No controller, no listener, no glue code."
+  />
+  <NextStep
+    title="Part 5 — Advanced manifest features"
+    href="/academy/deskdesk-tutorial-5-advanced-manifest"
+    description="actionToggles, fieldWidgets, route-param sentinels, public-mode pages, and the other page types (form, wiki, search, roadmap). The v2.7.0 features Part 2 deliberately skipped."
   />
   <NextStep
     title="Schemas and registers reference"

--- a/academy/2026-05-17-deskdesk-tutorial-4-knowledge-and-ship/index.mdx
+++ b/academy/2026-05-17-deskdesk-tutorial-4-knowledge-and-ship/index.mdx
@@ -271,7 +271,11 @@ The desk-detail page already mounts CnObjectSidebar. To add a **Knowledge tab** 
 }
 ```
 
-The `data` and `metadata` tabs use built-in widget types. The `knowledge` tab points at a custom component `knowledge-tab`, which the App registers via the `customComponents` map.
+A few things going on in that one config block:
+
+- **`config.sidebar` is in object form**, not the `sidebar: true` shorthand Part 2 used. The shorthand is the equivalent of `sidebar: {enabled: true}` — it gives you the lib's default tabs (Files / Notes / Tags / Tasks / Audit Trail). The object form lets you replace that default set with your own `tabs[]`. Use the shorthand whenever the defaults are enough; reach for the object form when you need a custom tab like `knowledge` here, or when you want to hide specific defaults with `hiddenTabs: ['files']`.
+- **`tabs[].widgets[]` vs `tabs[].component`** is the decision per-tab: declare a list of *built-in widget types* (`{type: 'data'}`, `{type: 'metadata'}`, `{type: 'audit-trail'}` — the lib renders them for you), or declare *one custom component* (`component: 'knowledge-tab'` — looked up in your app's `customComponents` map). A tab uses one or the other, never both. Built-ins are the cheap path; a custom component is the escape hatch when no built-in fits.
+- **The knowledge tab is the escape hatch.** xWiki articles aren't a generic widget the lib could ship — they're a per-app integration. So we register a Vue component and point the tab at it.
 
 Create the tab component itself at `src/views/KnowledgeTab.vue`:
 

--- a/academy/2026-05-21-deskdesk-tutorial-5-advanced-manifest/index.mdx
+++ b/academy/2026-05-21-deskdesk-tutorial-5-advanced-manifest/index.mdx
@@ -1,0 +1,316 @@
+---
+slug: deskdesk-tutorial-5-advanced-manifest
+title: "Build a Nextcloud app on the Conduction stack — Part 5: Advanced manifest features"
+contentType: tutorial
+authors: [conduction]
+date: 2026-05-21
+summary: Past the schema-driven CRUD basics, the v2.7.0 manifest schema gives you `actionToggles`, `fieldWidgets`, route-param sentinels, public-mode pages, and seven extra page types (form, wiki, search, roadmap, map, logs, settings). One tutorial that walks through each, using DeskDesk as the running example.
+tags: [App development, Manifest, OpenRegister, nextcloud-vue, Tutorial series, Advanced]
+apps: [openregister]
+durationMinutes: 30
+series: deskdesk-tutorial
+partNumber: 5
+---
+
+import {
+  Outcomes,
+  Outcome,
+  Prerequisites,
+  PrerequisiteItem,
+  NextSteps,
+  NextStep,
+  HexCard,
+} from '@conduction/docusaurus-preset/components';
+
+This is **Part 5** of the DeskDesk tutorial. Parts 1–4 got you a working app: scaffold, schemas + manifest, schema-driven Calendar, and a custom Knowledge tab. Part 5 is the "now what" — the v2.7.0 manifest features Parts 1–4 deliberately skipped so the learning curve stayed gentle. You don't need any of them to ship DeskDesk, but the moment your app needs a public form, a wiki, an admin-only listing, or a markdown editor inside a form, they save you from another round of hand-rolled Vue.
+
+Three principles run through every feature in this part: **schema-driven** (no per-page Vue), **type-safe** (the manifest schema validates every shape before runtime), and **fleet-portable** (the same JSON works in every Conduction app and gets lib upgrades for free).
+
+{/* truncate */}
+
+<Outcomes title="What you'll have at the end of Part 5">
+  <Outcome>An admin-only desks listing using <code>config.actionToggles</code> instead of nine sibling boolean flags.</Outcome>
+  <Outcome>A booking-creation form with a markdown notes field, declared via <code>config.fieldWidgets</code> — no Vue file written.</Outcome>
+  <Outcome>A <strong>public booking-confirmation page</strong> reachable via a token URL, using <code>config.mode: 'public'</code> + route-param sentinels.</Outcome>
+  <Outcome>A <code>type:'wiki'</code> zone-guidelines surface fed by the same OpenRegister register that powers the rest of the app.</Outcome>
+  <Outcome>A <code>type:'search'</code> faceted cross-schema search page.</Outcome>
+  <Outcome>A working mental map of every v2.7.0 manifest feature so you can pick the right shape next time without re-reading docs.</Outcome>
+</Outcomes>
+
+<Prerequisites title="Before you start">
+  <PrerequisiteItem>You've finished <a href="/academy/deskdesk-tutorial-2-schemas-manifest">Part 2</a> at minimum — you have a working manifest with index and detail pages.</PrerequisiteItem>
+  <PrerequisiteItem><code>@conduction/nextcloud-vue</code> at <code>^1.0.0-beta.65</code> or newer. The features in this part rely on schema 2.7.0 typed shapes.</PrerequisiteItem>
+  <PrerequisiteItem>Your <code>src/manifest.json</code> declares the v2 schema URL (<code>app-manifest-v2.schema.json</code>). Part 2 set this up.</PrerequisiteItem>
+</Prerequisites>
+
+## 1. `config.actionToggles` — read-only listings without nine flags
+
+The classic shape, before v2.7.0, for an admin-only or read-only `type:'index'` page meant nine sibling booleans:
+
+```json title="Old shape — works but reads poorly"
+"config": {
+  "register": "deskdesk", "schema": "desk", "columns": [...],
+  "showAdd": false, "showEdit": false, "showCopy": false, "showDelete": false,
+  "showMassImport": false, "showMassCopy": false, "showMassDelete": false,
+  "selectable": false, "showFormDialog": false
+}
+```
+
+`config.actionToggles` collapses all nine into one object. The renderer flattens it back to the underlying props at dispatch time — explicit `config.<key>` still wins if you set both, so you can override a single flag without rewriting the toggle block.
+
+```json title="src/manifest.json — admin-only desks read-out"
+{"id": "desks-admin-readout",
+ "route": "/admin/desks",
+ "type": "index",
+ "title": "deskdesk.admin.desks",
+ "permission": "admin",
+ "config": {
+   "register": "deskdesk", "schema": "desk",
+   "columns": ["label","floor","zone","equipment","capacity"],
+   "actionToggles": {
+     "showAdd": false, "showEdit": false, "showCopy": false,
+     "showDelete": false, "showMassImport": false, "showMassCopy": false,
+     "showMassDelete": false, "selectable": false, "showFormDialog": false
+   }
+ }}
+```
+
+There's a shorthand for the all-off case: `config.readOnly: true` expands to the same nine flags. Use it for genuinely read-only views — audit logs, archived snapshots, anything you want the user to read but not touch.
+
+```json
+"config": {"register": "deskdesk", "schema": "desk", "readOnly": true}
+```
+
+## 2. `config.fieldWidgets` — lib widgets inside a form, no Vue file
+
+DeskDesk's booking dialog has a free-text notes field. The schema-generated input gives you a `<textarea>` — fine, but not great. You want a markdown editor with a preview pane, syntax highlighting, and the standard toolbar. Pre-v2.7.0 that meant writing a custom Vue component, registering it, and overriding the field with a `#field-notes` slot.
+
+Schema 2.7.0 typed the `fieldWidgets[]` slot on `type:'form'` and `type:'detail'` pages: each entry mounts a lib `Cn*` component for a single field by id.
+
+```json title="src/manifest.json — booking creation form"
+{"id": "bookings-create",
+ "route": "/bookings/new",
+ "type": "form",
+ "title": "deskdesk.bookings.createTitle",
+ "config": {
+   "register": "deskdesk", "schema": "booking",
+   "submitEndpoint": "/index.php/apps/openregister/api/objects/deskdesk/booking",
+   "submitMethod": "POST",
+   "mode": "create",
+   "fieldWidgets": [
+     {"id": "notes", "component": "CnMarkdownEditor"}
+   ]
+ }}
+```
+
+A few rules:
+
+- **The `component` value must match the lib `Cn*` pattern** (`^Cn[A-Z]\w+$`). Host-app SFCs go on `type:'custom'` pages, not in `fieldWidgets[]`.
+- **`id` matches a schema property name.** The widget replaces that field's auto-generated input; everything else in the form stays schema-driven.
+- **`props` is optional** — a serialisable object passed to the lib component at mount time (e.g. `{"id": "preview", "component": "CnCodeViewer", "props": {"language": "yaml"}}`).
+- **Multiple `fieldWidgets[]` entries are allowed.** Use them for whichever fields need richer editing; the rest of the form keeps its schema-driven inputs.
+
+## 3. Route-param sentinels — bind URL params to config
+
+The manifest can declare a route with `:` placeholders (`/bookings/:id`) and the params reach the dispatched component automatically. v2.7.0 also lets the manifest *use* those params inside `config`, by writing `@route.<paramName>` as a string sentinel that the renderer resolves at dispatch time:
+
+```json title="A detail page that filters by route param"
+{"id": "desk-bookings",
+ "route": "/desks/:deskId/bookings",
+ "type": "index",
+ "title": "deskdesk.desks.bookings",
+ "config": {
+   "register": "deskdesk", "schema": "booking",
+   "filter": {"desk": "@route.deskId"},
+   "columns": ["bookedBy","start","end","status"]
+ }}
+```
+
+When the user visits `/desks/abc-123/bookings`, the renderer resolves `"@route.deskId"` → `"abc-123"` and `CnIndexPage` receives `filter: {desk: "abc-123"}` — the listing only shows bookings on that desk. No Vue, no `mounted()` hook, no `watch` on `$route.params`.
+
+Unresolved sentinels become `null` (with a one-shot `console.warn` for the page id) — they don't crash the page, they just produce no filter. Useful during incremental migrations where the route hasn't been declared yet.
+
+## 4. `config.mode: 'public'` — token-scoped unauthenticated pages
+
+Public booking confirmation. The user clicks a link in an email, lands on a page that confirms their booking, sees a small form to optionally add a note, no Nextcloud login required. The page is reachable by a one-shot token — anyone with the token sees it, no one without.
+
+```json title="src/manifest.json — public booking confirmation"
+{"id": "booking-confirm",
+ "route": "/public/bookings/:token",
+ "type": "detail",
+ "title": "deskdesk.bookings.confirmTitle",
+ "config": {
+   "register": "deskdesk", "schema": "booking",
+   "mode": "public",
+   "objectId": "@route.token",
+   "sidebar": false,
+   "fieldWidgets": [
+     {"id": "guestNote", "component": "CnMarkdownEditor"}
+   ]
+ }}
+```
+
+What you get:
+
+- **`mode: "public"`** signals to the renderer and the backing API that this page is unauthenticated. The OR endpoint that serves it must accept the token query — that's wired in your `appinfo/routes.php` and a small public-mode handler in `lib/Controller/`.
+- **`objectId: "@route.token"`** uses the route sentinel to feed the token into the page's object lookup. The token is the object's external identifier in this flow.
+- **`sidebar: false`** explicitly turns off the audit/files/notes sidebar — public viewers shouldn't see the internal trail.
+- **`fieldWidgets[]`** works the same as on authenticated forms.
+
+The same shape works for `type:'form'` (a public submission form) — the form's `submitEndpoint` resolves a token sentinel too.
+
+## 5. Other page types — `wiki`, `search`, `roadmap`, `map`, `logs`, `settings`
+
+Parts 2–4 used `index`, `detail`, `dashboard`, and `custom`. v2.7.0's 13-type enum gives you several more typed surfaces that drop in by manifest alone.
+
+### `type: 'wiki'`
+
+For markdown-article surfaces fed from an OR register. Useful for zone guidelines, knowledge-base articles, internal policies — anything that's "an article rendered from a stored markdown blob".
+
+```json
+{"id": "zone-guides",
+ "route": "/zones/guides/:id",
+ "type": "wiki",
+ "title": "deskdesk.zones.guideTitle",
+ "config": {
+   "register": "deskdesk", "schema": "zoneGuide",
+   "contentField": "body",
+   "titleField": "title",
+   "idParam": "id",
+   "sidebarSchema": "zoneGuide",
+   "treeField": "children"
+ }}
+```
+
+The `contentField` is the markdown property on the article record. `sidebarSchema` (optional) turns on an in-page tree sidebar fed from the same register — perfect when the wiki has a hierarchy.
+
+### `type: 'search'`
+
+A faceted cross-schema search page. One config block declares which registers + schemas to query and which fields are facets. `CnSearchPage` does the rest.
+
+```json
+{"id": "global-search",
+ "route": "/search",
+ "type": "search",
+ "title": "deskdesk.search.title",
+ "config": {
+   "scopes": [
+     {"register": "deskdesk", "schema": "desk"},
+     {"register": "deskdesk", "schema": "booking"},
+     {"register": "deskdesk", "schema": "zoneGuide"}
+   ],
+   "facets": ["floor","zone","schema"]
+ }}
+```
+
+### `type: 'roadmap'`
+
+`CnFeaturesAndRoadmapPage` reads a manifest-declared roadmap and pulls live status from GitHub issues. Drops in for a `Features & Roadmap` menu entry in any app.
+
+```json
+{"id": "features-roadmap",
+ "route": "/roadmap",
+ "type": "roadmap",
+ "title": "deskdesk.roadmap.title",
+ "config": {
+   "repo": "ConductionNL/deskdesk",
+   "milestones": ["1.0", "1.1", "Future"]
+ }}
+```
+
+### `type: 'map'`
+
+`CnMapPage` mounts a Leaflet map with marker layers fed from a register, a static GeoJSON, or a tile source. Useful for asset locations, geo-tagged objects, or just "where on this floor plan is desk X".
+
+```json
+{"id": "floor-map",
+ "route": "/floors/:floorId/map",
+ "type": "map",
+ "title": "deskdesk.floors.mapTitle",
+ "config": {
+   "center": [52.13, 5.29], "zoom": 18,
+   "layers": [{"type": "tile", "url": "https://tile.openstreetmap.org/{z}/{x}/{y}.png"}],
+   "markers": {"dataSource": {"register": "deskdesk", "schema": "desk"},
+               "latField": "lat", "lngField": "lng", "popupField": "label"}
+ }}
+```
+
+### `type: 'logs'` and `type: 'settings'`
+
+`logs` renders an audit/event log viewer (often points at an OR-managed `auditEntry` schema or an external `source`). `settings` mounts `CnSettingsPage` with a sections-or-tabs config that ships its own form rendering — the entire app's admin surface can be one `type:'settings'` page.
+
+```json
+"settings": {
+  "id": "deskdesk-settings",
+  "route": "/settings",
+  "type": "settings",
+  "title": "deskdesk.settings.title",
+  "config": {
+    "sections": [
+      {"id": "register-mapping", "label": "Register mapping",
+       "widgets": [{"type": "register-mapping"}]},
+      {"id": "version", "label": "Version",
+       "widgets": [{"type": "version-info"}]}
+    ]
+  }
+}
+```
+
+`CnSettingsPage` has its own widget vocabulary (`version-info`, `register-mapping`, `component` for a custom mount) that's thinner than the dashboard `widgetDef`. The reference page in the nc-vue docs has the full list.
+
+## 6. The `_note` rule on `type:'custom'`, softened
+
+When you mount a host-app SFC via `type:'custom'`, the v2.7.0 schema asks you to document *why* the custom was necessary in a `_note` field. That's there to fight scope creep — every custom is a place the manifest path didn't fit, and writing the reason down forces an honest answer.
+
+```json title="A custom that needs _note"
+{"id": "pipeline-board",
+ "route": "/pipeline",
+ "type": "custom",
+ "title": "deskdesk.pipeline.title",
+ "component": "PipelineBoard",
+ "_note": "Bespoke kanban board with drag-drop column reorder + per-card status transitions. No lib analogue."}
+```
+
+2.7.0 *softens* the rule for one case: if `component` matches the lib `Cn*` pattern (`^Cn[A-Z]\w+$`), `_note` is optional because the component name already documents the choice. So:
+
+```json title="Lib Cn* custom — _note no longer required"
+{"id": "federation-status",
+ "route": "/directory",
+ "type": "custom",
+ "title": "deskdesk.directory.title",
+ "component": "CnFederationStatus"}
+```
+
+The rule still bites on host-app SFCs (no `Cn*` prefix), which is where it earns its keep.
+
+## 7. Choosing between fieldWidgets, custom pages, and registered components
+
+When you have a one-off UI need, you have three options. Picking the right one saves you a refactor later.
+
+| Need | Use | Why |
+|---|---|---|
+| A single rich field inside an otherwise schema-driven form | `config.fieldWidgets[]` with a lib `Cn*` component | Smallest scope. Form stays declarative. |
+| A whole page that doesn't fit any typed type | `type:'custom'` with `component: 'YourHostSfc'` + `_note` | Honest escape hatch. The rest of the manifest stays clean. |
+| A reusable surface (a widget or tab) that several pages want | Register an integration with `OCA.OpenRegister.integrations.register({...})` and use `useRegistry: true` | Cross-app reusable. Other Conduction apps can pick up your registration. |
+
+The bigger your `type:'custom'` count climbs, the more it's worth asking whether the underlying gap should be a lib feature instead. If you find yourself writing similar custom pages in two apps, file an issue on `nextcloud-vue` — that's how features like `CnWikiPage` and the typed `actionToggles` shape got promoted from "everyone's writing the same custom" to "first-class lib surface".
+
+## Where to go from here
+
+<NextSteps>
+  <NextStep
+    title="Full manifest schema reference"
+    href="https://nextcloud-vue.conduction.nl/docs/architecture/manifest/"
+    description="Every field, every constraint, every $def — the schema URL your manifest.json points at, rendered as docs."
+  />
+  <NextStep
+    title="Pluggable integration registry (ADR-019)"
+    href="https://nextcloud-vue.conduction.nl/docs/architecture/integrations/"
+    description="When you outgrow per-app sidebars and want cross-app tabs (Calendar, Talk, Files) to flow into every app's detail page, this is the next step up."
+  />
+  <NextStep
+    title="OpenRegister advanced patterns"
+    href="https://openregister.conduction.nl/docs/advanced/"
+    description="GraphQL endpoints, cross-register relations, formula properties — the OR features that pair best with manifest-driven apps."
+  />
+</NextSteps>


### PR DESCRIPTION
Adds two new tutorials and refreshes the existing series to match the current Conduction Academy curriculum.

## Tutorial 0 — Three paths, one curriculum (NEW)

The orientation lap before the hands-on series. Lays out the three app-building paths honestly:

| | Traditional Nextcloud | OpenRegister + nextcloud-vue | Manifest + nextcloud-vue |
|---|---|---|---|
| Per-app code (DeskDesk reference feature) | ~1500 LOC | ~600 LOC | ~30 LOC + manifest |
| RBAC / audit / GraphQL / cross-app / files / integrations | Build each one | Free from OR | Free from OR |
| Listings / detail / forms / mass actions | Build each one | Reuse `Cn*` components | Reuse, dispatched from manifest |
| Ceiling | None but no leverage | Schema-driven CRUD scales | Same as Path 2, plus fleet-wide upgrades |

Picks Path 3 for the rest of the series and explains why. Surfaces OpenRegister's inherent perks (RBAC, audit log, GraphQL, cross-app references, files, calendar/contacts/Talk integrations, multi-tenancy) so readers know what Path 2 and Path 3 *inherit* before any lib code enters the picture.

Explicit **two-surfaces framing**: manifest is the declarative "what", `@conduction/nextcloud-vue` is the rendering "how". Separable in theory, intertwined in practice. The lesson-by-lesson table names which surface each Part touches.

## Tutorial 5 — Advanced manifest features (NEW)

The v2.7.0 features Parts 1–4 deliberately skipped:

- `config.actionToggles` + `readOnly` shorthand
- Typed `fieldWidgets[]` for rich form fields (lib `Cn*` components inline)
- `@route.<param>` sentinels
- `config.mode: 'public'` for token-scoped pages
- The wiki / search / roadmap / map / logs / settings page types
- Softened `_note`-on-custom rule (optional when component matches `Cn*`)

Plus a decision table for choosing between `fieldWidgets`, custom pages, and registered integrations.

## Refreshes

- **Tutorial 2**: manifest example now uses the v2 schema URL. New rules section explains top-level forwarding, `schema → objectType` bridging, and the v2.7.0-only shapes. Page-type list expanded from 4 to 7+. Forward-link to Tutorial 5 added.
- **Tutorial 4**: sidebar object form section now spells out `widgets[]` vs `component` per-tab decision rule, `sidebar:true` shorthand vs object form, and when to reach for the custom-component escape hatch.
- **Tutorial 1**: intro routes through Tutorial 0; series table now lists all seven entries (0–5 plus the 4 hands-on parts) with cross-links.
- **build-an-app**: footer pointing at the proper series so the 30-minute teaser links into the real curriculum.

## Diff

`6 files changed, 532 insertions(+), 18 deletions(-)`