### PR TITLE
Updated the local nextcloud tutorial for better use for non technical persons

### DIFF
--- a/academy/2026-05-07-nextcloud-lokaal-draaien/index.mdx
+++ b/academy/2026-05-07-nextcloud-lokaal-draaien/index.mdx
@@ -9,7 +9,29 @@ tags: [Nextcloud, Docker, Setup, Demo, Local]
 durationMinutes: 30
 ---
 
+import {useState, useEffect} from 'react';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 import {Outcomes, Outcome, Prerequisites, PrerequisiteItem, ContactCta, Troubleshooting, TroubleshootingItem, NextSteps, NextStep} from '@conduction/docusaurus-preset/components';
+
+export function OSTabs({children}) {
+  const [osKey, setOsKey] = useState('ssr');
+  const [os, setOs] = useState('windows');
+  useEffect(() => {
+    const ua = navigator.userAgent;
+    const detected = /Mac/.test(ua) ? 'mac' : /Linux/.test(ua) ? 'linux' : 'windows';
+    if (!localStorage.getItem('docusaurus.tab.os')) {
+      localStorage.setItem('docusaurus.tab.os', JSON.stringify(detected));
+    }
+    setOs(detected);
+    setOsKey(detected);
+  }, []);
+  return (
+    <Tabs key={osKey} groupId="os" defaultValue={os}>
+      {children}
+    </Tabs>
+  );
+}
 
 Every other tutorial in this academy needs a working Nextcloud. This is the fastest route: a few commands and you run the official Nextcloud locally on your laptop, identical to production. **You do not need to be a programmer** — if you can install an app and copy and paste text, you will get through this. After that you install the Conduction apps from the Nextcloud app store, the same path as production.
 
