### PR TITLE
fix(academy): escape ${...} in tutorial 5 so MDX build succeeds

### DIFF
--- a/academy/2026-05-21-deskdesk-tutorial-5-integrate/index.mdx
+++ b/academy/2026-05-21-deskdesk-tutorial-5-integrate/index.mdx
@@ -359,7 +359,7 @@ Save. The endpoint URL is `http://localhost:8080/apps/openconnector/api/endpoint
 
 xWiki ships a Webhook application. Install it once from `/xwiki/bin/view/XWiki/AddOnsManagerActions` (Extension Manager → search "Webhook"). Once installed, go to the `DeskDeskMaintenance` space, **Administer Space → Webhooks → Add**:
 
-```
+```text
 Name:    deskdesk-resolved
 URL:     http://nextcloud:80/apps/openconnector/api/endpoint/xwiki-maintenance-resolved
          (container-to-container; from xWiki's container, nextcloud:80 reaches Nextcloud)
@@ -367,8 +367,8 @@ Trigger: Page updated
 Filter:  Only pages in DeskDeskMaintenance
 Auth:    Bearer <the secret you set on the OpenConnector endpoint>
 Payload: {
-  "page":       "${doc.documentReference.name}",
-  "properties": ${object.properties.json}
+  "page":       "$!{doc.documentReference.name}",
+  "properties": $!{object.properties.json}
 }
 ```
 
@@ -407,7 +407,7 @@ The DeskDesk tutorial ends here. The app is shipped, in the store, integrated wi
 </HexCard>
 
 <HexCard title="xWiki webhook reaches OpenConnector but the payload is empty">
-  xWiki's <code>${object.properties.json}</code> template is only filled when the page has an XClass attached. Add a small <code>MaintenanceClass</code> with a <code>resolved</code> boolean to the <code>DeskDeskMaintenance</code> space and reference it from the body template Part 3a generates. The webhook starts including the properties block on the next save.
+  xWiki's <code>{'${object.properties.json}'}</code> template is only filled when the page has an XClass attached. Add a small <code>MaintenanceClass</code> with a <code>resolved</code> boolean to the <code>DeskDeskMaintenance</code> space and reference it from the body template Part 3a generates. The webhook starts including the properties block on the next save.
 </HexCard>
 
 ## Where to next

--- a/i18n/nl/docusaurus-plugin-content-blog/2026-05-21-deskdesk-tutorial-5-integrate/index.mdx
+++ b/i18n/nl/docusaurus-plugin-content-blog/2026-05-21-deskdesk-tutorial-5-integrate/index.mdx
@@ -359,7 +359,7 @@ Opslaan. De endpoint-URL is `http://localhost:8080/apps/openconnector/api/endpoi
 
 xWiki heeft een Webhook-applicatie. Installeer hem één keer vanuit `/xwiki/bin/view/XWiki/AddOnsManagerActions` (Extension Manager → zoek "Webhook"). Eenmaal geïnstalleerd: ga naar de space `DeskDeskMaintenance`, **Administer Space → Webhooks → Add**:
 
-```
+```text
 Name:    deskdesk-resolved
 URL:     http://nextcloud:80/apps/openconnector/api/endpoint/xwiki-maintenance-resolved
          (container-naar-container; vanuit de xWiki-container bereikt nextcloud:80 Nextcloud)
@@ -367,8 +367,8 @@ Trigger: Page updated
 Filter:  Alleen pagina's in DeskDeskMaintenance
 Auth:    Bearer <het geheim dat je op het OpenConnector-endpoint hebt gezet>
 Payload: {
-  "page":       "${doc.documentReference.name}",
-  "properties": ${object.properties.json}
+  "page":       "$!{doc.documentReference.name}",
+  "properties": $!{object.properties.json}
 }
 ```
 
@@ -407,7 +407,7 @@ De DeskDesk-tutorial eindigt hier. De app is uitgeleverd, staat in de store, is 
 </HexCard>
 
 <HexCard title="xWiki-webhook bereikt OpenConnector, maar de payload is leeg">
-  De template <code>${object.properties.json}</code> van xWiki wordt alleen ingevuld als de pagina een XClass heeft. Voeg een kleine <code>MaintenanceClass</code> met een <code>resolved</code>-boolean toe aan de <code>DeskDeskMaintenance</code>-space, en verwijs er vanaf de body-template uit Stap 3a naar. De webhook gaat het properties-blok bij de volgende save meesturen.
+  De template <code>{'${object.properties.json}'}</code> van xWiki wordt alleen ingevuld als de pagina een XClass heeft. Voeg een kleine <code>MaintenanceClass</code> met een <code>resolved</code>-boolean toe aan de <code>DeskDeskMaintenance</code>-space, en verwijs er vanaf de body-template uit Stap 3a naar. De webhook gaat het properties-blok bij de volgende save meesturen.
 </HexCard>
 
 ## Waar nu naartoe


### PR DESCRIPTION
The deploy of #102 failed with `ReferenceError: object is not defined` because:

1. The webhook-payload code fence at tutorial 5 step 3d was unlabeled, so MDX parsed `${object.properties.json}` as a template literal.
2. The matching HexCard troubleshooting block had the same string inside JSX text where it was actively evaluated.

Both fixed:
- Code fence now has a `text` language tag (and uses the silent `$!{...}` xWiki Velocity form for good measure).
- HexCard wraps the literal in a JSX string expression: `<code>{'${object.properties.json}'}</code>`.

Hotfix to unblock the www.conduction.nl deploy.