### PR TITLE
blog(academy): move DownloadPanel into Where Conduction is putting its weight

### DIFF
--- a/academy/2026-05-19-the-platform-moment/index.mdx
+++ b/academy/2026-05-19-the-platform-moment/index.mdx
@@ -178,6 +178,17 @@ These are not loose projects. They are two sides of the same coin. A workspace w
 
 And the best part: we do not have to do this alone. ZenDiS in Germany works on comparable pieces. La Suite Numérique in France ships components we plug into. Nextcloud GmbH itself keeps building the core. Conduction delivers the Dutch contribution to a European movement, not a Dutch version of something that already exists.
 
+<DownloadPanel
+  title={<>This is what we are building on top of <span className="next-blue">Nextcloud</span>.</>}
+  lede={<>ConNext is the open-source app stack from track one and the platform infrastructure from track two, shipping today. Catalogs, registers, integrations, document handling, the AI substrate. Pick what you need from the Nextcloud app store and you are working today.</>}
+  meta="Open-source · EUPL-1.2 · no lead form, no sales call"
+  card={{
+    title: 'Explore ConNext',
+    body: 'The apps that turn the workspace and the platform argument into something you can install in two minutes.',
+    cta: {label: 'Explore ConNext', href: '/connext'},
+  }}
+/>
+
 ## Component overview
 
 For anyone who wants to see it concretely, the stack looks like this.
@@ -266,17 +277,6 @@ That is what Nextcloud already is, only under the wrong name. 16 million users w
 At Conduction we are choosing our role deliberately. Workspace on top of the Nextcloud substrate. Platform infrastructure underneath, where developers and civil servants can build. Both in the open. Both plugging into what is already there. No separate Dutch version of something that already exists.
 
 The choice is easy. The time is now.
-
-<DownloadPanel
-  title={<>Want to see the platform we just argued for?</>}
-  lede={<>ConNext is the open-source app stack Conduction ships on top of <span className="next-blue">Nextcloud</span>. Catalogs, registers, integrations, document handling, the AI substrate. Pick what you need from the Nextcloud app store and you are working today.</>}
-  meta="Open-source · EUPL-1.2 · no lead form, no sales call"
-  card={{
-    title: 'Explore ConNext',
-    body: 'The apps that turn the platform reality into something you can install in two minutes.',
-    cta: {label: 'Explore ConNext', href: '/connext'},
-  }}
-/>
 
 ## Sources
 


### PR DESCRIPTION
## Summary

Repositions the `<DownloadPanel/>` CTA so it sits at the end of the **Where Conduction is putting its weight** section, directly under the two-track `<PairRow/>` that explains what Conduction is building. Previously it lived at the post closer, which read as a generic bottom-of-page prompt; this placement makes it the natural extension of the 'this is what we are doing' argument.

Copy retuned to bridge the two-track framing ("This is what we are building on top of Nextcloud") directly into the ConNext product surface.

## Test plan
- [x] Hot-reload clean on dev server
- [ ] After deploy: confirm the panel sits between the two-track PairRow and the Component overview section

🤖 Generated with [Claude Code](https://claude.com/claude-code)