### PR TITLE
blog(academy): cancel DownloadPanel -200px margin to stop overlap

### DIFF
--- a/academy/2026-05-19-the-platform-moment/index.mdx
+++ b/academy/2026-05-19-the-platform-moment/index.mdx
@@ -178,16 +178,23 @@ These are not loose projects. They are two sides of the same coin. A workspace w
 
 And the best part: we do not have to do this alone. ZenDiS in Germany works on comparable pieces. La Suite Numérique in France ships components we plug into. Nextcloud GmbH itself keeps building the core. Conduction delivers the Dutch contribution to a European movement, not a Dutch version of something that already exists.
 
-<DownloadPanel
-  title={<>This is what we are building on top of <span className="next-blue">Nextcloud</span>.</>}
-  lede={<>ConNext is the open-source app stack from track one and the platform infrastructure from track two, shipping today. Catalogs, registers, integrations, document handling, the AI substrate. Pick what you need from the Nextcloud app store and you are working today.</>}
-  meta="Open-source · EUPL-1.2 · no lead form, no sales call"
-  card={{
-    title: 'Explore ConNext',
-    body: 'The apps that turn the workspace and the platform argument into something you can install in two minutes.',
-    cta: {label: 'Explore ConNext', href: '/connext'},
-  }}
-/>
+{/* DownloadPanel.module.css:.section sets margin-top:-200px, a hack
+    for /connext where it sits below PlatformOverview's 240px of
+    structural empty space. In the blog there is no such spacer, so
+    the negative margin overlaps the preceding paragraphs. Wrap in a
+    div that cancels it out until the preset exposes an opt-out prop. */}
+<div style={{marginTop: 200}}>
+  <DownloadPanel
+    title={<>This is what we are building on top of <span className="next-blue">Nextcloud</span>.</>}
+    lede={<>ConNext is the open-source app stack from track one and the platform infrastructure from track two, shipping today. Catalogs, registers, integrations, document handling, the AI substrate. Pick what you need from the Nextcloud app store and you are working today.</>}
+    meta="Open-source · EUPL-1.2 · no lead form, no sales call"
+    card={{
+      title: 'Explore ConNext',
+      body: 'The apps that turn the workspace and the platform argument into something you can install in two minutes.',
+      cta: {label: 'Explore ConNext', href: '/connext'},
+    }}
+  />
+</div>
 
 ## Component overview
 


### PR DESCRIPTION
## Summary

DownloadPanel's outer `.section` has `margin-top:-200px` hard-coded for `/connext` (calibrated to eat PlatformOverview's 240px of structural empty space). When dropped into the blog body in #108, that negative margin overlapped the closing paragraph of the preceding section.

Wraps the panel in a `<div style={{marginTop: 200}}>` to cancel the negative pull. Playwright-verified locally — the panel now sits cleanly between the body paragraph and the next h2.

Tracked as long-term follow-up in [design-system#26](https://github.com/ConductionNL/design-system/issues/26) (opt-in `pullUp` prop on `<DownloadPanel/>`). Once that lands, the wrapper div can be dropped.

## Test plan
- [x] Playwright screenshot confirms no overlap, clean spacing top + bottom
- [x] Hot-reload clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)