@@ -27,7 +49,7 @@ After this you can move on to [Set up a Woo register](/academy/woo-register-opze
 <Prerequisites title="What you need">
   <PrerequisiteItem>A laptop with at least 4 GB of free memory.</PrerequisiteItem>
   <PrerequisiteItem>Docker Desktop — a free program you install in step 0.</PrerequisiteItem>
-  <PrerequisiteItem>A text editor: Notepad (Windows) or TextEdit (Mac) is enough.</PrerequisiteItem>
+  <PrerequisiteItem>A text editor: Notepad (Windows), TextEdit (Mac), or nano (Linux) is enough.</PrerequisiteItem>
 </Prerequisites>
 
 > **This is a local development environment.** It runs the same software as a real Nextcloud installation and behaves the same way, so everything you learn here applies directly to a production deployment. However, data you store here is not backed up, is not shared with anyone, and can be wiped at any time — for example, running `docker compose down -v` permanently deletes everything. Use this environment to explore, experiment, and learn. Do not store real, sensitive, or production data here.
@@ -44,15 +66,8 @@ Docker is a free program that lets you run other programs — like Nextcloud —
 
 ### Install Docker
 
-**Mac**
-
-1. Go to the <a href="https://www.docker.com/products/docker-desktop/" target="_blank" rel="noopener noreferrer">Docker Desktop download page</a>.
-2. You will see two download buttons — **Apple Silicon** (for M1, M2, M3, and M4 chips) and **Intel** (for older Macs). Not sure which you have? Click the **Apple logo (🍎)** in the top-left corner of your screen and choose **About This Mac**. If it says "Apple M1", "Apple M2", or similar, click **Apple Silicon**. If it says "Intel Core", click **Intel**.
-3. Open the downloaded `.dmg` file. Drag the Docker icon into the **Applications** folder when prompted.
-4. Open Docker from your Applications folder. macOS may ask if you are sure you want to open it — click **Open**.
-5. Wait until the whale icon in the menu bar stops moving. Docker is ready.
-
-**Windows**
+<OSTabs>
+<TabItem value="windows" label="Windows">
 
 Windows needs WSL 2 installed before Docker Desktop — skip this and the most common Docker error appears. It only takes a minute.
 
@@ -68,26 +83,48 @@ Windows needs WSL 2 installed before Docker Desktop — skip this and the most c
 7. Open **Docker Desktop** from the Start menu.
 8. Wait until the whale icon in the taskbar stops moving. Docker is ready.
 
-**Linux**
+</TabItem>
+<TabItem value="mac" label="Mac">
+
+1. Go to the <a href="https://www.docker.com/products/docker-desktop/" target="_blank" rel="noopener noreferrer">Docker Desktop download page</a>.
+2. You will see two download buttons — **Apple Silicon** (for M1, M2, M3, and M4 chips) and **Intel** (for older Macs). Not sure which you have? Click the **Apple logo (🍎)** in the top-left corner of your screen and choose **About This Mac**. If it says "Apple M1", "Apple M2", or similar, click **Apple Silicon**. If it says "Intel Core", click **Intel**.
+3. Open the downloaded `.dmg` file. Drag the Docker icon into the **Applications** folder when prompted.
+4. Open Docker from your Applications folder. macOS may ask if you are sure you want to open it — click **Open**.
+5. Wait until the whale icon in the menu bar stops moving. Docker is ready.
+
+</TabItem>
+<TabItem value="linux" label="Linux">
 
 Follow the <a href="https://docs.docker.com/engine/install/" target="_blank" rel="noopener noreferrer">Docker Engine installation instructions</a> for your distribution.
+
+</TabItem>
+</OSTabs>
 
 ### Open a terminal
 
 A **terminal** (also called a command prompt or console) is a text window where you type commands. You type a command, press **Enter**, and the computer runs it. You do not need to know the terminal beforehand — every command in this tutorial can be copied and pasted.
 
-**Windows:**
+<OSTabs>
+<TabItem value="windows" label="Windows">
+
 1. Press the **Windows key** and type `cmd`.
 2. Click **Command Prompt** in the results, or press **Enter**.
 3. A black window opens — that is your Command Prompt (terminal).
 
-**Mac:**
+</TabItem>
+<TabItem value="mac" label="Mac">
+
 1. Press **Cmd + Space** to open Spotlight.
 2. Type `Terminal` and press **Enter**.
 3. A window with a blinking cursor opens — that is your terminal.
 
-**Linux:**
+</TabItem>
+<TabItem value="linux" label="Linux">
+
 1. Press **Ctrl + Alt + T**, or search for "Terminal" in your application menu.
+
+</TabItem>
+</OSTabs>
 
 ### Check that Docker works
 
@@ -118,21 +155,45 @@ cd conduction-demo
 
 The compose file tells Docker which programs to start and how they talk to each other. You create it once and never need to touch it again.
 
-Open Notepad from the terminal so the filename and folder are set automatically — no manual navigation needed when saving:
+Open a text editor from the terminal so the filename and folder are set automatically — no manual navigation needed when saving:
 
-**Windows:** type in the terminal:
+<OSTabs>
+<TabItem value="windows" label="Windows">
+
+Type in the terminal:
+
 ```
 notepad docker-compose.yml
 ```
-Windows asks whether to create the file — click **Yes**. Notepad opens.
 
-**Mac:** type in the terminal:
+Windows asks whether to create the file — click **Yes**. Notepad opens. Paste the content below, then press **Ctrl+S** to save.
+
+</TabItem>
+<TabItem value="mac" label="Mac">
+
+Type in the terminal:
+
 ```bash
 touch docker-compose.yml && open -e docker-compose.yml
 ```
-TextEdit opens with the file already created.
 
-Copy the full text below and paste it into the editor. Then press **Ctrl+S** (Windows) or **Cmd+S** (Mac) to save. The correct filename (`docker-compose.yml`) and folder are already set — you do not need to change anything.
+TextEdit opens with the file already created. Paste the content below, then press **Cmd+S** to save.
+
+</TabItem>
+<TabItem value="linux" label="Linux">
+
+Type in the terminal:
+
+```bash
+nano docker-compose.yml
+```
+
+The nano text editor opens. Paste the content below, then press **Ctrl+X**, then **Y**, then **Enter** to save.
+
+</TabItem>
+</OSTabs>
+
+Copy the full text below and paste it into the editor. The correct filename (`docker-compose.yml`) and folder are already set — you do not need to change anything.
 
 ```yaml title="docker-compose.yml"
 services:
@@ -187,7 +248,7 @@ volumes:
 
 The file describes four services: Nextcloud itself, a database (Postgres), a cache (Redis), and a live-update system (notify_push). All official, free images — Docker downloads them automatically in the next step.
 
-Close Notepad (or TextEdit) and go back to the terminal that is still open.
+Close the editor and go back to the terminal that is still open.
 
 ## Step 2: Start the stack
 
@@ -290,9 +351,23 @@ This is the only step that requires a bit more terminal work. Go back to the ter
 
 Copy the commands below one line at a time, paste them into the terminal, and press **Enter** after each one. How to paste depends on your system:
 
-- **Windows (Command Prompt):** right-click inside the terminal window to paste. Ctrl+V may also work on Windows 10 and 11, but right-click is more reliable.
-- **Mac (Terminal):** press **Cmd+V**.
-- **Linux (Terminal):** press **Ctrl+Shift+V**, or right-click and choose **Paste**.
+<OSTabs>
+<TabItem value="windows" label="Windows">
+
+**Right-click** inside the terminal window to paste. Ctrl+V may also work on Windows 10 and 11, but right-click is more reliable.
+
+</TabItem>
+<TabItem value="mac" label="Mac">
+
+Press **Cmd+V** to paste.
+
+</TabItem>
+<TabItem value="linux" label="Linux">
+
+Press **Ctrl+Shift+V** to paste, or right-click and choose **Paste**.
+
+</TabItem>
+</OSTabs>
 
 Run each command below one at a time — copy it, paste it into the terminal, and press **Enter**. Wait for the terminal to return a new prompt before pasting the next one.
 
@@ -424,7 +499,7 @@ Open Command Prompt as administrator and run `wsl --update`, then restart Docker
 
 <TroubleshootingItem symptom="`http://localhost:8080` does not open in the browser">
 
-The port may already be in use by another program. Open `docker-compose.yml` in Notepad, change `"8080:80"` to `"8081:80"`, save, and try `http://localhost:8081` instead.
+The port may already be in use by another program. Open `docker-compose.yml` in your text editor, change `"8080:80"` to `"8081:80"`, save, and try `http://localhost:8081` instead.
 
 </TroubleshootingItem>
 

--- a/academy/2026-05-07-nextcloud-lokaal-draaien/index.mdx
+++ b/academy/2026-05-07-nextcloud-lokaal-draaien/index.mdx
@@ -4,20 +4,20 @@ title: Run Nextcloud locally with Docker
 contentType: tutorial
 authors: [conduction]
 date: 2026-05-07
-summary: Three commands, four steps, a quarter of an hour. After that you have a clean Nextcloud running on your laptop, ready for Conduction apps.
+summary: Five steps, half an hour. After that you have a clean Nextcloud running on your laptop — even if you have never used Docker or a terminal before.
 tags: [Nextcloud, Docker, Setup, Demo, Local]
-durationMinutes: 15
+durationMinutes: 30
 ---
 
-import {Outcomes, Outcome, Prerequisites, PrerequisiteItem, NextSteps, NextStep, ContactCta} from '@conduction/docusaurus-preset/components';
+import {Outcomes, Outcome, Prerequisites, PrerequisiteItem, ContactCta, Troubleshooting, TroubleshootingItem, NextSteps, NextStep} from '@conduction/docusaurus-preset/components';
 
-Every other tutorial in this academy needs a working Nextcloud. This is the fastest route: three commands and you run the official Nextcloud image locally, identical to production. No sales call, no demo environment that can go offline, no custom Dockerfile. After that you install the Conduction apps from the Nextcloud app store, the same path as production.
+Every other tutorial in this academy needs a working Nextcloud. This is the fastest route: a few commands and you run the official Nextcloud locally on your laptop, identical to production. **You do not need to be a programmer** — if you can install an app and copy and paste text, you will get through this. After that you install the Conduction apps from the Nextcloud app store, the same path as production.
 
 {/* truncate */}
 
 <Outcomes title="What you'll learn">
+  <Outcome>How to open a terminal and run simple commands.</Outcome>
   <Outcome>How to run a working Nextcloud on <code>http://localhost:8080</code> with Docker.</Outcome>
-  <Outcome>How to combine Postgres for data, Redis for cache, Nextcloud for the work, and <code>notify_push</code> for realtime updates in one compose file.</Outcome>
   <Outcome>How to create an admin account where you can install Conduction apps at will.</Outcome>
   <Outcome>How to tear down the whole stack with one command.</Outcome>
 </Outcomes>
@@ -26,36 +26,113 @@ After this you can move on to [Set up a Woo register](/academy/woo-register-opze
 
 <Prerequisites title="What you need">
   <PrerequisiteItem>A laptop with at least 4 GB of free memory.</PrerequisiteItem>
-  <PrerequisiteItem>Docker, running locally.</PrerequisiteItem>
-  <PrerequisiteItem>A terminal and a text editor.</PrerequisiteItem>
+  <PrerequisiteItem>Docker Desktop — a free program you install in step 0.</PrerequisiteItem>
+  <PrerequisiteItem>A text editor: Notepad (Windows) or TextEdit (Mac) is enough.</PrerequisiteItem>
 </Prerequisites>
 
-On a clean laptop, step 0 (installing Docker) takes about ten minutes. After that, steps 1 through 3 together take a quarter of an hour.
+> **This is a local development environment.** It runs the same software as a real Nextcloud installation and behaves the same way, so everything you learn here applies directly to a production deployment. However, data you store here is not backed up, is not shared with anyone, and can be wiped at any time — for example, running `docker compose down -v` permanently deletes everything. Use this environment to explore, experiment, and learn. Do not store real, sensitive, or production data here.
 
-## Step 0: Make sure Docker is running
+No prior experience needed. On a clean laptop, step 0 (installing Docker and learning the terminal) takes about ten minutes. Steps 1 through 5 together take half an hour after that.
 
-One-time setup.
+If something does not work as expected at any point, the [Troubleshooting](#troubleshooting) section at the bottom of this page has solutions for the most common problems.
 
-- **Mac or Linux:** install [Docker Desktop](https://docs.docker.com/get-docker/).
-- **Windows:** first enable [WSL 2](https://learn.microsoft.com/en-us/windows/wsl/install), then install Docker Desktop.
+## Step 0: Install Docker and open a terminal
 
-Check that it works:
+### What is Docker?
+
+Docker is a free program that lets you run other programs — like Nextcloud — in an isolated environment on your laptop. Think of virtual boxes: Nextcloud, the database, and the cache each run in their own box and do not affect anything outside it. When you are done, you throw the boxes away and your laptop is clean again.
+
+### Install Docker
+
+**Mac**
+
+1. Go to the <a href="https://www.docker.com/products/docker-desktop/" target="_blank" rel="noopener noreferrer">Docker Desktop download page</a>.
+2. You will see two download buttons — **Apple Silicon** (for M1, M2, M3, and M4 chips) and **Intel** (for older Macs). Not sure which you have? Click the **Apple logo (🍎)** in the top-left corner of your screen and choose **About This Mac**. If it says "Apple M1", "Apple M2", or similar, click **Apple Silicon**. If it says "Intel Core", click **Intel**.
+3. Open the downloaded `.dmg` file. Drag the Docker icon into the **Applications** folder when prompted.
+4. Open Docker from your Applications folder. macOS may ask if you are sure you want to open it — click **Open**.
+5. Wait until the whale icon in the menu bar stops moving. Docker is ready.
+
+**Windows**
+
+Windows needs WSL 2 installed before Docker Desktop — skip this and the most common Docker error appears. It only takes a minute.
+
+1. Press the **Windows key**, type `cmd`, then **right-click** Command Prompt and choose **Run as administrator**. Click **Yes** when Windows asks for permission.
+2. Type the command below and press **Enter**. This installs WSL 2 with Ubuntu automatically:
+   ```
+   wsl --install
+   ```
+3. When it finishes, **restart your computer**.
+4. After the restart, go to the [Docker Desktop download page](https://www.docker.com/products/docker-desktop/) and click **Download for Windows**. This downloads an `.exe` installer.
+5. Open the downloaded file. If Windows asks "Do you want to allow this app to make changes to your device?" click **Yes**.
+6. Follow the steps in the installer — click **OK**, **Next**, and **Finish** when asked.
+7. Open **Docker Desktop** from the Start menu.
+8. Wait until the whale icon in the taskbar stops moving. Docker is ready.
+
+**Linux**
+
+Follow the <a href="https://docs.docker.com/engine/install/" target="_blank" rel="noopener noreferrer">Docker Engine installation instructions</a> for your distribution.
+
+### Open a terminal
+
+A **terminal** (also called a command prompt or console) is a text window where you type commands. You type a command, press **Enter**, and the computer runs it. You do not need to know the terminal beforehand — every command in this tutorial can be copied and pasted.
+
+**Windows:**
+1. Press the **Windows key** and type `cmd`.
+2. Click **Command Prompt** in the results, or press **Enter**.
+3. A black window opens — that is your Command Prompt (terminal).
+
+**Mac:**
+1. Press **Cmd + Space** to open Spotlight.
+2. Type `Terminal` and press **Enter**.
+3. A window with a blinking cursor opens — that is your terminal.
+
+**Linux:**
+1. Press **Ctrl + Alt + T**, or search for "Terminal" in your application menu.
+
+### Check that Docker works
+
+Type the following in the terminal (press **Enter** after each line):
 
 ```bash
 docker --version
 docker compose version
 ```
 
-Both should return a version, not an error.
+You should see something like `Docker version 27.0.3` and `Docker Compose version v2.x`. If you see an error, check that Docker Desktop is open and active (whale icon in the taskbar or menu bar).
 
 ## Step 1: Create a working directory and the compose file
+
+### Create a directory
+
+Type in the terminal:
 
 ```bash
 mkdir conduction-demo
 cd conduction-demo
 ```
 
-Save the following as `docker-compose.yml` in that directory:
+- `mkdir conduction-demo` creates a new folder called `conduction-demo`.
+- `cd conduction-demo` steps into that folder ("cd" stands for "change directory").
+
+### Create the compose file
+
+The compose file tells Docker which programs to start and how they talk to each other. You create it once and never need to touch it again.
+
+Open Notepad from the terminal so the filename and folder are set automatically — no manual navigation needed when saving:
+
+**Windows:** type in the terminal:
+```
+notepad docker-compose.yml
+```
+Windows asks whether to create the file — click **Yes**. Notepad opens.
+
+**Mac:** type in the terminal:
+```bash
+touch docker-compose.yml && open -e docker-compose.yml
+```
+TextEdit opens with the file already created.
+
+Copy the full text below and paste it into the editor. Then press **Ctrl+S** (Windows) or **Cmd+S** (Mac) to save. The correct filename (`docker-compose.yml`) and folder are already set — you do not need to change anything.
 
 ```yaml title="docker-compose.yml"
 services:
@@ -88,7 +165,7 @@ services:
       POSTGRES_USER: nextcloud
       POSTGRES_PASSWORD: nextcloud
       REDIS_HOST: redis
-      NEXTCLOUD_TRUSTED_DOMAINS: "localhost"
+      NEXTCLOUD_TRUSTED_DOMAINS: "localhost nextcloud"
 
   notify_push:
     image: icewind1991/notify_push:latest
@@ -108,127 +185,307 @@ volumes:
   nextcloud:
 ```
 
-Four services, all official images, no custom build. The `./apps` bind mount is optional. It is handy when you want to drop a Conduction app next to the installation as a zip instead of going through the app store. `notify_push` is the WebSocket push server that Conduction apps use for realtime updates. More on that in step 5.
+The file describes four services: Nextcloud itself, a database (Postgres), a cache (Redis), and a live-update system (notify_push). All official, free images — Docker downloads them automatically in the next step.
+
+Close Notepad (or TextEdit) and go back to the terminal that is still open.
 
 ## Step 2: Start the stack
+
+Make sure your terminal is still in the `conduction-demo` folder (it will be if you just finished step 1). Type:
 
 ```bash
 docker compose up -d
 ```
 
-The first time, Docker pulls about 750 MB of images. After that the stack starts in seconds.
+Docker downloads the required programs — about 750 MB the first time — and then starts them. The `-d` keeps everything running in the background so your terminal stays free.
 
-Follow the logs while Nextcloud bootstraps itself:
+Want to see what is happening behind the scenes? Follow the progress with:
 
 ```bash
 docker compose logs -f nextcloud
 ```
 
-Wait until you see `apache2 -D FOREGROUND` or similar, then `Ctrl+C` to exit the log follower. The containers keep running.
+You will see lines of text scroll by while Nextcloud sets itself up. Wait until you see a line with `apache2 -D FOREGROUND` or similar — that means Nextcloud is ready. Then press **Ctrl+C** to close the log view. The containers keep running.
+
+**Keep the terminal open** — you will need it again in step 5.
 
 ## Step 3: Finish the Nextcloud setup wizard
 
-Open `http://localhost:8080` in your browser. Nextcloud shows a setup wizard:
+Open your web browser (Chrome, Firefox, Edge — whatever you prefer) and go to:
 
-1. Fill in an **admin name** and **password**. `admin` and `admin` is fine for local work. In production it is not.
-2. Under **Storage & database**, pick nothing. The Postgres config is already in `docker-compose.yml`.
-3. Click **Install**.
+```
+http://localhost:8080
+```
 
-After half a minute, you land on the dashboard, signed in as admin.
+You see the Nextcloud setup screen. We will create an admin account using `admin` as the username and `admin` as the password.
+
+Nextcloud will warn you that the password is too weak — that warning is correct, but this installation runs **only on your own laptop** and cannot be reached by anyone else, so it is fine for a local demo. You can ignore the warning.
+
+If you ever run a Nextcloud that others can reach — over the internet or within a network — always choose a strong, unique password. A good rule of thumb: at least 12 characters, mixing uppercase letters, numbers, and a special character.
+
+> **Note:** below the password field you will see a collapsed section called **Storage & database**. You do not need to open it — the database configuration is already taken care of through the `docker-compose.yml` file.
+
+1. Fill in `admin` as the **username** and `admin` as the **password**. **Do not press Enter while filling in the fields** — wait until both fields are filled in before you continue.
+2. Click **Install** or press Enter after filling in the password. The screen disappears immediately and Nextcloud starts installing.
+3. Wait about half a minute while Nextcloud finishes setting up.
+4. Nextcloud may ask if you want to install recommended apps. Click **Skip** — we will install only the Conduction apps you need in the next step.
+
+You land on the Nextcloud dashboard, signed in as admin.
 
 ## Step 4: Install the Conduction apps
 
-Click your avatar in the top right and choose **Apps**. The Conduction apps are listed under **Integration** and **Office & text**. Our suggestion for a first demo:
+First open the Nextcloud app store:
 
-- **OpenRegister.** The typed-data foundation. Install this first. Every other app reads from it.
-- **OpenCatalogi.** Makes every register searchable as a public entry. Federates to `data.overheid.nl`.
-- **OpenConnector.** Pulls in sample data via REST, SOAP, and file drops.
+1. Click your **avatar** — the circle with your initials in the top right corner of the screen.
+2. Choose **Apps** from the dropdown menu.
+3. In the left sidebar, click **Featured apps** — if you skip this the search may show no results because Nextcloud only searches within the currently active category.
 
-After every install, the schema bootstrap runs automatically. Sample data is visible within seconds.
+Now install the Conduction apps one by one. Start with **Open Register** — OpenCatalogi and Open Connector both depend on it.
 
-Also install the `notify_push` app (under **Integration**). It is the Nextcloud side of the WebSocket push server you already started in step 1. You only have to enable it. No further config needed.
+> **Note:** when you click **Download and enable**, Nextcloud may ask you to confirm your password before it allows the installation. Enter `admin` and confirm.
 
-## Step 5: Wire `notify_push` to the push server
+---
 
-`notify_push` has one one-off setup step so the Nextcloud app knows where the Rust binary runs. Run this in your working directory:
+**Open Register**
 
+The foundation for all other Conduction apps. Install this one first — OpenCatalogi and Open Connector both read from it.
+
+1. Click the **search field** at the top of the Apps page (the magnifying glass icon) so the cursor appears inside it.
+2. Type `Open Register` — the results update as you type.
+3. Click **Download and enable** on the Open Register card.
+4. Wait for the installation to finish before moving on.
+
+---
+
+**OpenCatalogi**
+
+Makes every register searchable as a public catalogue and federates to `data.overheid.nl`.
+
+1. Clear the search field, type `OpenCatalogi`, and press **Enter**.
+2. Click **Download and enable** on the OpenCatalogi card.
+
+---
+
+**Open Connector**
+
+Pulls in sample data via REST, SOAP, and file drops.
+
+1. Clear the search field, type `Open Connector`, and press **Enter**.
+2. Click **Download and enable** on the Open Connector card.
+
+---
+
+After every Conduction app install, the setup runs automatically and sample data becomes visible within seconds.
+
+### Also install: Client Push
+
+**Client Push** is a standard Nextcloud app — not a Conduction app — that provides live browser updates so the page refreshes automatically when data changes. You need it for step 5.
+
+1. Clear the search field, type `Client Push`, and press **Enter**.
+2. Click **Download and enable** on the Client Push card.
+
+## Step 5: Wire Client Push to the push server
+
+This is the only step that requires a bit more terminal work. Go back to the terminal you kept open and make sure you are still in the `conduction-demo` folder.
+
+Copy the commands below one line at a time, paste them into the terminal, and press **Enter** after each one. How to paste depends on your system:
+
+- **Windows (Command Prompt):** right-click inside the terminal window to paste. Ctrl+V may also work on Windows 10 and 11, but right-click is more reliable.
+- **Mac (Terminal):** press **Cmd+V**.
+- **Linux (Terminal):** press **Ctrl+Shift+V**, or right-click and choose **Paste**.
+
+Run each command below one at a time — copy it, paste it into the terminal, and press **Enter**. Wait for the terminal to return a new prompt before pasting the next one.
+
+**Command 1 of 5** — tell Nextcloud which server handles the shared cache:
 ```bash
 docker compose exec --user www-data nextcloud php occ config:system:set redis host --value redis
+```
+
+**Command 2 of 5** — set the port for the cache server:
+```bash
 docker compose exec --user www-data nextcloud php occ config:system:set redis port --value 6379 --type integer
+```
+
+**Command 3 of 5** — tell Nextcloud to use the cache for shared data:
+```bash
 docker compose exec --user www-data nextcloud php occ config:system:set memcache.distributed --value '\OC\Memcache\Redis'
+```
+
+**Command 4 of 5** — mark the internal Docker network as trusted so Client Push can talk back to Nextcloud:
+```bash
 docker compose exec --user www-data nextcloud php occ config:system:set trusted_proxies 0 --value 172.16.0.0/12
+```
+
+**Command 5 of 5** — register the Client Push server address with Nextcloud:
+```bash
 docker compose exec --user www-data nextcloud php occ notify_push:setup http://notify_push:7867
 ```
 
-The first three lines tell Nextcloud that Redis is the shared cache. `notify_push` listens on it for change events. The fourth line marks the Docker network as trusted so the push server can call back to Nextcloud for authentication. The last line registers the URL with the Nextcloud app.
-
-Verify everything works:
+Once all five have run, check that everything is connected:
 
 ```bash
 docker compose exec --user www-data nextcloud php occ notify_push:self-test
 ```
 
-You get a list of checkmarks: `redis is configured`, `push server is receiving redis messages`, `push server can connect to the Nextcloud server`, and so on. The warning about `unencrypted http` is normal for local work. In production, `notify_push` sits behind the same reverse proxy as Nextcloud, so it is not an issue there.
-
-From now on, apps that listen to `notify_push` (like OpenRegister's live-update integration via `@conduction/nextcloud-vue`) get direct pushes on object changes. The browser does not have to poll.
+You should see a list of green checkmarks (✓). One warning about `unencrypted http` is expected for local use — you can ignore it. If any other item shows a red ✗, check the troubleshooting section at the bottom of this page.
 
 ## What you get
 
-| Property | Value |
+Here is a quick overview of what is now running on your laptop:
+
+| | |
 | --- | --- |
-| First boot | About three minutes (first run downloads 750 MB) |
-| Subsequent boots | Seconds |
-| Image | Official `nextcloud:latest`, identical to production |
-| Memory | Around 1 GB under light load |
-| Reset | `docker compose down -v` (removes volumes) |
+| **Browser address** | `http://localhost:8080` |
+| **First startup** | About 3 minutes (downloads ~750 MB once) |
+| **Starting again later** | A few seconds |
+| **Nextcloud version** | Official latest, identical to production |
+| **Memory used** | Around 1 GB |
+| **To wipe everything and start fresh** | Run `docker compose down -v` — ⚠️ deletes all data |
 
-No pre-recorded screencast, no demo environment that can go offline. What you see here is exactly what a real customer sees.
+This is a real, fully working Nextcloud — not a recording or a shared demo that can go offline.
 
-## Reset or stop
+## Stopping and starting
 
+When you are done for the day you do not need to leave everything running.
+
+**Pause for now** — stops the containers but keeps all your data:
 ```bash
-# temporarily stop, keep data
 docker compose stop
+```
 
-# start again
+**Start again after pausing:**
+```bash
 docker compose start
+```
 
-# tear down completely, including volumes
+**Wipe everything and start from scratch:**
+```bash
 docker compose down -v
 ```
 
-After `down -v`, your laptop is clean again. Two minutes later, you can start over.
+> ⚠️ **This deletes everything.** All your Nextcloud data, every installed app, every setting, and every file you uploaded will be permanently gone. There is no undo. Only run this if you are sure you want to start completely fresh.
+
+After `docker compose down -v` your laptop is back to its original state. To start over, run `docker compose up -d` from the `conduction-demo` folder and go through the full setup again from step 3.
 
 ## Troubleshooting
 
-**Apache port 8080 in use:** change `"8080:80"` to something like `"8081:80"` in `docker-compose.yml`. Remember to update the URL to `http://localhost:8081`.
+<Troubleshooting lede="Something not working? Find the matching situation below.">
 
-**Setup wizard wants to start over:** the Postgres database probably emptied out. Run `docker compose down -v` and start again with `docker compose up -d`.
+<TroubleshootingItem symptom="The terminal does not recognise `docker`">
 
-**Nextcloud shows a "Trusted domain" error:** add the host to `NEXTCLOUD_TRUSTED_DOMAINS` (comma-separated) and restart with `docker compose up -d`.
+Docker Desktop is probably not running. Open Docker Desktop and wait for the whale icon to stop moving, then try again. On Windows: close the Command Prompt and open a new one after Docker Desktop has started.
 
-**App store install does not work:** check that Nextcloud can reach the internet. Corporate networks sometimes block `apps.nextcloud.com`. A proxy via `HTTP_PROXY` env variables fixes this.
+</TroubleshootingItem>
 
-**`notify_push` self-test fails on `is not trusted as a reverse proxy`:** the Docker network range in your setup differs from `172.16.0.0/12`. Inspect the range with `docker network inspect $(docker network ls --filter name=conduction-demo -q) --format '{{range .IPAM.Config}}{{.Subnet}}{{end}}'` and update the `trusted_proxies` line from step 5 with that subnet.
+<TroubleshootingItem symptom="Docker Desktop fails to start on Windows with an error about virtualization or WSL 2">
 
-**`notify_push` keeps restarting after `docker compose up -d`:** check the logs (`docker compose logs notify_push`) for `× No redis server is configured`. That means Nextcloud's `memcache.distributed` config is not on Redis yet. Run the first three `occ config:system:set` commands from step 5, then restart with `docker compose up -d notify_push`.
+Virtualization is probably disabled in your computer's BIOS. The BIOS is a settings screen that exists below Windows and controls your hardware — it looks different from everything you normally see. On most modern laptops (2018+) virtualization is already on by default, so this error is uncommon.
+
+> **Not comfortable making changes in the BIOS?** That is completely understandable — ask someone with IT knowledge to help you with the steps below.
+
+**Step 1 — get into the BIOS.** The easiest way on Windows 10 and 11:
+1. Click **Start** → **Settings** (the gear icon) → **System** → **Recovery**.
+2. Under **Advanced startup**, click **Restart now**.
+3. After the restart, click **Troubleshoot** → **Advanced options** → **UEFI Firmware Settings** → **Restart**.
+4. Your PC restarts directly into the BIOS screen.
+
+If that option is not available, restart your computer and immediately press the key for your laptop brand — you only have a few seconds before Windows starts loading:
+
+| Brand | Key |
+| --- | --- |
+| Dell | F2 |
+| HP | F10 or Esc |
+| Lenovo | F1 or F2 |
+| ASUS | Del or F2 |
+| Acer | Del or F2 |
+| Microsoft Surface | Hold **Volume Up** while pressing the power button |
+
+Not sure? Watch the screen right after startup — it usually shows a message like "Press F2 to enter Setup".
+
+**Step 2 — find the virtualization setting.** Once inside the BIOS:
+1. Use the **arrow keys** on your keyboard to navigate — your mouse usually does not work here.
+2. Look for a tab or section called **Advanced**, **Configuration**, or **CPU Configuration**.
+3. Find a setting named **Intel Virtualization Technology**, **Intel VT-x**, **AMD-V**, **SVM Mode**, or **Virtualization Technology**.
+4. Change it from **Disabled** to **Enabled**.
+
+**Step 3 — save and exit.** Press **F10** to save and exit, or look for a **Save & Exit** tab and press **Enter** on **Save Changes and Exit**. Confirm with **Yes** when asked.
+
+> **Important:** only change the virtualization setting. Do not touch anything else.
+
+Your computer will restart. Open Docker Desktop and it should start normally now.
+
+</TroubleshootingItem>
+
+<TroubleshootingItem symptom='Docker Desktop shows "WSL 2 installation is incomplete"'>
+
+Open Command Prompt as administrator and run `wsl --update`, then restart Docker Desktop.
+
+</TroubleshootingItem>
+
+<TroubleshootingItem symptom="`http://localhost:8080` does not open in the browser">
+
+The port may already be in use by another program. Open `docker-compose.yml` in Notepad, change `"8080:80"` to `"8081:80"`, save, and try `http://localhost:8081` instead.
+
+</TroubleshootingItem>
+
+<TroubleshootingItem symptom="The Nextcloud setup screen appears again after you already finished it">
+
+The database was wiped, probably after a `docker compose down -v`. Run `docker compose up -d` to start fresh — you will need to go through the setup wizard again.
+
+</TroubleshootingItem>
+
+<TroubleshootingItem symptom='Nextcloud shows a "Trusted domain" error after opening the browser'>
+
+The address you are using is not on Nextcloud's allowed list. Open `docker-compose.yml`, find `NEXTCLOUD_TRUSTED_DOMAINS`, add your address to the value (space-separated), save, and run `docker compose up -d`.
+
+</TroubleshootingItem>
+
+<TroubleshootingItem symptom='"Download and enable" in the app store does nothing or shows an error'>
+
+Nextcloud may not be able to reach the internet. This sometimes happens on corporate networks. Try switching to a mobile hotspot to confirm, then ask your IT department about proxy settings.
+
+</TroubleshootingItem>
+
+<TroubleshootingItem symptom="Client Push self-test fails with `push server can't connect to the Nextcloud server` or `nextcloud is not configured as a trusted domain`">
+
+The internal hostname `nextcloud` is missing from Nextcloud's trusted list. Run this one command to fix it:
+
+```bash
+docker compose exec --user www-data nextcloud php occ config:system:set trusted_domains 1 --value nextcloud
+```
+
+Then re-run command 5 from step 5. If you are starting fresh, this is already fixed in the `docker-compose.yml` above.
+
+</TroubleshootingItem>
+
+<TroubleshootingItem symptom="Client Push self-test fails with `is not trusted as a reverse proxy`">
+
+The internal Docker network address range on your machine is different from the default. This is rare — if it happens, contact us and we will help you sort it out.
+
+</TroubleshootingItem>
+
+<TroubleshootingItem symptom="Client Push keeps restarting after `docker compose up -d`">
+
+Run `docker compose logs notify_push` and look for `× No redis server is configured`. If you see it, run commands 1, 2, and 3 from step 5 again, then restart with:
+
+```bash
+docker compose up -d notify_push
+```
+
+</TroubleshootingItem>
+
+</Troubleshooting>
 
 <NextSteps title="Next step" lede="A working Nextcloud is the entry point for the other tutorials in this series.">
-  <NextStep
-    title="Set up a Woo register"
-    href="/academy/woo-register-opzetten"
-    description="Import the canonical Woo register into OpenRegister."
-  />
-  <NextStep
-    title="Upload files to a Woo publication"
-    href="/academy/woo-bestanden-uploaden"
-    description="Four upload modes for documents."
-  />
-  <NextStep
-    title="Build your first Conduction app"
-    href="/academy/build-an-app"
-    description="Ends with an installed app on this stack."
-  />
+  <NextStep href="/academy/woo-register-opzetten" title="Set up a Woo register" cta="Start tutorial">
+    Import the canonical Woo register into OpenRegister.
+  </NextStep>
+  <NextStep href="/academy/woo-bestanden-uploaden" title="Upload files to a Woo publication" cta="Start tutorial">
+    Four upload modes for documents.
+  </NextStep>
+  <NextStep href="/academy/build-an-app" title="Build your first Conduction app" cta="Start tutorial">
+    Ends with an installed app on this stack.
+  </NextStep>
 </NextSteps>
 
 Send the `docker-compose.yml` to a colleague if you want to see this work together.

--- a/academy/2026-05-07-nextcloud-lokaal-draaien/index.mdx
+++ b/academy/2026-05-07-nextcloud-lokaal-draaien/index.mdx
@@ -15,8 +15,13 @@ import TabItem from '@theme/TabItem';
 import {Outcomes, Outcome, Prerequisites, PrerequisiteItem, ContactCta, Troubleshooting, TroubleshootingItem, NextSteps, NextStep} from '@conduction/docusaurus-preset/components';
 
 export function OSTabs({children}) {
-  const [osKey, setOsKey] = useState('ssr');
-  const [os, setOs] = useState('windows');
+  const [os, setOs] = useState(() => {
+    if (typeof window === 'undefined') return 'windows';
+    const stored = localStorage.getItem('docusaurus.tab.os');
+    if (stored) { try { return JSON.parse(stored); } catch (e) {} }
+    const ua = navigator.userAgent;
+    return /Mac/.test(ua) ? 'mac' : /Linux/.test(ua) ? 'linux' : 'windows';
+  });
   useEffect(() => {
     const ua = navigator.userAgent;
     const detected = /Mac/.test(ua) ? 'mac' : /Linux/.test(ua) ? 'linux' : 'windows';
@@ -24,10 +29,9 @@ export function OSTabs({children}) {
       localStorage.setItem('docusaurus.tab.os', JSON.stringify(detected));
     }
     setOs(detected);
-    setOsKey(detected);
   }, []);
   return (
-    <Tabs key={osKey} groupId="os" defaultValue={os}>
+    <Tabs groupId="os" defaultValue={os}>
       {children}
     </Tabs>
   );
@@ -162,7 +166,7 @@ Open a text editor from the terminal so the filename and folder are set automati
 
 Type in the terminal:
 
-```
+```bash
 notepad docker-compose.yml
 ```
 
@@ -246,7 +250,7 @@ volumes:
   nextcloud:
 ```
 
-The file describes four services: Nextcloud itself, a database (Postgres), a cache (Redis), and a live-update system (notify_push). All official, free images — Docker downloads them automatically in the next step.
+The file describes four services: Nextcloud itself, a database (Postgres), a cache (Redis), and a live-update system (notify_push — also known as **Client Push** in the Nextcloud app store). All official, free images — Docker downloads them automatically in the next step.
 
 Close the editor and go back to the terminal that is still open.
 
@@ -354,7 +358,7 @@ Copy the commands below one line at a time, paste them into the terminal, and pr
 <OSTabs>
 <TabItem value="windows" label="Windows">
 
-**Right-click** inside the terminal window to paste. Ctrl+V may also work on Windows 10 and 11, but right-click is more reliable.
+**Right-click** inside the terminal window to paste. **Ctrl+V** may also work on Windows 10 and 11, but right-click is more reliable.
 
 </TabItem>
 <TabItem value="mac" label="Mac">

--- a/i18n/nl/docusaurus-plugin-content-blog/2026-05-07-nextcloud-lokaal-draaien/index.mdx
+++ b/i18n/nl/docusaurus-plugin-content-blog/2026-05-07-nextcloud-lokaal-draaien/index.mdx
@@ -15,8 +15,13 @@ import TabItem from '@theme/TabItem';
 import {Outcomes, Outcome, Prerequisites, PrerequisiteItem, ContactCta, Troubleshooting, TroubleshootingItem, NextSteps, NextStep} from '@conduction/docusaurus-preset/components';
 
 export function OSTabs({children}) {
-  const [osKey, setOsKey] = useState('ssr');
-  const [os, setOs] = useState('windows');
+  const [os, setOs] = useState(() => {
+    if (typeof window === 'undefined') return 'windows';
+    const stored = localStorage.getItem('docusaurus.tab.os');
+    if (stored) { try { return JSON.parse(stored); } catch (e) {} }
+    const ua = navigator.userAgent;
+    return /Mac/.test(ua) ? 'mac' : /Linux/.test(ua) ? 'linux' : 'windows';
+  });
   useEffect(() => {
     const ua = navigator.userAgent;
     const detected = /Mac/.test(ua) ? 'mac' : /Linux/.test(ua) ? 'linux' : 'windows';
@@ -24,10 +29,9 @@ export function OSTabs({children}) {
       localStorage.setItem('docusaurus.tab.os', JSON.stringify(detected));
     }
     setOs(detected);
-    setOsKey(detected);
   }, []);
   return (
-    <Tabs key={osKey} groupId="os" defaultValue={os}>
+    <Tabs groupId="os" defaultValue={os}>
       {children}
     </Tabs>
   );
@@ -62,7 +66,7 @@ Loop je ergens vast? De sectie [Probleemoplossing](#probleemoplossing) onderaan 
 
 ### Wat is Docker?
 
-Docker is een gratis programma waarmee je andere programma's — zoals Nextcloud — in een afgeschermde omgeving op je laptop kunt draaien. Denk aan virtuale dozen: Nextcloud, de database en de cache draaien elk in hun eigen doos en beïnvloeden niets buiten die doos. Als je klaar bent, gooi je de dozen weg en is je laptop weer schoon.
+Docker is een gratis programma waarmee je andere programma's — zoals Nextcloud — in een afgeschermde omgeving op je laptop kunt draaien. Denk aan virtuele dozen: Nextcloud, de database en de cache draaien elk in hun eigen doos en beïnvloeden niets buiten die doos. Als je klaar bent, gooi je de dozen weg en is je laptop weer schoon.
 
 ### Docker installeren
 
@@ -354,7 +358,7 @@ Kopieer de onderstaande commando's één voor één, plak ze in de terminal en d
 <OSTabs>
 <TabItem value="windows" label="Windows">
 
-Klik met de **rechtermuisknop** in het terminalvenster om te plakken. Ctrl+V werkt soms ook op Windows 10 en 11, maar rechtermuisknop is betrouwbaarder.
+Klik met de **rechtermuisknop** in het terminalvenster om te plakken. **Ctrl+V** werkt soms ook op Windows 10 en 11, maar rechtermuisknop is betrouwbaarder.
 
 </TabItem>
 <TabItem value="mac" label="Mac">

--- a/i18n/nl/docusaurus-plugin-content-blog/2026-05-07-nextcloud-lokaal-draaien/index.mdx
+++ b/i18n/nl/docusaurus-plugin-content-blog/2026-05-07-nextcloud-lokaal-draaien/index.mdx
@@ -9,7 +9,29 @@ tags: [Nextcloud, Docker, Setup, Demo, Lokaal]
 durationMinutes: 30
 ---
 
+import {useState, useEffect} from 'react';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 import {Outcomes, Outcome, Prerequisites, PrerequisiteItem, ContactCta, Troubleshooting, TroubleshootingItem, NextSteps, NextStep} from '@conduction/docusaurus-preset/components';
+
+export function OSTabs({children}) {
+  const [osKey, setOsKey] = useState('ssr');
+  const [os, setOs] = useState('windows');
+  useEffect(() => {
+    const ua = navigator.userAgent;
+    const detected = /Mac/.test(ua) ? 'mac' : /Linux/.test(ua) ? 'linux' : 'windows';
+    if (!localStorage.getItem('docusaurus.tab.os')) {
+      localStorage.setItem('docusaurus.tab.os', JSON.stringify(detected));
+    }
+    setOs(detected);
+    setOsKey(detected);
+  }, []);
+  return (
+    <Tabs key={osKey} groupId="os" defaultValue={os}>
+      {children}
+    </Tabs>
+  );
+}
 
 Voor elke andere tutorial in deze academy heb je een werkende Nextcloud nodig. Dit is de snelste route: een paar commando's en je draait de officiële Nextcloud lokaal op je laptop, identiek aan productie. **Je hoeft geen programmeur te zijn** — als je een app kunt installeren en tekst kunt kopiëren, kom je er doorheen. Daarna installeer je de Conduction-apps via de Nextcloud app store, hetzelfde pad als productie.
 
@@ -27,7 +49,7 @@ Daarna kun je verder met [Een Woo-register opzetten](/academy/woo-register-opzet
 <Prerequisites title="Wat je nodig hebt">
   <PrerequisiteItem>Een laptop met minimaal 4 GB vrij geheugen.</PrerequisiteItem>
   <PrerequisiteItem>Docker Desktop — een gratis programma dat je in stap 0 installeert.</PrerequisiteItem>
-  <PrerequisiteItem>Een teksteditor: Kladblok (Windows) of TextEdit (Mac) is genoeg.</PrerequisiteItem>
+  <PrerequisiteItem>Een teksteditor: Kladblok (Windows), TextEdit (Mac) of nano (Linux) is genoeg.</PrerequisiteItem>
 </Prerequisites>
 
 > **Dit is een lokale ontwikkelomgeving.** Er draait dezelfde software als een echte Nextcloud-installatie en het gedraagt zich op dezelfde manier, dus alles wat je hier leert is direct toepasbaar op een productieomgeving. Data die je hier opslaat wordt echter niet bewaard, wordt niet gedeeld met anderen en kan op elk moment worden gewist — zo verwijdert `docker compose down -v` alles permanent. Gebruik deze omgeving om te verkennen, te experimenteren en te leren. Sla geen echte, gevoelige of productiedata op in deze omgeving.
@@ -44,15 +66,8 @@ Docker is een gratis programma waarmee je andere programma's — zoals Nextcloud
 
 ### Docker installeren
 
-**Mac**
-
-1. Ga naar de <a href="https://www.docker.com/products/docker-desktop/" target="_blank" rel="noopener noreferrer">Docker Desktop downloadpagina</a>.
-2. Je ziet twee downloadknoppen — **Apple Silicon** (voor M1, M2, M3 en M4-chips) en **Intel** (voor oudere Macs). Weet je niet welke jij hebt? Klik op het **Apple-logo (🍎)** linksboven in je scherm en kies **Over deze Mac**. Staat er "Apple M1", "Apple M2" of vergelijkbaar, klik dan op **Apple Silicon**. Staat er "Intel Core", klik dan op **Intel**.
-3. Open het gedownloade `.dmg`-bestand. Sleep het Docker-icoontje naar de map **Programma's** (Applications) wanneer dat gevraagd wordt.
-4. Open Docker vanuit je map Programma's. macOS vraagt mogelijk of je het zeker weet — klik op **Open**.
-5. Wacht tot het walvisicoontje in de menubalk stil staat. Docker is klaar.
-
-**Windows**
+<OSTabs>
+<TabItem value="windows" label="Windows">
 
 Windows heeft WSL 2 nodig vóórdat Docker Desktop wordt geïnstalleerd — sla je dit over, dan verschijnt de meest voorkomende Docker-fout. Het kost maar een minuutje.
 
@@ -68,26 +83,48 @@ Windows heeft WSL 2 nodig vóórdat Docker Desktop wordt geïnstalleerd — sla 
 7. Open **Docker Desktop** via het Start-menu.
 8. Wacht tot het walvisicoontje in de taakbalk stil staat. Docker is klaar.
 
-**Linux**
+</TabItem>
+<TabItem value="mac" label="Mac">
+
+1. Ga naar de <a href="https://www.docker.com/products/docker-desktop/" target="_blank" rel="noopener noreferrer">Docker Desktop downloadpagina</a>.
+2. Je ziet twee downloadknoppen — **Apple Silicon** (voor M1, M2, M3 en M4-chips) en **Intel** (voor oudere Macs). Weet je niet welke jij hebt? Klik op het **Apple-logo (🍎)** linksboven in je scherm en kies **Over deze Mac**. Staat er "Apple M1", "Apple M2" of vergelijkbaar, klik dan op **Apple Silicon**. Staat er "Intel Core", klik dan op **Intel**.
+3. Open het gedownloade `.dmg`-bestand. Sleep het Docker-icoontje naar de map **Programma's** (Applications) wanneer dat gevraagd wordt.
+4. Open Docker vanuit je map Programma's. macOS vraagt mogelijk of je het zeker weet — klik op **Open**.
+5. Wacht tot het walvisicoontje in de menubalk stil staat. Docker is klaar.
+
+</TabItem>
+<TabItem value="linux" label="Linux">
 
 Volg de <a href="https://docs.docker.com/engine/install/" target="_blank" rel="noopener noreferrer">installatie-instructies voor Docker Engine</a> voor jouw distributie.
+
+</TabItem>
+</OSTabs>
 
 ### Een terminal openen
 
 Een **terminal** (ook wel 'opdrachtprompt' of 'console' genoemd) is een tekstvenster waarin je opdrachten typt. Je typt een commando, drukt op **Enter**, en de computer voert het uit. Je hoeft de terminal niet al te kennen — alle commando's in deze tutorial kun je gewoon kopiëren en plakken.
 
-**Windows:**
+<OSTabs>
+<TabItem value="windows" label="Windows">
+
 1. Druk op de **Windows-toets** en typ `cmd`.
 2. Klik op **Opdrachtprompt** in de resultaten, of druk op **Enter**.
 3. Er opent een zwart venster — dat is je opdrachtprompt (terminal).
 
-**Mac:**
+</TabItem>
+<TabItem value="mac" label="Mac">
+
 1. Druk op **Cmd + Spatiebalk** om Spotlight te openen.
 2. Typ `Terminal` en druk op **Enter**.
 3. Er opent een venster met een knipperende cursor — dat is je terminal.
 
-**Linux:**
+</TabItem>
+<TabItem value="linux" label="Linux">
+
 1. Druk op **Ctrl + Alt + T**, of zoek "Terminal" in je applicatiemenu.
+
+</TabItem>
+</OSTabs>
 
 ### Controleer of Docker werkt
 
@@ -118,21 +155,45 @@ cd conduction-demo
 
 Het compose-bestand vertelt Docker welke programma's hij moet starten en hoe ze met elkaar praten. Je maakt het één keer aan en hoeft het daarna niet meer aan te raken.
 
-Open Kladblok via de terminal zodat de bestandsnaam en map automatisch goed staan — je hoeft niets handmatig in te vullen bij het opslaan:
+Open een teksteditor via de terminal zodat de bestandsnaam en map automatisch goed staan — je hoeft niets handmatig in te vullen bij het opslaan:
 
-**Windows:** typ in de terminal:
+<OSTabs>
+<TabItem value="windows" label="Windows">
+
+Typ in de terminal:
+
 ```
 notepad docker-compose.yml
 ```
-Windows vraagt of het bestand aangemaakt mag worden — klik op **Ja**. Kladblok opent zich.
 
-**Mac:** typ in de terminal:
+Windows vraagt of het bestand aangemaakt mag worden — klik op **Ja**. Kladblok opent zich. Plak de inhoud hieronder, druk daarna op **Ctrl+S** om op te slaan.
+
+</TabItem>
+<TabItem value="mac" label="Mac">
+
+Typ in de terminal:
+
 ```bash
 touch docker-compose.yml && open -e docker-compose.yml
 ```
-TextEdit opent zich met het bestand al aangemaakt.
 
-Kopieer de volledige tekst hieronder en plak die in de editor. Druk daarna op **Ctrl+S** (Windows) of **Cmd+S** (Mac) om op te slaan. De juiste bestandsnaam (`docker-compose.yml`) en map worden automatisch gebruikt — je hoeft niets te wijzigen.
+TextEdit opent zich met het bestand al aangemaakt. Plak de inhoud hieronder, druk daarna op **Cmd+S** om op te slaan.
+
+</TabItem>
+<TabItem value="linux" label="Linux">
+
+Typ in de terminal:
+
+```bash
+nano docker-compose.yml
+```
+
+De nano-teksteditor opent zich. Plak de inhoud hieronder, druk daarna op **Ctrl+X**, dan **Y**, dan **Enter** om op te slaan.
+
+</TabItem>
+</OSTabs>
+
+Kopieer de volledige tekst hieronder en plak die in de editor. De juiste bestandsnaam (`docker-compose.yml`) en map worden automatisch gebruikt — je hoeft niets te wijzigen.
 
 ```yaml title="docker-compose.yml"
 services:
@@ -187,7 +248,7 @@ volumes:
 
 Het bestand beschrijft vier services: Nextcloud zelf, een database (Postgres), een cache (Redis) en een systeem voor live updates (notify_push). Allemaal officiële, gratis images — Docker downloadt ze automatisch in de volgende stap.
 
-Sluit Kladblok (of TextEdit) nu en ga terug naar de terminal die nog open staat.
+Sluit de editor nu en ga terug naar de terminal die nog open staat.
 
 ## Stap 2: Start de stack
 
@@ -290,9 +351,23 @@ Dit is de enige stap die iets meer terminal-werk vraagt. Ga terug naar de termin
 
 Kopieer de onderstaande commando's één voor één, plak ze in de terminal en druk na elk commando op **Enter**. Hoe je plakt hangt af van je systeem:
 
-- **Windows (opdrachtprompt):** klik met de **rechtermuisknop** in het terminalvenster om te plakken. Ctrl+V werkt soms ook op Windows 10 en 11, maar rechtermuisknop is betrouwbaarder.
-- **Mac (Terminal):** druk op **Cmd+V**.
-- **Linux (Terminal):** druk op **Ctrl+Shift+V**, of klik met de rechtermuisknop en kies **Plakken**.
+<OSTabs>
+<TabItem value="windows" label="Windows">
+
+Klik met de **rechtermuisknop** in het terminalvenster om te plakken. Ctrl+V werkt soms ook op Windows 10 en 11, maar rechtermuisknop is betrouwbaarder.
+
+</TabItem>
+<TabItem value="mac" label="Mac">
+
+Druk op **Cmd+V** om te plakken.
+
+</TabItem>
+<TabItem value="linux" label="Linux">
+
+Druk op **Ctrl+Shift+V** om te plakken, of klik met de rechtermuisknop en kies **Plakken**.
+
+</TabItem>
+</OSTabs>
 
 Voer elk commando hieronder één voor één uit — kopieer het, plak het in de terminal en druk op **Enter**. Wacht tot de terminal een nieuwe regel toont voordat je het volgende commando plakt.
 
@@ -424,7 +499,7 @@ Open de opdrachtprompt als administrator en voer `wsl --update` uit, herstart da
 
 <TroubleshootingItem symptom="`http://localhost:8080` opent niet in de browser">
 
-De poort is waarschijnlijk al in gebruik door een ander programma. Open `docker-compose.yml` in Kladblok, verander `"8080:80"` naar `"8081:80"`, sla op en probeer `http://localhost:8081`.
+De poort is waarschijnlijk al in gebruik door een ander programma. Open `docker-compose.yml` in je teksteditor, verander `"8080:80"` naar `"8081:80"`, sla op en probeer `http://localhost:8081`.
 
 </TroubleshootingItem>
 

--- a/i18n/nl/docusaurus-plugin-content-blog/2026-05-07-nextcloud-lokaal-draaien/index.mdx
+++ b/i18n/nl/docusaurus-plugin-content-blog/2026-05-07-nextcloud-lokaal-draaien/index.mdx
@@ -4,20 +4,20 @@ title: Nextcloud lokaal draaien met Docker
 contentType: tutorial
 authors: [conduction]
 date: 2026-05-07
-summary: Drie commando's, vier stappen, een kwartier werk. Daarna draait er een schone Nextcloud op je laptop, klaar om Conduction-apps op te installeren.
+summary: Vijf stappen, een halfuur. Daarna draait er een schone Nextcloud op je laptop — ook als je nog nooit met Docker of een terminal hebt gewerkt.
 tags: [Nextcloud, Docker, Setup, Demo, Lokaal]
-durationMinutes: 15
+durationMinutes: 30
 ---
 
-import {Outcomes, Outcome, Prerequisites, PrerequisiteItem, ContactCta} from '@conduction/docusaurus-preset/components';
+import {Outcomes, Outcome, Prerequisites, PrerequisiteItem, ContactCta, Troubleshooting, TroubleshootingItem, NextSteps, NextStep} from '@conduction/docusaurus-preset/components';
 
-Voor elke andere tutorial in deze academy heb je een werkende Nextcloud nodig. Dit is de snelste route: drie commando's en je draait de officiële Nextcloud-image lokaal, identiek aan productie. Geen sales-call, geen demo-omgeving die offline kan, geen custom Dockerfile. Daarna installeer je de Conduction-apps via de Nextcloud app store, hetzelfde pad als productie.
+Voor elke andere tutorial in deze academy heb je een werkende Nextcloud nodig. Dit is de snelste route: een paar commando's en je draait de officiële Nextcloud lokaal op je laptop, identiek aan productie. **Je hoeft geen programmeur te zijn** — als je een app kunt installeren en tekst kunt kopiëren, kom je er doorheen. Daarna installeer je de Conduction-apps via de Nextcloud app store, hetzelfde pad als productie.
 
 {/* truncate */}
 
 <Outcomes title="Wat je leert">
+  <Outcome>Een terminal openen en eenvoudige opdrachten uitvoeren.</Outcome>
   <Outcome>Een werkende Nextcloud op <code>http://localhost:8080</code> opzetten met Docker.</Outcome>
-  <Outcome>Postgres voor data, Redis voor cache, Nextcloud voor het werk en <code>notify_push</code> voor realtime updates in één compose-bestand combineren.</Outcome>
   <Outcome>Een admin-account aanmaken waar je naar believen Conduction-apps op installeert.</Outcome>
   <Outcome>Met één commando de hele stack weer opruimen.</Outcome>
 </Outcomes>
@@ -26,36 +26,113 @@ Daarna kun je verder met [Een Woo-register opzetten](/academy/woo-register-opzet
 
 <Prerequisites title="Wat je nodig hebt">
   <PrerequisiteItem>Een laptop met minimaal 4 GB vrij geheugen.</PrerequisiteItem>
-  <PrerequisiteItem>Docker, lokaal draaiend.</PrerequisiteItem>
-  <PrerequisiteItem>Een terminal en een teksteditor.</PrerequisiteItem>
+  <PrerequisiteItem>Docker Desktop — een gratis programma dat je in stap 0 installeert.</PrerequisiteItem>
+  <PrerequisiteItem>Een teksteditor: Kladblok (Windows) of TextEdit (Mac) is genoeg.</PrerequisiteItem>
 </Prerequisites>
 
-Op een schone laptop is stap 0 (Docker installeren) ongeveer tien minuten. Daarna is stap 1 t/m 3 samen een kwartier.
+> **Dit is een lokale ontwikkelomgeving.** Er draait dezelfde software als een echte Nextcloud-installatie en het gedraagt zich op dezelfde manier, dus alles wat je hier leert is direct toepasbaar op een productieomgeving. Data die je hier opslaat wordt echter niet bewaard, wordt niet gedeeld met anderen en kan op elk moment worden gewist — zo verwijdert `docker compose down -v` alles permanent. Gebruik deze omgeving om te verkennen, te experimenteren en te leren. Sla geen echte, gevoelige of productiedata op in deze omgeving.
 
-## Stap 0: Zorg dat Docker draait
+Geen eerdere ervaring nodig. Op een schone laptop is stap 0 (Docker installeren en de terminal leren kennen) ongeveer tien minuten. Stap 1 t/m 5 samen daarna een halfuur.
 
-Eenmalig.
+Loop je ergens vast? De sectie [Probleemoplossing](#probleemoplossing) onderaan deze pagina bevat oplossingen voor de meest voorkomende problemen.
 
-- **Mac of Linux:** installeer [Docker Desktop](https://docs.docker.com/get-docker/).
-- **Windows:** zet eerst [WSL 2](https://learn.microsoft.com/nl-nl/windows/wsl/install) aan en installeer daarna Docker Desktop.
+## Stap 0: Docker installeren en een terminal openen
 
-Test of het werkt:
+### Wat is Docker?
+
+Docker is een gratis programma waarmee je andere programma's — zoals Nextcloud — in een afgeschermde omgeving op je laptop kunt draaien. Denk aan virtuale dozen: Nextcloud, de database en de cache draaien elk in hun eigen doos en beïnvloeden niets buiten die doos. Als je klaar bent, gooi je de dozen weg en is je laptop weer schoon.
+
+### Docker installeren
+
+**Mac**
+
+1. Ga naar de <a href="https://www.docker.com/products/docker-desktop/" target="_blank" rel="noopener noreferrer">Docker Desktop downloadpagina</a>.
+2. Je ziet twee downloadknoppen — **Apple Silicon** (voor M1, M2, M3 en M4-chips) en **Intel** (voor oudere Macs). Weet je niet welke jij hebt? Klik op het **Apple-logo (🍎)** linksboven in je scherm en kies **Over deze Mac**. Staat er "Apple M1", "Apple M2" of vergelijkbaar, klik dan op **Apple Silicon**. Staat er "Intel Core", klik dan op **Intel**.
+3. Open het gedownloade `.dmg`-bestand. Sleep het Docker-icoontje naar de map **Programma's** (Applications) wanneer dat gevraagd wordt.
+4. Open Docker vanuit je map Programma's. macOS vraagt mogelijk of je het zeker weet — klik op **Open**.
+5. Wacht tot het walvisicoontje in de menubalk stil staat. Docker is klaar.
+
+**Windows**
+
+Windows heeft WSL 2 nodig vóórdat Docker Desktop wordt geïnstalleerd — sla je dit over, dan verschijnt de meest voorkomende Docker-fout. Het kost maar een minuutje.
+
+1. Druk op de **Windows-toets**, typ `cmd`, **klik met de rechtermuisknop** op Opdrachtprompt en kies **Als administrator uitvoeren**. Klik op **Ja** als Windows om toestemming vraagt.
+2. Typ het onderstaande commando en druk op **Enter**. Dit installeert WSL 2 met Ubuntu automatisch:
+   ```
+   wsl --install
+   ```
+3. Als het klaar is, **herstart je computer**.
+4. Ga na de herstart naar de [Docker Desktop downloadpagina](https://www.docker.com/products/docker-desktop/) en klik op **Download for Windows**. Dit downloadt een `.exe`-installatiebestand.
+5. Open het gedownloade bestand. Als Windows vraagt "Wilt u toestaan dat deze app wijzigingen aanbrengt op uw apparaat?" klik dan op **Ja**.
+6. Volg de stappen in het installatieprogramma — klik op **OK**, **Volgende** en **Voltooien** wanneer dat gevraagd wordt.
+7. Open **Docker Desktop** via het Start-menu.
+8. Wacht tot het walvisicoontje in de taakbalk stil staat. Docker is klaar.
+
+**Linux**
+
+Volg de <a href="https://docs.docker.com/engine/install/" target="_blank" rel="noopener noreferrer">installatie-instructies voor Docker Engine</a> voor jouw distributie.
+
+### Een terminal openen
+
+Een **terminal** (ook wel 'opdrachtprompt' of 'console' genoemd) is een tekstvenster waarin je opdrachten typt. Je typt een commando, drukt op **Enter**, en de computer voert het uit. Je hoeft de terminal niet al te kennen — alle commando's in deze tutorial kun je gewoon kopiëren en plakken.
+
+**Windows:**
+1. Druk op de **Windows-toets** en typ `cmd`.
+2. Klik op **Opdrachtprompt** in de resultaten, of druk op **Enter**.
+3. Er opent een zwart venster — dat is je opdrachtprompt (terminal).
+
+**Mac:**
+1. Druk op **Cmd + Spatiebalk** om Spotlight te openen.
+2. Typ `Terminal` en druk op **Enter**.
+3. Er opent een venster met een knipperende cursor — dat is je terminal.
+
+**Linux:**
+1. Druk op **Ctrl + Alt + T**, of zoek "Terminal" in je applicatiemenu.
+
+### Controleer of Docker werkt
+
+Typ in de terminal (druk na elke regel op **Enter**):
 
 ```bash
 docker --version
 docker compose version
 ```
 
-Allebei moeten een versie teruggeven, geen foutmelding.
+Je ziet iets zoals `Docker version 27.0.3` en `Docker Compose version v2.x`. Zie je een foutmelding? Controleer of Docker Desktop open en actief is (walvisicoontje in de taak- of menubalk).
 
 ## Stap 1: Maak een werkmap en het compose-bestand
+
+### Een map aanmaken
+
+Typ in de terminal:
 
 ```bash
 mkdir conduction-demo
 cd conduction-demo
 ```
 
-Sla het volgende op als `docker-compose.yml` in die map:
+- `mkdir conduction-demo` maakt een nieuwe map aan met de naam `conduction-demo`.
+- `cd conduction-demo` stapt die map in ("cd" staat voor "change directory", map wisselen).
+
+### Het compose-bestand aanmaken
+
+Het compose-bestand vertelt Docker welke programma's hij moet starten en hoe ze met elkaar praten. Je maakt het één keer aan en hoeft het daarna niet meer aan te raken.
+
+Open Kladblok via de terminal zodat de bestandsnaam en map automatisch goed staan — je hoeft niets handmatig in te vullen bij het opslaan:
+
+**Windows:** typ in de terminal:
+```
+notepad docker-compose.yml
+```
+Windows vraagt of het bestand aangemaakt mag worden — klik op **Ja**. Kladblok opent zich.
+
+**Mac:** typ in de terminal:
+```bash
+touch docker-compose.yml && open -e docker-compose.yml
+```
+TextEdit opent zich met het bestand al aangemaakt.
+
+Kopieer de volledige tekst hieronder en plak die in de editor. Druk daarna op **Ctrl+S** (Windows) of **Cmd+S** (Mac) om op te slaan. De juiste bestandsnaam (`docker-compose.yml`) en map worden automatisch gebruikt — je hoeft niets te wijzigen.
 
 ```yaml title="docker-compose.yml"
 services:
@@ -88,7 +165,7 @@ services:
       POSTGRES_USER: nextcloud
       POSTGRES_PASSWORD: nextcloud
       REDIS_HOST: redis
-      NEXTCLOUD_TRUSTED_DOMAINS: "localhost"
+      NEXTCLOUD_TRUSTED_DOMAINS: "localhost nextcloud"
 
   notify_push:
     image: icewind1991/notify_push:latest
@@ -108,118 +185,308 @@ volumes:
   nextcloud:
 ```
 
-Vier services, allemaal officiële images, geen custom build. De `./apps`-bind-mount is optioneel: handig als je een Conduction-app als zip naast de installatie wilt zetten in plaats van via de app store. `notify_push` is de WebSocket push-server die Conduction-apps gebruiken voor realtime updates — meer daarover in stap 5.
+Het bestand beschrijft vier services: Nextcloud zelf, een database (Postgres), een cache (Redis) en een systeem voor live updates (notify_push). Allemaal officiële, gratis images — Docker downloadt ze automatisch in de volgende stap.
+
+Sluit Kladblok (of TextEdit) nu en ga terug naar de terminal die nog open staat.
 
 ## Stap 2: Start de stack
+
+Zorg dat je terminal nog in de map `conduction-demo` staat (dit is zo als je stap 1 net hebt gedaan). Typ:
 
 ```bash
 docker compose up -d
 ```
 
-De eerste keer trekt Docker ongeveer 750 MB aan images binnen. Daarna start de stack in seconden.
+Docker downloadt nu de benodigde programma's — de eerste keer ongeveer 750 MB — en start ze daarna op. De `-d` zorgt ervoor dat alles op de achtergrond blijft draaien, zodat je de terminal vrij houdt.
 
-Volg de logs terwijl Nextcloud zichzelf bootstrapt:
+Wil je zien wat er achter de schermen gebeurt? Volg de voortgang met:
 
 ```bash
 docker compose logs -f nextcloud
 ```
 
-Wacht tot je `apache2 -D FOREGROUND` of vergelijkbaar ziet, en `Ctrl+C` om de log-volger af te sluiten. De containers blijven draaien.
+Je ziet regels tekst voorbijkomen terwijl Nextcloud zichzelf instelt. Wacht tot je een regel ziet met `apache2 -D FOREGROUND` of iets vergelijkbaars — dat betekent dat Nextcloud klaar is. Druk daarna op **Ctrl+C** om de log-weergave te sluiten. De containers blijven gewoon draaien.
+
+**Sluit de terminal niet** — je hebt hem in stap 5 opnieuw nodig.
 
 ## Stap 3: Voltooi de Nextcloud setup-wizard
 
-Open `http://localhost:8080` in je browser. Nextcloud toont een setup-wizard:
+Open je webbrowser (Chrome, Firefox, Edge — wat je wilt) en ga naar:
 
-1. Vul een **admin-naam** en **wachtwoord** in. `admin` en `admin` is prima voor lokaal werk; in productie natuurlijk niet.
-2. Onder **Storage & database** kies je niets, want de Postgres-config zit al in `docker-compose.yml`.
-3. Klik op **Install**.
+```
+http://localhost:8080
+```
 
-Na een halve minuut land je op het dashboard, ingelogd als admin.
+Je ziet het setup-scherm van Nextcloud. We maken een admin-account aan met `admin` als gebruikersnaam en `admin` als wachtwoord.
+
+Nextcloud waarschuwt je dat het wachtwoord te zwak is — dat klopt, maar deze installatie draait **alleen op jouw eigen laptop** en is niet bereikbaar voor anderen, dus voor een lokale demo is dat prima. Je kunt de waarschuwing negeren.
+
+Gebruik je ooit een Nextcloud die anderen kunnen bereiken — via internet of binnen een netwerk — kies dan altijd een sterk, uniek wachtwoord. Een goede vuistregel: minimaal 12 tekens, met hoofdletters, cijfers en een speciaal teken.
+
+> **Let op:** onder het wachtwoordveld zie je een ingeklapt onderdeel **Storage & database**. Je hoeft dit niet open te klikken — de databaseconfiguratie is al geregeld via het `docker-compose.yml`-bestand.
+
+1. Vul `admin` in als **gebruikersnaam** en `admin` als **wachtwoord**. **Druk nog niet op Enter terwijl je de velden invult** — wacht tot beide velden zijn ingevuld voordat je verdergaat.
+2. Klik op **Install** of druk op Enter nadat je het wachtwoord hebt ingevuld. Het scherm verdwijnt direct en Nextcloud begint met installeren.
+3. Wacht een halve minuut terwijl Nextcloud zichzelf instelt.
+4. Nextcloud vraagt mogelijk of je aanbevolen apps wilt installeren. Klik op **Sla over** — we installeren straks alleen de Conduction-apps die je nodig hebt.
+
+Je komt op het Nextcloud-dashboard terecht. Je bent ingelogd als beheerder.
 
 ## Stap 4: Installeer de Conduction-apps
 
-Klik je avatar rechtsboven en kies **Apps**. De Conduction-apps staan onder **Integration** en **Office & text**. Onze suggestie voor een eerste demo:
+Open eerst de Nextcloud app store:
 
-- **OpenRegister.** De typed-data foundation. Installeer deze als eerste, alle andere apps lezen ervan af.
-- **OpenCatalogi.** Maakt elk register doorzoekbaar als publieke entry. Federation naar `data.overheid.nl`.
-- **OpenConnector.** Trekt voorbeelddata binnen via REST, SOAP en file-drops.
+1. Klik op je **avatar** — de cirkel met je initialen rechtsboven in het scherm.
+2. Kies **Apps** in het uitklapmenu.
+3. Klik in de linker zijbalk op **Aanbevolen apps** — als je dit overslaat, geeft de zoekfunctie mogelijk geen resultaten omdat Nextcloud alleen zoekt binnen de actieve categorie.
 
-Na elke install draait de schema-bootstrap automatisch. Voorbeelddata is binnen seconden zichtbaar.
+Installeer de Conduction-apps nu één voor één. Begin met **Open Register** — OpenCatalogi en Open Connector zijn daar allebei van afhankelijk.
 
-Installeer ook de `notify_push`-app (onder **Integration**). Die is de Nextcloud-zijde van de WebSocket push-server die je in stap 1 al hebt gestart — je hoeft hem alleen te enabelen, geen verdere config nodig.
+> **Let op:** als je op **Download en activeren** klikt, kan Nextcloud vragen om je wachtwoord te bevestigen voordat de installatie wordt toegestaan. Vul `admin` in en bevestig.
 
-## Stap 5: Koppel `notify_push` aan de push-server
+---
 
-`notify_push` heeft één eenmalige setup-stap zodat de Nextcloud-app weet waar de Rust-binary draait. Voer in de werkmap uit:
+**Open Register**
 
+De basis voor alle andere Conduction-apps. Installeer deze als eerste — OpenCatalogi en Open Connector lezen er allebei van af.
+
+1. Klik op het **zoekveld** bovenaan de Apps-pagina (het vergrootglas-icoon) zodat de cursor erin verschijnt.
+2. Typ `Open Register` — de resultaten worden automatisch bijgewerkt terwijl je typt.
+3. Klik op **Download en activeren** bij de Open Register-kaart.
+4. Wacht tot de installatie klaar is voordat je verdergaat.
+
+---
+
+**OpenCatalogi**
+
+Maakt elk register doorzoekbaar als publieke catalogus en federeert naar `data.overheid.nl`.
+
+1. Wis het zoekveld, typ `OpenCatalogi` en druk op **Enter**.
+2. Klik op **Download en activeren** bij de OpenCatalogi-kaart.
+
+---
+
+**Open Connector**
+
+Haalt voorbeelddata op via REST, SOAP en bestandsuploads.
+
+1. Wis het zoekveld, typ `Open Connector` en druk op **Enter**.
+2. Klik op **Download en activeren** bij de Open Connector-kaart.
+
+---
+
+Na elke Conduction-app installatie start de setup automatisch en is voorbeelddata binnen seconden zichtbaar.
+
+### Ook installeren: Client Push
+
+**Client Push** is een standaard Nextcloud-app — geen Conduction-app — die live browser-updates verzorgt zodat de pagina automatisch ververst als data verandert. Je hebt hem nodig voor stap 5.
+
+1. Wis het zoekveld, typ `Client Push` en druk op **Enter**.
+2. Klik op **Download en activeren** bij de Client Push-kaart.
+
+## Stap 5: Koppel Client Push aan de push-server
+
+Dit is de enige stap die iets meer terminal-werk vraagt. Ga terug naar de terminal die je open hebt gehouden en zorg dat je nog in de map `conduction-demo` staat.
+
+Kopieer de onderstaande commando's één voor één, plak ze in de terminal en druk na elk commando op **Enter**. Hoe je plakt hangt af van je systeem:
+
+- **Windows (opdrachtprompt):** klik met de **rechtermuisknop** in het terminalvenster om te plakken. Ctrl+V werkt soms ook op Windows 10 en 11, maar rechtermuisknop is betrouwbaarder.
+- **Mac (Terminal):** druk op **Cmd+V**.
+- **Linux (Terminal):** druk op **Ctrl+Shift+V**, of klik met de rechtermuisknop en kies **Plakken**.
+
+Voer elk commando hieronder één voor één uit — kopieer het, plak het in de terminal en druk op **Enter**. Wacht tot de terminal een nieuwe regel toont voordat je het volgende commando plakt.
+
+**Commando 1 van 5** — vertel Nextcloud welke server de gedeelde cache beheert:
 ```bash
 docker compose exec --user www-data nextcloud php occ config:system:set redis host --value redis
+```
+
+**Commando 2 van 5** — stel de poort van de cacheserver in:
+```bash
 docker compose exec --user www-data nextcloud php occ config:system:set redis port --value 6379 --type integer
+```
+
+**Commando 3 van 5** — vertel Nextcloud de cache te gebruiken voor gedeelde data:
+```bash
 docker compose exec --user www-data nextcloud php occ config:system:set memcache.distributed --value '\OC\Memcache\Redis'
+```
+
+**Commando 4 van 5** — markeer het interne Docker-netwerk als vertrouwd zodat Client Push met Nextcloud kan communiceren:
+```bash
 docker compose exec --user www-data nextcloud php occ config:system:set trusted_proxies 0 --value 172.16.0.0/12
+```
+
+**Commando 5 van 5** — registreer het adres van de Client Push-server bij Nextcloud:
+```bash
 docker compose exec --user www-data nextcloud php occ notify_push:setup http://notify_push:7867
 ```
 
-De eerste drie regels vertellen Nextcloud dat Redis de gedeelde cache is — `notify_push` luistert daarop voor change-events. De vierde regel markeert het Docker-netwerk als trusted zodat de push-server bij Nextcloud terugmag bellen voor authenticatie. De laatste regel registreert de URL bij de Nextcloud-app.
-
-Verifieer dat alles werkt:
+Controleer daarna of alles goed verbonden is:
 
 ```bash
 docker compose exec --user www-data nextcloud php occ notify_push:self-test
 ```
 
-Je krijgt een lijstje vinkjes — `redis is configured`, `push server is receiving redis messages`, `push server can connect to the Nextcloud server`, et cetera. De waarschuwing over `unencrypted http` is voor lokaal werk normaal; in productie zit `notify_push` achter dezelfde reverse proxy als Nextcloud, dus dan is dat geen issue.
+Je ziet een lijst met groene vinkjes (✓). Eén waarschuwing over `unencrypted http` is normaal voor lokaal gebruik — die kun je negeren. Staat er ergens anders een rood ✗, kijk dan in de probleemoplossingssectie onderaan deze pagina.
 
-Vanaf nu krijgen apps die op `notify_push` luisteren — zoals OpenRegister's live-update-integratie via `@conduction/nextcloud-vue` — direct doorduwingen op object-wijzigingen, zonder dat de browser hoeft te pollen.
+## Wat je hebt opgebouwd
 
-## Wat je krijgt
+Een kort overzicht van wat er nu op je laptop draait:
 
-| Eigenschap | Waarde |
+| | |
 | --- | --- |
-| Eerste boot | Ongeveer drie minuten (eerste keer 750 MB download) |
-| Volgende boots | Seconden |
-| Image | Officiële `nextcloud:latest`, identiek aan productie |
-| Geheugen | Rond 1 GB onder lichte load |
-| Reset | `docker compose down -v` (verwijdert volumes) |
+| **Browseradres** | `http://localhost:8080` |
+| **Eerste opstart** | Ongeveer 3 minuten (download ~750 MB eenmalig) |
+| **Later opnieuw opstarten** | Een paar seconden |
+| **Nextcloud-versie** | Officiële laatste versie, identiek aan productie |
+| **Geheugengebruik** | Ongeveer 1 GB |
+| **Alles wissen en opnieuw beginnen** | Voer `docker compose down -v` uit — ⚠️ verwijdert alle data |
 
-Geen vooraf opgenomen screencast, geen demo-omgeving die offline kan. Wat je hier ziet, is precies wat een echte klant ziet.
+Dit is een echte, volledig werkende Nextcloud — geen opname of gedeelde demo die offline kan gaan.
 
-## Reset of stoppen
+## Stoppen en opnieuw starten
 
+Als je klaar bent voor vandaag, hoef je niet alles aan te laten staan.
+
+**Even pauzeren** — stopt de containers maar behoudt al je data:
 ```bash
-# tijdelijk stoppen, data behouden
 docker compose stop
+```
 
-# weer starten
+**Opnieuw starten na een pauze:**
+```bash
 docker compose start
+```
 
-# helemaal opruimen, ook volumes
+**Alles verwijderen en opnieuw beginnen:**
+```bash
 docker compose down -v
 ```
 
-Na `down -v` is je laptop weer schoon. Twee minuten later kun je opnieuw beginnen.
+> ⚠️ **Dit verwijdert alles.** Al je Nextcloud-data, elke geïnstalleerde app, elke instelling en elk bestand dat je hebt geüpload verdwijnt permanent. Er is geen hersteloptie. Voer dit alleen uit als je zeker weet dat je helemaal opnieuw wilt beginnen.
+
+Na `docker compose down -v` is je laptop weer in de oorspronkelijke staat. Wil je opnieuw beginnen, voer dan `docker compose up -d` uit vanuit de map `conduction-demo` en doorloop de volledige setup opnieuw vanaf stap 3.
 
 ## Probleemoplossing
 
-**Apache port 8080 in gebruik:** wijzig `"8080:80"` naar bijvoorbeeld `"8081:80"` in `docker-compose.yml`. Vergeet niet de URL aan te passen naar `http://localhost:8081`.
+<Troubleshooting lede="Werkt er iets niet? Zoek de bijpassende situatie hieronder.">
 
-**Setup-wizard wil opnieuw beginnen:** waarschijnlijk is de Postgres-database leeg geraakt. Voer `docker compose down -v` uit en start opnieuw met `docker compose up -d`.
+<TroubleshootingItem symptom="De terminal herkent `docker` niet">
 
-**Nextcloud toont "Trusted domain"-foutmelding:** voeg de host toe aan `NEXTCLOUD_TRUSTED_DOMAINS` (komma-gescheiden) en herstart met `docker compose up -d`.
+Docker Desktop is waarschijnlijk niet actief. Open Docker Desktop en wacht tot het walvisicoontje stil staat, probeer het daarna opnieuw. Op Windows: sluit de opdrachtprompt en open een nieuwe nadat Docker Desktop is opgestart.
 
-**App-store install werkt niet:** controleer of Nextcloud naar buiten kan. In een corporate netwerk soms blokkade op `apps.nextcloud.com`. Een proxy via `HTTP_PROXY`-env-variabelen lost dit op.
+</TroubleshootingItem>
 
-**`notify_push` self-test faalt op `is not trusted as a reverse proxy`:** het Docker-netwerk-bereik in jouw setup wijkt af van `172.16.0.0/12`. Bekijk het bereik met `docker network inspect $(docker network ls --filter name=conduction-demo -q) --format '{{range .IPAM.Config}}{{.Subnet}}{{end}}'` en pas de `trusted_proxies`-regel uit stap 5 aan met die subnet.
+<TroubleshootingItem symptom="Docker Desktop start niet op Windows en geeft een foutmelding over virtualisatie of WSL 2">
 
-**`notify_push` blijft restarten na `docker compose up -d`:** kijk in de logs (`docker compose logs notify_push`) of je `× No redis server is configured` ziet. Dat betekent dat Nextcloud's `memcache.distributed`-config nog niet op Redis staat — voer de eerste drie `occ config:system:set`-commando's uit stap 5 uit, en herstart dan met `docker compose up -d notify_push`.
+Virtualisatie is waarschijnlijk uitgeschakeld in de BIOS van je pc. De BIOS is een instellingenscherm dat onder Windows zit en je hardware beheert — het ziet er anders uit dan alles wat je normaal gesproken ziet. Op de meeste moderne laptops (2018+) staat virtualisatie standaard al aan, dus deze fout komt weinig voor.
 
-## Volgende stap
+> **Niet comfortable met BIOS-wijzigingen?** Dat is heel begrijpelijk — vraag iemand met IT-kennis om je te helpen met de onderstaande stappen.
 
-Een werkende Nextcloud is de aanleiding voor de andere tutorials in deze serie:
+**Stap 1 — toegang tot de BIOS.** De makkelijkste manier op Windows 10 en 11:
+1. Klik op **Start** → **Instellingen** (het tandwiel-icoon) → **Systeem** → **Herstel**.
+2. Klik onder **Geavanceerde opstart** op **Nu opnieuw opstarten**.
+3. Klik na het herstarten op **Problemen oplossen** → **Geavanceerde opties** → **UEFI-firmware-instellingen** → **Opnieuw opstarten**.
+4. Je pc herstart direct in het BIOS-scherm.
 
-- [Een Woo-register opzetten](/academy/woo-register-opzetten) — importeer het canonieke Woo-register in OpenRegister
-- [Bestanden uploaden bij een Woo-publicatie](/academy/woo-bestanden-uploaden) — vier upload-modes voor documenten
-- [Build je eerste Conduction-app](/academy/build-an-app) — eindigt met een geïnstalleerde app op deze stack
+Als die optie niet beschikbaar is, herstart je computer en druk meteen op de toets die bij jouw laptopfabrikant hoort — je hebt maar een paar seconden voordat Windows begint te laden:
+
+| Fabrikant | Toets |
+| --- | --- |
+| Dell | F2 |
+| HP | F10 of Esc |
+| Lenovo | F1 of F2 |
+| ASUS | Del of F2 |
+| Acer | Del of F2 |
+| Microsoft Surface | Houd **Volume omhoog** ingedrukt terwijl je op de aan/uitknop drukt |
+
+Weet je het niet? Kijk goed naar het scherm direct na het opstarten — er staat meestal een melding als "Press F2 to enter Setup".
+
+**Stap 2 — de virtualisatie-instelling zoeken.** Eenmaal in de BIOS:
+1. Gebruik de **pijltjestoetsen** op je toetsenbord om te navigeren — je muis werkt hier meestal niet.
+2. Zoek naar een tabblad of sectie genaamd **Advanced**, **Configuration** of **CPU Configuration**.
+3. Zoek een instelling met de naam **Intel Virtualization Technology**, **Intel VT-x**, **AMD-V**, **SVM Mode** of **Virtualization Technology**.
+4. Verander die van **Disabled** naar **Enabled**.
+
+**Stap 3 — opslaan en afsluiten.** Druk op **F10** om op te slaan en te sluiten, of zoek een tabblad **Save & Exit** en druk op **Enter** bij **Save Changes and Exit**. Bevestig met **Yes** als daarom gevraagd wordt.
+
+> **Belangrijk:** wijzig alleen de virtualisatie-instelling. Raak niets anders aan.
+
+Je computer herstart. Open Docker Desktop en het zou nu normaal moeten starten.
+
+</TroubleshootingItem>
+
+<TroubleshootingItem symptom='Docker Desktop toont "WSL 2 installation is incomplete"'>
+
+Open de opdrachtprompt als administrator en voer `wsl --update` uit, herstart daarna Docker Desktop.
+
+</TroubleshootingItem>
+
+<TroubleshootingItem symptom="`http://localhost:8080` opent niet in de browser">
+
+De poort is waarschijnlijk al in gebruik door een ander programma. Open `docker-compose.yml` in Kladblok, verander `"8080:80"` naar `"8081:80"`, sla op en probeer `http://localhost:8081`.
+
+</TroubleshootingItem>
+
+<TroubleshootingItem symptom="Het Nextcloud-setup-scherm verschijnt opnieuw terwijl je al klaar was">
+
+De database is gewist, waarschijnlijk na een `docker compose down -v`. Voer `docker compose up -d` uit om opnieuw te beginnen — je doorloopt de setup-wizard opnieuw.
+
+</TroubleshootingItem>
+
+<TroubleshootingItem symptom='Nextcloud toont een "Trusted domain"-foutmelding na het openen van de browser'>
+
+Het adres dat je gebruikt staat niet op de toegestane lijst van Nextcloud. Open `docker-compose.yml`, zoek `NEXTCLOUD_TRUSTED_DOMAINS`, voeg je adres toe aan de waarde (spatie-gescheiden), sla op en voer `docker compose up -d` uit.
+
+</TroubleshootingItem>
+
+<TroubleshootingItem symptom='Op "Download en activeren" klikken in de app store doet niets of geeft een fout'>
+
+Nextcloud kan waarschijnlijk het internet niet bereiken. Dit gebeurt soms op bedrijfsnetwerken. Probeer een mobiele hotspot om te bevestigen, en vraag daarna je IT-afdeling naar proxyinstellingen.
+
+</TroubleshootingItem>
+
+<TroubleshootingItem symptom="Client Push self-test faalt met `push server can't connect to the Nextcloud server` of `nextcloud is not configured as a trusted domain`">
+
+De interne hostnaam `nextcloud` ontbreekt in de vertrouwde lijst van Nextcloud. Voer dit commando uit om het te herstellen:
+
+```bash
+docker compose exec --user www-data nextcloud php occ config:system:set trusted_domains 1 --value nextcloud
+```
+
+Voer daarna commando 5 uit stap 5 opnieuw uit. Begin je opnieuw, dan is dit al opgelost in de `docker-compose.yml` hierboven.
+
+</TroubleshootingItem>
+
+<TroubleshootingItem symptom="Client Push self-test faalt met `is not trusted as a reverse proxy`">
+
+Het interne Docker-netwerk op jouw computer heeft een ander adresbereik dan de standaard. Dit komt zelden voor — neem contact met ons op als het bij jou gebeurt.
+
+</TroubleshootingItem>
+
+<TroubleshootingItem symptom="Client Push blijft herstarten na `docker compose up -d`">
+
+Voer `docker compose logs notify_push` uit en zoek naar `× No redis server is configured`. Als je dat ziet, voer dan commando 1, 2 en 3 uit stap 5 opnieuw uit en herstart daarna met:
+
+```bash
+docker compose up -d notify_push
+```
+
+</TroubleshootingItem>
+
+</Troubleshooting>
+
+<NextSteps title="Volgende stap" lede="Een werkende Nextcloud is de basis voor de andere tutorials in deze serie.">
+  <NextStep href="/academy/woo-register-opzetten" title="Een Woo-register opzetten" cta="Start tutorial">
+    Importeer het canonieke Woo-register in OpenRegister.
+  </NextStep>
+  <NextStep href="/academy/woo-bestanden-uploaden" title="Bestanden uploaden bij een Woo-publicatie" cta="Start tutorial">
+    Vier upload-modes voor documenten.
+  </NextStep>
+  <NextStep href="/academy/build-an-app" title="Build je eerste Conduction-app" cta="Start tutorial">
+    Eindigt met een geïnstalleerde app op deze stack.
+  </NextStep>
+</NextSteps>
 
 Stuur het `docker-compose.yml` naar een collega als je dit samen wilt zien werken.
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "prestart": "node scripts/sync-app-downloads.js",
     "start": "docusaurus start --locale en",
     "start:nl": "docusaurus start --locale nl",
+    "preview": "docusaurus build && docusaurus serve",
     "prebuild": "python3 .github/scripts/app_downloads.py && node scripts/sync-app-downloads.js",
     "build": "docusaurus build",
     "postbuild": "node scripts/validate-ai-baseline.mjs",

--- a/src/css/site.css
+++ b/src/css/site.css
@@ -4,6 +4,11 @@
  * here when this site needs something the brand baseline does not.
  */
 
+/* Keep inline code on the text baseline so it does not drop below surrounding text. */
+:not(pre) > code {
+  vertical-align: baseline;
+}
+
 /* Hero treatment, tied to the cobalt-900 inverse panel */
 .cn-hero {
   background: var(--c-cobalt-900);


### PR DESCRIPTION
## tutorial: expand local Nextcloud tutorial for non-technical users

### Summary

- Rewrote the "Nextcloud lokaal draaien" tutorial (NL) to be accessible to users with no prior terminal or Docker experience, expanding from ~15 min to ~30 min estimated reading time.
- Added OS-aware tab sections (`<OSTabs>`) that auto-detect Windows, Mac, or Linux and show step-by-step instructions tailored to each platform — including how to open a terminal, install WSL 2, and install Docker Desktop.
- Added a Troubleshooting section and a prominent disclaimer that this is a local dev environment, not for real/sensitive data.
- Added `npm run preview` script to `package.json` for a one-command production build preview.
- Fixed inline `<code>` vertical alignment in `site.css` so inline code no longer drops below the surrounding text baseline.
