### PR TITLE
copy(quality): refresh policy statement to January 2026

### DIFF
--- a/academy/2026-05-21-deskdesk-tutorial-5-integrate/index.mdx
+++ b/academy/2026-05-21-deskdesk-tutorial-5-integrate/index.mdx
@@ -359,7 +359,7 @@ Save. The endpoint URL is `http://localhost:8080/apps/openconnector/api/endpoint
 
 xWiki ships a Webhook application. Install it once from `/xwiki/bin/view/XWiki/AddOnsManagerActions` (Extension Manager → search "Webhook"). Once installed, go to the `DeskDeskMaintenance` space, **Administer Space → Webhooks → Add**:
 
-```
+```text
 Name:    deskdesk-resolved
 URL:     http://nextcloud:80/apps/openconnector/api/endpoint/xwiki-maintenance-resolved
          (container-to-container; from xWiki's container, nextcloud:80 reaches Nextcloud)
@@ -367,8 +367,8 @@ Trigger: Page updated
 Filter:  Only pages in DeskDeskMaintenance
 Auth:    Bearer <the secret you set on the OpenConnector endpoint>
 Payload: {
-  "page":       "${doc.documentReference.name}",
-  "properties": ${object.properties.json}
+  "page":       "$!{doc.documentReference.name}",
+  "properties": $!{object.properties.json}
 }
 ```
 
@@ -407,7 +407,7 @@ The DeskDesk tutorial ends here. The app is shipped, in the store, integrated wi
 </HexCard>
 
 <HexCard title="xWiki webhook reaches OpenConnector but the payload is empty">
-  xWiki's <code>${object.properties.json}</code> template is only filled when the page has an XClass attached. Add a small <code>MaintenanceClass</code> with a <code>resolved</code> boolean to the <code>DeskDeskMaintenance</code> space and reference it from the body template Part 3a generates. The webhook starts including the properties block on the next save.
+  xWiki's <code>{'${object.properties.json}'}</code> template is only filled when the page has an XClass attached. Add a small <code>MaintenanceClass</code> with a <code>resolved</code> boolean to the <code>DeskDeskMaintenance</code> space and reference it from the body template Part 3a generates. The webhook starts including the properties block on the next save.
 </HexCard>
 
 ## Where to next

--- a/i18n/nl/docusaurus-plugin-content-blog/2026-05-21-deskdesk-tutorial-5-integrate/index.mdx
+++ b/i18n/nl/docusaurus-plugin-content-blog/2026-05-21-deskdesk-tutorial-5-integrate/index.mdx
@@ -359,7 +359,7 @@ Opslaan. De endpoint-URL is `http://localhost:8080/apps/openconnector/api/endpoi
 
 xWiki heeft een Webhook-applicatie. Installeer hem één keer vanuit `/xwiki/bin/view/XWiki/AddOnsManagerActions` (Extension Manager → zoek "Webhook"). Eenmaal geïnstalleerd: ga naar de space `DeskDeskMaintenance`, **Administer Space → Webhooks → Add**:
 
-```
+```text
 Name:    deskdesk-resolved
 URL:     http://nextcloud:80/apps/openconnector/api/endpoint/xwiki-maintenance-resolved
          (container-naar-container; vanuit de xWiki-container bereikt nextcloud:80 Nextcloud)
@@ -367,8 +367,8 @@ Trigger: Page updated
 Filter:  Alleen pagina's in DeskDeskMaintenance
 Auth:    Bearer <het geheim dat je op het OpenConnector-endpoint hebt gezet>
 Payload: {
-  "page":       "${doc.documentReference.name}",
-  "properties": ${object.properties.json}
+  "page":       "$!{doc.documentReference.name}",
+  "properties": $!{object.properties.json}
 }
 ```
 
@@ -407,7 +407,7 @@ De DeskDesk-tutorial eindigt hier. De app is uitgeleverd, staat in de store, is 
 </HexCard>
 
 <HexCard title="xWiki-webhook bereikt OpenConnector, maar de payload is leeg">
