### PR TITLE
blog(academy): polish DownloadPanel — strip tinted band, restore white title, ConNext highlight

### DIFF
--- a/academy/2026-05-19-the-platform-moment/index.mdx
+++ b/academy/2026-05-19-the-platform-moment/index.mdx
@@ -178,18 +178,20 @@ These are not loose projects. They are two sides of the same coin. A workspace w
 
 And the best part: we do not have to do this alone. ZenDiS in Germany works on comparable pieces. La Suite Numérique in France ships components we plug into. Nextcloud GmbH itself keeps building the core. Conduction delivers the Dutch contribution to a European movement, not a Dutch version of something that already exists.
 
-{/* DownloadPanel.module.css:.section sets margin-top:-200px, a hack
-    for /connext where it sits below PlatformOverview's 240px of
-    structural empty space. In the blog there is no such spacer, so
-    the negative margin overlaps the preceding paragraphs. Wrap in a
-    div that cancels it out until the preset exposes an opt-out prop. */}
-<div style={{marginTop: 200}}>
+{/* .blog-download-cta (src/css/site.css) strips the preset
+    DownloadPanel's outer tinted band + cancels its -200px negative
+    margin, both calibrated for marketing pages (/connext) where the
+    panel sits below a structural spacer and the band reads as a
+    section divider. Inside a blog body, the band reads as an unrelated
+    section break. Tracked as design-system#26 for a proper opt-out
+    prop on the preset. */}
+<div className="blog-download-cta">
   <DownloadPanel
     title={<>This is what we are building on top of <span className="next-blue">Nextcloud</span>.</>}
-    lede={<>ConNext is the open-source app stack from track one and the platform infrastructure from track two, shipping today. Catalogs, registers, integrations, document handling, the AI substrate. Pick what you need from the Nextcloud app store and you are working today.</>}
+    lede={<>Con<span className="next-blue">Next</span> is the open-source app stack from track one and the platform infrastructure from track two, shipping today. Catalogs, registers, integrations, document handling, the AI substrate. Pick what you need from the Nextcloud app store and you are working today.</>}
     meta="Open-source · EUPL-1.2 · no lead form, no sales call"
     card={{
-      title: 'Explore ConNext',
+      title: <>Explore Con<span className="next-blue">Next</span></>,
       body: 'The apps that turn the workspace and the platform argument into something you can install in two minutes.',
       cta: {label: 'Explore ConNext', href: '/connext'},
     }}

--- a/src/css/site.css
+++ b/src/css/site.css
@@ -301,6 +301,27 @@
   color: var(--c-cobalt-700);
 }
 
+/* ============================================================
+   .blog-download-cta · DownloadPanel inside an academy post body
+   ============================================================
+   Strips the preset DownloadPanel's outer tinted band (cobalt-50
+   fill + hairline borders + -200px negative margin) which is
+   calibrated for marketing pages where it sits below a structural
+   spacer. Inside a blog body, the band reads as a section break
+   that doesn't relate to anything around it.
+   Tracked as design-system#26 for a proper opt-out prop on the
+   preset; this is the inline fallback. */
+.blog-download-cta { margin-top: var(--space-8); }
+.blog-download-cta > section {
+  background: transparent !important;
+  border: none !important;
+  margin-top: 0 !important;
+}
+.blog-download-cta > section > div {
+  padding-left: 0 !important;
+  padding-right: 0 !important;
+}
+
 /* "Test jezelf" sections at the end of academy tutorials: each question
    sits in a card with collapsible Hint and Antwoord <details> blocks. */
 .tutorial-quiz {

--- a/src/theme/BlogPostPage/styles.module.css
+++ b/src/theme/BlogPostPage/styles.module.css
@@ -19,9 +19,13 @@
   color: var(--c-cobalt-700);
 }
 
-/* Heading rhythm. Tighter top-margin on the first heading after the
-   hero (the lede paragraph), wider gaps on subsequent ones. */
-.body h2 {
+/* Heading rhythm. Direct-child selectors so the cascade does not
+   bleed into nested preset components (DownloadPanel, PairCard,
+   HexCard, etc.), which carry their own typography. Without the
+   direct-child scope, .body h3 overrides white-on-dark titles
+   inside cobalt panels because it has higher specificity than
+   the preset's single-class .title rule. */
+.body > h2 {
   font-size: 28px;
   font-weight: 700;
   letter-spacing: -0.01em;
@@ -29,21 +33,21 @@
   margin: var(--space-10) 0 var(--space-3);
   line-height: 1.2;
 }
-.body h3 {
+.body > h3 {
   font-size: 21px;
   font-weight: 700;
   color: var(--c-cobalt-900);
   margin: var(--space-7) 0 var(--space-2);
   line-height: 1.3;
 }
-.body h2 + p,
-.body h3 + p,
-.body h2 + ul,
-.body h3 + ul,
-.body h2 + ol,
-.body h3 + ol { margin-top: 0; }
+.body > h2 + p,
+.body > h3 + p,
+.body > h2 + ul,
+.body > h3 + ul,
+.body > h2 + ol,
+.body > h3 + ol { margin-top: 0; }
 
-.body p { margin: var(--space-3) 0; }
+.body > p { margin: var(--space-3) 0; }
 
 /* Images: respect natural size, never stretch. Centre with breathing
    room; cap at column width. */


### PR DESCRIPTION
## Summary

Three polish fixes on the platform-moment DownloadPanel:

1. **Strip the tinted cobalt-50 band** wrapping the dark panel. Calibrated for `/connext` where it serves as a section break below PlatformOverview; in a blog body it reads as an unrelated divider. New `.blog-download-cta` wrapper class in `site.css` replaces the inline `margin-top:200` hack from #109.

2. **Restore white panel title.** The BlogPostPage swizzle's `.body h2/h3` rules were cascading into nested preset components with higher specificity (0,1,1) than the preset's `.title` rules (0,1,0), overriding white-on-dark titles with cobalt-900. Scope blog heading rules to direct children only (`.body > h2`, `.body > h3`, etc.) so they stop bleeding into components.

3. **Highlight 'Next' in 'ConNext'** per the design-system convention (`Con<span className="next-blue">Next</span>`). Default `.next-blue` rule renders as #0082C9 on white, matching FeatureList, HowSteps, Hero, and the connext landing page treatment.

## Test plan
- [x] Hot-reload clean, user confirmed visual fix on local dev server
- [ ] After deploy: confirm card title 'Explore Con**Next**' renders the Next in #0082C9, pitch title in white, no cobalt-50 band around the dark panel

Tinted-band opt-out tracked in [design-system#26](https://github.com/ConductionNL/design-system/issues/26).

🤖 Generated with [Claude Code](https://claude.com/claude-code)