### PR TITLE
blog(academy): add DownloadPanel CTA at end of the-platform-moment

### DIFF
--- a/academy/2026-05-19-the-platform-moment/index.mdx
+++ b/academy/2026-05-19-the-platform-moment/index.mdx
@@ -13,6 +13,7 @@ import {
   StatsStrip,
   PairCard,
   PairRow,
+  DownloadPanel,
 } from '@conduction/docusaurus-preset/components';
 
 Nextcloud is standing in front of an open window. Most people, including many inside the ecosystem itself, have not yet noticed it is open. What started as a safe alternative for file storage has quietly grown into something fundamentally different. The technical reality is already that of a platform. The name is the only thing still trailing behind. And in technology, as history teaches us, naming is not cosmetic. Naming is load-bearing. Windows close.
@@ -265,6 +266,17 @@ That is what Nextcloud already is, only under the wrong name. 16 million users w
 At Conduction we are choosing our role deliberately. Workspace on top of the Nextcloud substrate. Platform infrastructure underneath, where developers and civil servants can build. Both in the open. Both plugging into what is already there. No separate Dutch version of something that already exists.
 
 The choice is easy. The time is now.
+
+<DownloadPanel
+  title={<>Want to see the platform we just argued for?</>}
+  lede={<>ConNext is the open-source app stack Conduction ships on top of <span className="next-blue">Nextcloud</span>. Catalogs, registers, integrations, document handling, the AI substrate. Pick what you need from the Nextcloud app store and you are working today.</>}
+  meta="Open-source · EUPL-1.2 · no lead form, no sales call"
+  card={{
+    title: 'Explore ConNext',
+    body: 'The apps that turn the platform reality into something you can install in two minutes.',
+    cta: {label: 'Explore ConNext', href: '/connext'},
+  }}
+/>
 
 ## Sources
 


### PR DESCRIPTION
## Summary

Adds a no-form `<DownloadPanel/>` at the end of the platform-moment opinion post (between 'The choice is easy. The time is now.' and the Sources footnotes) pointing readers at `/connext`. Cobalt-800 panel with a cut-corner white card and a single primary CTA in KNVB orange.

Bridges the editorial argument of the post ("Nextcloud is a platform, not a suite") to the concrete product surface (the open-source ConNext app stack).

## Test plan
- [x] Hot-reload clean on local dev server
- [x] Uses the same DownloadPanel component already imported on `/connext`
- [ ] After deploy: confirm the panel renders correctly at the bottom of `/academy/the-platform-moment` and the CTA navigates to `/connext`

🤖 Generated with [Claude Code](https://claude.com/claude-code)