-  De template <code>${object.properties.json}</code> van xWiki wordt alleen ingevuld als de pagina een XClass heeft. Voeg een kleine <code>MaintenanceClass</code> met een <code>resolved</code>-boolean toe aan de <code>DeskDeskMaintenance</code>-space, en verwijs er vanaf de body-template uit Stap 3a naar. De webhook gaat het properties-blok bij de volgende save meesturen.
+  De template <code>{'${object.properties.json}'}</code> van xWiki wordt alleen ingevuld als de pagina een XClass heeft. Voeg een kleine <code>MaintenanceClass</code> met een <code>resolved</code>-boolean toe aan de <code>DeskDeskMaintenance</code>-space, en verwijs er vanaf de body-template uit Stap 3a naar. De webhook gaat het properties-blok bij de volgende save meesturen.
 </HexCard>
 
 ## Waar nu naartoe

--- a/i18n/nl/docusaurus-plugin-content-pages/quality.mdx
+++ b/i18n/nl/docusaurus-plugin-content-pages/quality.mdx
@@ -418,48 +418,45 @@ export const QualityHeroIllustration = (
   <dl style={{display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))', gap: '14px 28px', margin: 0}}>
     <div>
       <dt style={{fontSize: 10, fontWeight: 700, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--c-cobalt-500, #6f7da3)', marginBottom: 4}}>Norm</dt>
-      <dd style={{margin: 0, fontFamily: 'var(--conduction-typography-font-family-code)', fontSize: 13, color: 'var(--c-cobalt-900)', fontWeight: 600}}>ISO 9001:2015 · ISO 27001:2022</dd>
+      <dd style={{margin: 0, fontFamily: 'var(--conduction-typography-font-family-code)', fontSize: 13, color: 'var(--c-cobalt-900)', fontWeight: 600}}>ISO 9001:2015 · ISO/IEC 27001:2022</dd>
     </div>
     <div>
       <dt style={{fontSize: 10, fontWeight: 700, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--c-cobalt-500, #6f7da3)', marginBottom: 4}}>Vastgesteld</dt>
-      <dd style={{margin: 0, fontFamily: 'var(--conduction-typography-font-family-code)', fontSize: 13, color: 'var(--c-cobalt-900)', fontWeight: 600}}>januari 2025</dd>
+      <dd style={{margin: 0, fontFamily: 'var(--conduction-typography-font-family-code)', fontSize: 13, color: 'var(--c-cobalt-900)', fontWeight: 600}}>januari 2026</dd>
     </div>
     <div>
       <dt style={{fontSize: 10, fontWeight: 700, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--c-cobalt-500, #6f7da3)', marginBottom: 4}}>Certificaten</dt>
-      <dd style={{margin: 0, fontFamily: 'var(--conduction-typography-font-family-code)', fontSize: 13, color: 'var(--c-cobalt-900)', fontWeight: 600}}>24 juli 2025</dd>
+      <dd style={{margin: 0, fontFamily: 'var(--conduction-typography-font-family-code)', fontSize: 13, color: 'var(--c-cobalt-900)', fontWeight: 600}}>24 jul 2025 – 21 jul 2028</dd>
     </div>
     <div>
       <dt style={{fontSize: 10, fontWeight: 700, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--c-cobalt-500, #6f7da3)', marginBottom: 4}}>Volgende review</dt>
-      <dd style={{margin: 0, fontFamily: 'var(--conduction-typography-font-family-code)', fontSize: 13, color: 'var(--c-cobalt-900)', fontWeight: 600}}>februari 2027</dd>
+      <dd style={{margin: 0, fontFamily: 'var(--conduction-typography-font-family-code)', fontSize: 13, color: 'var(--c-cobalt-900)', fontWeight: 600}}>januari 2027</dd>
     </div>
   </dl>
 </div>
 
-Conduction, opgericht in 2018, streeft naar een betere digitale wereld door democratische, inclusieve en transparante software te ontwikkelen volgens de Common Ground-principes. Als Digital Socials richten we ons op het creëren van digitale oplossingen voor maatschappelijke vraagstukken, met 'Tech to serve people' als leidraad.
+Conduction is in 2018 opgericht met als doel bij te dragen aan een betere digitale wereld. Wij ontwikkelen en beheren democratische, inclusieve en transparante digitale oplossingen volgens de Common Ground-principes. Als Digital Socials werken wij aan maatschappelijke vraagstukken voor publieke organisaties en overheden, met de mens centraal en *Tech to serve people* als leidraad.
 
-Onze missie is een digitale wereld te realiseren die fair, duurzaam en toegankelijk is voor iedereen. Dit doen we door democratische, inclusieve en transparante oplossingen te ontwikkelen met eerlijke verdienmodellen. Onze focus ligt op het bouwen van software en applicaties voor overheden, waarbij de mens centraal staat.
+Kwaliteit en informatiebeveiliging zijn essentieel voor het vertrouwen van onze klanten, partners en gebruikers. Conduction werkt volgens een geïntegreerd kwaliteits- en informatieveiligheidssysteem dat is ingericht conform ISO 9001:2015 en ISO/IEC 27001:2022. Dit systeem ondersteunt ons bij het beheersen van risico's, het oppakken van kansen en het continu verbeteren van onze dienstverlening volgens de Plan-Do-Check-Act-cyclus. Kwaliteits- en informatiebeveiligingsdoelstellingen stellen we jaarlijks vast en beoordelen we periodiek.
 
-Kwaliteit en informatieveiligheid zijn essentieel voor ons. We streven naar voortdurende verbetering van onze dienstverlening volgens de Plan-Do-Check-Act-cyclus. Actieve betrokkenheid bij onze omgeving, partners en stakeholders, samen met proactieve inspanningen voor nieuwe dienstverlening, verbeterde kwaliteit en informatiebeveiliging, vormen de kern van ons beleid.
+Met ons kwaliteits- en informatieveiligheidssysteem borgen we dat:
 
-Ons kwaliteits- en informatieveiligheidssysteem, conform ISO 9001:2015 en ISO 27001:2022, is ontworpen om te waarborgen dat:
+- processen en werkwijzen duidelijk zijn vastgelegd en worden nageleefd;
+- werkzaamheden doeltreffend en beheerst worden uitgevoerd, met aandacht voor risico's;
+- prestaties worden gemonitord, geëvalueerd en waar mogelijk verbeterd;
+- medewerkers inzicht hebben in hun verantwoordelijkheden en werkwijzen;
+- wordt voldaan aan toepasselijke wet- en regelgeving en contractuele verplichtingen.
 
-- werkmethoden geïdentificeerd en gedocumenteerd zijn voor duidelijkheid onder medewerkers;
-- processen doeltreffend worden uitgevoerd en beheerst, met aandacht voor risico's;
-- middelen beschikbaar zijn en processen worden bewaakt, gemeten, geanalyseerd en indien mogelijk verbeterd;
-- nieuwe medewerkers snel inzicht krijgen in de werkwijzen;
-- potentiële klanten inzicht hebben in ons kwaliteitsmanagementsysteem;
-- we voldoen aan wettelijke en overheidsverplichtingen.
+Het managementteam is verantwoordelijk voor en gecommit aan het vaststellen, uitvoeren en onderhouden van dit beleid en zorgt dat de organisatie beschikt over de benodigde mensen, middelen en informatie. We pakken kansen en mitigeren risico's. Dit delen we met onze medewerkers en laten hen hier zo veel mogelijk in meedenken. We maken tijd vrij voor onszelf, de interne auditors en medewerkers.
 
-We zijn als partners verantwoordelijk voor de uitvoering van het beleid en zorgen ervoor dat de organisatie over de mensen, informatie, middelen en materialen beschikt om het kwaliteitsbeleid te kunnen realiseren. We pakken kansen en mitigeren risico's. Dit delen we met onze medewerkers en laten hen hier zo veel mogelijk in meedenken. We maken tijd vrij voor onszelf, de interne auditors en medewerkers.
+Het toepassingsgebied van dit beleid en de certificering betreft de kwaliteit in informatieveiligheid gerelateerd aan advisering over, en het ontwikkelen en beheren van digitale oplossingen voor maatschappelijke vraagstukken.
 
-De scope van het kwaliteits- en informatieveiligheidssysteem betreft productontwikkeling, beheer/abonnementen, training en advies.
+Kwaliteit, informatiebeveiliging, continue verbetering en klanttevredenheid staan centraal bij Conduction. De certificaten ISO 9001:2015 en ISO/IEC 27001:2022 zijn afgegeven op 24 juli 2025 en geldig tot en met 21 juli 2028.
 
-Kwaliteit, informatiebeveiliging, continue evaluatie en klanttevredenheid staan centraal bij Conduction. Op 24 juli 2025 zijn de certificaten voor ISO 9001:2015 en ISO 27001:2022 verkregen.
-
-Voor meer informatie over ons kwaliteits- en informatieveiligheidssysteem kunt u contact met ons opnemen via [info@conduction.nl](mailto:info@conduction.nl).
+Voor meer informatie over ons kwaliteits- en informatieveiligheidssysteem kunt u contact met ons opnemen via [het contactformulier op onze website](/contact).
 
 <div style={{marginTop: 36, paddingTop: 20, borderTop: '2px solid var(--c-cobalt-100)', fontSize: 13, color: 'var(--c-cobalt-700)', fontStyle: 'italic'}}>
-  Vastgesteld door de directie van Conduction B.V. — Amsterdam. Tekst overgenomen uit de ondertekende beleidsverklaring van januari 2025.
+  Vastgesteld door de directie van Conduction B.V. — Amsterdam. Tekst overgenomen uit de ondertekende beleidsverklaring van januari 2026.
 </div>
 
 </div>

--- a/src/pages/quality.mdx
+++ b/src/pages/quality.mdx
@@ -414,113 +414,49 @@ export const QualityHeroIllustration = (
 
 <div style={{borderBottom: '2px solid var(--c-cobalt-100)', paddingBottom: 24, marginBottom: 28}}>
   <div style={{fontFamily: 'var(--conduction-typography-font-family-code)', fontSize: 10, fontWeight: 700, letterSpacing: '0.12em', textTransform: 'uppercase', color: 'var(--c-orange-knvb)', marginBottom: 6}}>Policy statement</div>
-  <h3 style={{margin: 0, marginBottom: 18, fontSize: 28}} id="quality-policy-statement">Quality policy</h3>
+  <h3 style={{margin: 0, marginBottom: 18, fontSize: 28}} id="policy-statement">Quality and information-security management system</h3>
   <dl style={{display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))', gap: '14px 28px', margin: 0}}>
     <div>
-      <dt style={{fontSize: 10, fontWeight: 700, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--c-cobalt-500, #6f7da3)', marginBottom: 4}}>Reference</dt>
-      <dd style={{margin: 0, fontFamily: 'var(--conduction-typography-font-family-code)', fontSize: 13, color: 'var(--c-cobalt-900)', fontWeight: 600}}>ISO 9001:2015 §5.2</dd>
+      <dt style={{fontSize: 10, fontWeight: 700, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--c-cobalt-500, #6f7da3)', marginBottom: 4}}>Standard</dt>
+      <dd style={{margin: 0, fontFamily: 'var(--conduction-typography-font-family-code)', fontSize: 13, color: 'var(--c-cobalt-900)', fontWeight: 600}}>ISO 9001:2015 · ISO/IEC 27001:2022</dd>
     </div>
     <div>
-      <dt style={{fontSize: 10, fontWeight: 700, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--c-cobalt-500, #6f7da3)', marginBottom: 4}}>First issued</dt>
-      <dd style={{margin: 0, fontFamily: 'var(--conduction-typography-font-family-code)', fontSize: 13, color: 'var(--c-cobalt-900)', fontWeight: 600}}>24 July 2025</dd>
+      <dt style={{fontSize: 10, fontWeight: 700, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--c-cobalt-500, #6f7da3)', marginBottom: 4}}>Adopted</dt>
+      <dd style={{margin: 0, fontFamily: 'var(--conduction-typography-font-family-code)', fontSize: 13, color: 'var(--c-cobalt-900)', fontWeight: 600}}>January 2026</dd>
     </div>
     <div>
-      <dt style={{fontSize: 10, fontWeight: 700, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--c-cobalt-500, #6f7da3)', marginBottom: 4}}>Last review</dt>
-      <dd style={{margin: 0, fontFamily: 'var(--conduction-typography-font-family-code)', fontSize: 13, color: 'var(--c-cobalt-900)', fontWeight: 600}}>April 2026</dd>
+      <dt style={{fontSize: 10, fontWeight: 700, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--c-cobalt-500, #6f7da3)', marginBottom: 4}}>Certificates</dt>
+      <dd style={{margin: 0, fontFamily: 'var(--conduction-typography-font-family-code)', fontSize: 13, color: 'var(--c-cobalt-900)', fontWeight: 600}}>24 Jul 2025 – 21 Jul 2028</dd>
     </div>
     <div>
       <dt style={{fontSize: 10, fontWeight: 700, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--c-cobalt-500, #6f7da3)', marginBottom: 4}}>Next review</dt>
-      <dd style={{margin: 0, fontFamily: 'var(--conduction-typography-font-family-code)', fontSize: 13, color: 'var(--c-cobalt-900)', fontWeight: 600}}>February 2027</dd>
+      <dd style={{margin: 0, fontFamily: 'var(--conduction-typography-font-family-code)', fontSize: 13, color: 'var(--c-cobalt-900)', fontWeight: 600}}>January 2027</dd>
     </div>
   </dl>
 </div>
 
-Conduction is committed to delivering high-quality open-source software and services for digital government infrastructure. Our Quality Management System (QMS) is designed to consistently meet customer requirements and applicable regulatory requirements, and to enhance customer satisfaction.
+Conduction was founded in 2018 with the aim of contributing to a better digital world. We develop and operate democratic, inclusive, and transparent digital solutions in line with the Common Ground principles. As Digital Socials we tackle societal challenges for public organisations and governments, putting people at the centre and *Tech to serve people* as our guiding principle.
 
-#### Scope
+Quality and information security are essential to the trust of our customers, partners, and users. Conduction operates an integrated quality and information-security management system designed in accordance with ISO 9001:2015 and ISO/IEC 27001:2022. This system supports us in managing risks, seizing opportunities, and continually improving our services through the Plan-Do-Check-Act cycle. Quality and information-security objectives are set annually and reviewed periodically.
 
-The design, development, implementation, and support of open-source software solutions for digital government infrastructure, delivered from the Netherlands by Conduction B.V. employees and contractors — including remote workers.
+Through our quality and information-security management system we ensure that:
 
-Excluded: hardware manufacturing, physical product distribution.
+- processes and ways of working are clearly documented and followed;
+- work is performed effectively and in a controlled manner, with attention to risk;
+- performance is monitored, evaluated, and improved where possible;
+- employees understand their responsibilities and the procedures that apply to them;
+- applicable laws, regulations, and contractual obligations are met.
 
-#### Quality objectives
+The management team is responsible for and committed to establishing, implementing, and maintaining this policy, and ensures the organisation has the people, resources, and information it needs. We seize opportunities and mitigate risks. We share this with our employees and involve them as much as possible in the thinking. We make time for ourselves, the internal auditors, and our employees.
 
-- Support tickets acknowledged within one business day.
-- Every pull request passes the automated quality gates before merge.
-- At least two process improvements implemented per quarter.
-- Every employee reviewed annually against the competence matrix.
+The scope of this policy and the certification covers quality in information security related to advising on, developing, and operating digital solutions for societal challenges.
 
-#### Management commitment
+Quality, information security, continual improvement, and customer satisfaction are central to Conduction. The ISO 9001:2015 and ISO/IEC 27001:2022 certificates were issued on 24 July 2025 and are valid through 21 July 2028.
 
-Conduction's management commits to:
-
-1. Providing the resources necessary to establish, implement, maintain, and continually improve the QMS.
-2. Communicating the importance of effective quality management and conforming to QMS requirements.
-3. Ensuring this policy is understood, implemented, and maintained at all levels of the organisation.
-4. Reviewing this policy at least annually as part of the management review cycle.
+For more information about our quality and information-security management system, please contact us via [the contact form on our website](/contact).
 
 <div style={{marginTop: 36, paddingTop: 20, borderTop: '2px solid var(--c-cobalt-100)', fontSize: 13, color: 'var(--c-cobalt-700)', fontStyle: 'italic'}}>
-  Adopted by the management of Conduction B.V. — Amsterdam, the Netherlands.
-</div>
-
-</div>
-
-<div style={{background: 'white', border: '1px solid var(--c-cobalt-100)', borderRadius: 8, boxShadow: '0 2px 16px rgba(33, 70, 139, 0.06)', padding: '40px clamp(20px, 4vw, 56px)', maxWidth: 820, margin: '40px auto 0'}}>
-
-<div style={{borderBottom: '2px solid var(--c-cobalt-100)', paddingBottom: 24, marginBottom: 28}}>
-  <div style={{fontFamily: 'var(--conduction-typography-font-family-code)', fontSize: 10, fontWeight: 700, letterSpacing: '0.12em', textTransform: 'uppercase', color: 'var(--c-orange-knvb)', marginBottom: 6}}>Policy statement</div>
-  <h3 style={{margin: 0, marginBottom: 18, fontSize: 28}} id="information-security-policy-statement">Information-security policy</h3>
-  <dl style={{display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))', gap: '14px 28px', margin: 0}}>
-    <div>
-      <dt style={{fontSize: 10, fontWeight: 700, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--c-cobalt-500, #6f7da3)', marginBottom: 4}}>Reference</dt>
-      <dd style={{margin: 0, fontFamily: 'var(--conduction-typography-font-family-code)', fontSize: 13, color: 'var(--c-cobalt-900)', fontWeight: 600}}>ISO 27001:2022 §5.2 · Annex A.5.1</dd>
-    </div>
-    <div>
-      <dt style={{fontSize: 10, fontWeight: 700, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--c-cobalt-500, #6f7da3)', marginBottom: 4}}>First issued</dt>
-      <dd style={{margin: 0, fontFamily: 'var(--conduction-typography-font-family-code)', fontSize: 13, color: 'var(--c-cobalt-900)', fontWeight: 600}}>24 July 2025</dd>
-    </div>
-    <div>
-      <dt style={{fontSize: 10, fontWeight: 700, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--c-cobalt-500, #6f7da3)', marginBottom: 4}}>Last review</dt>
-      <dd style={{margin: 0, fontFamily: 'var(--conduction-typography-font-family-code)', fontSize: 13, color: 'var(--c-cobalt-900)', fontWeight: 600}}>April 2026</dd>
-    </div>
-    <div>
-      <dt style={{fontSize: 10, fontWeight: 700, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--c-cobalt-500, #6f7da3)', marginBottom: 4}}>Next review</dt>
-      <dd style={{margin: 0, fontFamily: 'var(--conduction-typography-font-family-code)', fontSize: 13, color: 'var(--c-cobalt-900)', fontWeight: 600}}>February 2027</dd>
-    </div>
-  </dl>
-</div>
-
-Conduction protects the confidentiality, integrity, and availability of the information it handles — including customer data, internal systems, and the open-source software it develops and operates. This policy establishes the framework for Conduction's Information Security Management System (ISMS) in accordance with ISO 27001:2022.
-
-#### Scope
-
-All information assets related to the design, development, implementation, and support of our open-source software for digital government infrastructure, including:
-
-- Source code and repositories on GitHub.
-- Customer data processed via Conduction's software and hosting.
-- Internal systems (Google Workspace, Jira, Passwork, development environments).
-- Employee devices (BYOD) used for company work.
-
-#### Security objectives
-
-- Zero unauthorised access incidents per year.
-- Critical systems ≥ 99.5% uptime ([status.commonground.nu](https://status.commonground.nu)).
-- Security incidents acknowledged within four business hours.
-- Critical and high CVEs patched within 30 days.
-- Every employee completes the annual security awareness session.
-
-#### Key Annex A controls
-
-- **Access control (A.5.15)** — role-based, granted on a need-to-know basis.
-- **Cryptography (A.8.24)** — protects sensitive data in transit and at rest.
-- **Supplier relationships (A.5.19)** — assessed and contractually bound.
-- **Incident management (A.6.8)** — covers all suspected incidents.
-- **Business continuity (A.5.29)** — documented for every critical service.
-
-The privacy side of the ISMS is described in the [privacy policy](/privacy).
-
-<div style={{marginTop: 36, paddingTop: 20, borderTop: '2px solid var(--c-cobalt-100)', fontSize: 13, color: 'var(--c-cobalt-700)', fontStyle: 'italic'}}>
-  Adopted by the management of Conduction B.V. — Amsterdam, the Netherlands.
+  Adopted by the management of Conduction B.V. — Amsterdam, the Netherlands. Text taken from the signed policy statement of January 2026.
 </div>
 
 </div>


### PR DESCRIPTION
## Summary
- Replaces the body of the Quality & information-security policy statement with the signed January 2026 version.
- Collapses the EN page from two separate policy boxes (Quality + Information security) into one combined box that mirrors the NL structure and the integrated nature of the new statement.
- Updates the header metadata (Adopted → January 2026, Certificates → 24 Jul 2025 – 21 Jul 2028, Next review → January 2027, Standard → ISO 9001:2015 · ISO/IEC 27001:2022) and switches the contact reference to `/contact`.

## Test plan
- [ ] `npm run start` → load `/quality` (EN) and `/nl/quality`, scroll to the **Policy statement** box, confirm copy and metadata render correctly.
- [ ] Click the contact link → lands on `/contact`.
- [ ] Confirm anchor `#iso-certifications` from the hero CTA still scrolls to the right section.