### PR TITLE
fix(academy): Tutorial 2 manifest example matches v2 schema

### DIFF
--- a/academy/2026-05-13-deskdesk-tutorial-2-schemas-manifest/index.mdx
+++ b/academy/2026-05-13-deskdesk-tutorial-2-schemas-manifest/index.mdx
@@ -151,9 +151,7 @@ The matching path the SettingsService takes is **importFromFilePath** with a pat
 ```json title="src/manifest.json"
 {
   "$schema": "https://raw.githubusercontent.com/ConductionNL/nextcloud-vue/main/src/schemas/app-manifest-v2.schema.json",
-  "version": "1.0.0",
-  "id": "deskdesk",
-  "title": "DeskDesk",
+  "version": "2.0.0",
   "dependencies": ["openregister"],
   "menu": [
     {"id": "desks-index",    "label": "deskdesk.menu.desks",    "icon": "icon-category-organization", "route": "desks-index",    "order": 10},


### PR DESCRIPTION
When deskdesk's actual manifest was migrated to v2 (ConductionNL/deskdesk#31), top-level `id` and `title` had to be removed — v2's page-def schema has `additionalProperties: false`. Tutorial 2's copy-pasteable example still showed both, which would fail validation. Also bumps `version` to 2.0.0 to match the v2 schema URL (the field is the manifest spec version, not the app version).