### PR TITLE
site(css): hide auto-generated 'Footnotes' label so 'Sources' h2 stands alone

### DIFF
--- a/src/css/site.css
+++ b/src/css/site.css
@@ -397,3 +397,27 @@
   color: var(--c-blue-cobalt);
 }
 
+
+/* ============================================================
+   Footnote label cleanup
+   ============================================================
+   Docusaurus's GFM footnote handler auto-injects an <h2> with the
+   text "Footnotes" above the generated <ol>. The blog post already
+   prints its own '## Sources' heading above the footnote anchors,
+   so the auto label duplicates that heading. Hide the auto one
+   (visually) but keep it accessible to screen readers via sr-only
+   semantics. */
+.markdown section.footnotes > h2,
+.markdown section[data-footnotes] > h2,
+.content-detail-body section.footnotes > h2,
+.content-detail-body section[data-footnotes] > h2 {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}


### PR DESCRIPTION
## Summary

Docusaurus's GFM footnote handler auto-injects `<h2>Footnotes</h2>` above the generated ordered list. The platform-moment post (and any future post that prints its own `## Sources` heading) ends up showing both 'Sources' and 'Footnotes' as duplicate section labels.

Hide the auto label via sr-only-style positioning so:
- Screen readers still announce 'Footnotes' as the navigation landmark
- It no longer duplicates the editorial heading visually

Targets both `.markdown` and `.content-detail-body` containers so it works for academy posts and any future docs pages that render footnotes.

## Test plan
- [x] Playwright-verified: auto h2 is `position: absolute`, 'Sources' h2 still renders, numbered list flows directly under it

🤖 Generated with [Claude Code](https://claude.com/claude-code)