### PR TITLE
feat(homepage): pivot hero to ConNext

### DIFF
--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Public Tech for Nextcloud
-description: Open-source apps that plug into the Nextcloud workspace. Install yourself, get managed support, or bring a partner. EUPL-1.2, ISO 27001, Amsterdam.
+description: ConNext is open-source apps on Nextcloud, bundled as one workspace stack. Catalogs, registers, document handling, integrations. EUPL-1.2, ISO 27001, Amsterdam.
 hide_table_of_contents: true
 ---
 
@@ -29,10 +29,10 @@ import {APP_COUNT} from '@site/src/data/apps-catalog';
 
 <Hero
   eyebrow={<>Public Tech · open-source apps for <span className="next-blue">Nextcloud</span></>}
-  title={<>Tech to serve people.<br/>One workspace.<br/>{APP_COUNT} apps.</>}
-  lede={<>We are Conduction. We build open-source apps that plug into <span className="next-blue">Nextcloud</span>. Catalogs, registers, document handling, integrations. Install yourself, host with us as SaaS, or bring in a partner. Same code, same licence, no procurement track required.</>}
-  primaryCta={{label: <>Install from <span className="next-blue">Nextcloud</span> app store</>, href: '/apps'}}
-  secondaryCta={{label: 'Run a local demo', href: '/demo'}}
+  title={<>Tech to serve people.</>}
+  lede={<>We are Conduction. We build open-source apps that plug into <span className="next-blue">Nextcloud</span> — catalogs, registers, document handling, integrations. <span className="next-blue">ConNext</span> bundles them into one workspace stack you can roll out in days. Same code, no licence, support when you need it.</>}
+  primaryCta={{label: 'Explore ConNext', href: '/connext'}}
+  secondaryCta={{label: 'Get support', href: '/support'}}
   tertiaryCta={{label: 'View on GitHub', href: 'https://github.com/ConductionNL'}}
 >
   <HexRain />


### PR DESCRIPTION
## Summary
- Hero CTAs swap from app-store/local-demo to **Explore ConNext** (`/connext`) and **Get support** (`/support`); GitHub CTA stays.
- Title tightened to "Tech to serve people." (drops the "One workspace. {APP_COUNT} apps." lines).
- SEO description + hero lede rewritten to introduce ConNext as the bundled workspace stack. Lede ends "Same code, no licence, support when you need it."

## Notes
- Hero only — StatsStrip and bottom CtaBanner still reference app-store flow; intentional, separate follow-up.
- Verified locally on localhost:3050 (Docusaurus dev), screenshot in chat.

## Test plan
- [ ] CI build passes
- [ ] After merge: confirm www.conduction.nl hero shows new copy and CTAs