### PR TITLE
i18n(academy): NL/EN translation pairs for Hydra, OpenSpec, Claude Skills

### DIFF
--- a/academy/2026-05-07-nextcloud-lokaal-draaien/index.mdx
+++ b/academy/2026-05-07-nextcloud-lokaal-draaien/index.mdx
@@ -56,7 +56,11 @@ After this you can move on to [Set up a Woo register](/academy/woo-register-opze
   <PrerequisiteItem>A text editor: Notepad (Windows), TextEdit (Mac), or nano (Linux) is enough.</PrerequisiteItem>
 </Prerequisites>
 
-> **This is a local development environment.** It runs the same software as a real Nextcloud installation and behaves the same way, so everything you learn here applies directly to a production deployment. However, data you store here is not backed up, is not shared with anyone, and can be wiped at any time — for example, running `docker compose down -v` permanently deletes everything. Use this environment to explore, experiment, and learn. Do not store real, sensitive, or production data here.
+:::info This is a local development environment
+
+It runs the same software as a real Nextcloud installation and behaves the same way, so everything you learn here applies directly to a production deployment. However, data you store here is not backed up, is not shared with anyone, and can be wiped at any time — for example, running `docker compose down -v` permanently deletes everything. Use this environment to explore, experiment, and learn. Do not store real, sensitive, or production data here.
+
+:::
 
 No prior experience needed. On a clean laptop, step 0 (installing Docker and learning the terminal) takes about ten minutes. Steps 1 through 5 together take half an hour after that.
 
@@ -288,7 +292,11 @@ Nextcloud will warn you that the password is too weak — that warning is correc
 
 If you ever run a Nextcloud that others can reach — over the internet or within a network — always choose a strong, unique password. A good rule of thumb: at least 12 characters, mixing uppercase letters, numbers, and a special character.
 
-> **Note:** below the password field you will see a collapsed section called **Storage & database**. You do not need to open it — the database configuration is already taken care of through the `docker-compose.yml` file.
+:::note
+
+Below the password field you will see a collapsed section called **Storage & database**. You do not need to open it — the database configuration is already taken care of through the `docker-compose.yml` file.
+
+:::
 
 1. Fill in `admin` as the **username** and `admin` as the **password**. **Do not press Enter while filling in the fields** — wait until both fields are filled in before you continue.
 2. Click **Install** or press Enter after filling in the password. The screen disappears immediately and Nextcloud starts installing.
@@ -307,7 +315,11 @@ First open the Nextcloud app store:
 
 Now install the Conduction apps one by one. Start with **Open Register** — OpenCatalogi and Open Connector both depend on it.
 
-> **Note:** when you click **Download and enable**, Nextcloud may ask you to confirm your password before it allows the installation. Enter `admin` and confirm.
+:::note
+
+When you click **Download and enable**, Nextcloud may ask you to confirm your password before it allows the installation. Enter `admin` and confirm.
+
+:::
 
 ---
 
@@ -442,7 +454,11 @@ docker compose start
 docker compose down -v
 ```
 
-> ⚠️ **This deletes everything.** All your Nextcloud data, every installed app, every setting, and every file you uploaded will be permanently gone. There is no undo. Only run this if you are sure you want to start completely fresh.
+:::danger This deletes everything
+
+All your Nextcloud data, every installed app, every setting, and every file you uploaded will be permanently gone. There is no undo. Only run this if you are sure you want to start completely fresh.
+
+:::
 
 After `docker compose down -v` your laptop is back to its original state. To start over, run `docker compose up -d` from the `conduction-demo` folder and go through the full setup again from step 3.
 
@@ -460,7 +476,11 @@ Docker Desktop is probably not running. Open Docker Desktop and wait for the wha
 
 Virtualization is probably disabled in your computer's BIOS. The BIOS is a settings screen that exists below Windows and controls your hardware — it looks different from everything you normally see. On most modern laptops (2018+) virtualization is already on by default, so this error is uncommon.
 
-> **Not comfortable making changes in the BIOS?** That is completely understandable — ask someone with IT knowledge to help you with the steps below.
+:::tip Not comfortable making changes in the BIOS?
+
+That is completely understandable — ask someone with IT knowledge to help you with the steps below.
+
+:::
 
 **Step 1 — get into the BIOS.** The easiest way on Windows 10 and 11:
 1. Click **Start** → **Settings** (the gear icon) → **System** → **Recovery**.
@@ -489,7 +509,11 @@ Not sure? Watch the screen right after startup — it usually shows a message li
 
 **Step 3 — save and exit.** Press **F10** to save and exit, or look for a **Save & Exit** tab and press **Enter** on **Save Changes and Exit**. Confirm with **Yes** when asked.
 
-> **Important:** only change the virtualization setting. Do not touch anything else.
+:::warning Important
+
+Only change the virtualization setting. Do not touch anything else.
+
+:::
 
 Your computer will restart. Open Docker Desktop and it should start normally now.
 

--- a/academy/2026-05-07-nextcloud-lokaal-draaien/index.mdx
+++ b/academy/2026-05-07-nextcloud-lokaal-draaien/index.mdx
@@ -56,11 +56,7 @@ After this you can move on to [Set up a Woo register](/academy/woo-register-opze
   <PrerequisiteItem>A text editor: Notepad (Windows), TextEdit (Mac), or nano (Linux) is enough.</PrerequisiteItem>
 </Prerequisites>
 
-:::info This is a local development environment
-
-It runs the same software as a real Nextcloud installation and behaves the same way, so everything you learn here applies directly to a production deployment. However, data you store here is not backed up, is not shared with anyone, and can be wiped at any time — for example, running `docker compose down -v` permanently deletes everything. Use this environment to explore, experiment, and learn. Do not store real, sensitive, or production data here.
-
-:::
+> **This is a local development environment.** It runs the same software as a real Nextcloud installation and behaves the same way, so everything you learn here applies directly to a production deployment. However, data you store here is not backed up, is not shared with anyone, and can be wiped at any time — for example, running `docker compose down -v` permanently deletes everything. Use this environment to explore, experiment, and learn. Do not store real, sensitive, or production data here.
 
 No prior experience needed. On a clean laptop, step 0 (installing Docker and learning the terminal) takes about ten minutes. Steps 1 through 5 together take half an hour after that.
 
@@ -292,11 +288,7 @@ Nextcloud will warn you that the password is too weak — that warning is correc
 
 If you ever run a Nextcloud that others can reach — over the internet or within a network — always choose a strong, unique password. A good rule of thumb: at least 12 characters, mixing uppercase letters, numbers, and a special character.
 
-:::note
-
-Below the password field you will see a collapsed section called **Storage & database**. You do not need to open it — the database configuration is already taken care of through the `docker-compose.yml` file.
-
-:::
+> **Note:** below the password field you will see a collapsed section called **Storage & database**. You do not need to open it — the database configuration is already taken care of through the `docker-compose.yml` file.
 
 1. Fill in `admin` as the **username** and `admin` as the **password**. **Do not press Enter while filling in the fields** — wait until both fields are filled in before you continue.
 2. Click **Install** or press Enter after filling in the password. The screen disappears immediately and Nextcloud starts installing.
@@ -315,11 +307,7 @@ First open the Nextcloud app store:
 
 Now install the Conduction apps one by one. Start with **Open Register** — OpenCatalogi and Open Connector both depend on it.
 
-:::note
-
-When you click **Download and enable**, Nextcloud may ask you to confirm your password before it allows the installation. Enter `admin` and confirm.
-
-:::
+> **Note:** when you click **Download and enable**, Nextcloud may ask you to confirm your password before it allows the installation. Enter `admin` and confirm.
 
 ---
 
@@ -454,11 +442,7 @@ docker compose start
 docker compose down -v
 ```
 
-:::danger This deletes everything
-
-All your Nextcloud data, every installed app, every setting, and every file you uploaded will be permanently gone. There is no undo. Only run this if you are sure you want to start completely fresh.
-
-:::
+> ⚠️ **This deletes everything.** All your Nextcloud data, every installed app, every setting, and every file you uploaded will be permanently gone. There is no undo. Only run this if you are sure you want to start completely fresh.
 
 After `docker compose down -v` your laptop is back to its original state. To start over, run `docker compose up -d` from the `conduction-demo` folder and go through the full setup again from step 3.
 
@@ -476,11 +460,7 @@ Docker Desktop is probably not running. Open Docker Desktop and wait for the wha
 
 Virtualization is probably disabled in your computer's BIOS. The BIOS is a settings screen that exists below Windows and controls your hardware — it looks different from everything you normally see. On most modern laptops (2018+) virtualization is already on by default, so this error is uncommon.
 
-:::tip Not comfortable making changes in the BIOS?
-
-That is completely understandable — ask someone with IT knowledge to help you with the steps below.
-
-:::
+> **Not comfortable making changes in the BIOS?** That is completely understandable — ask someone with IT knowledge to help you with the steps below.
 
 **Step 1 — get into the BIOS.** The easiest way on Windows 10 and 11:
 1. Click **Start** → **Settings** (the gear icon) → **System** → **Recovery**.
@@ -509,11 +489,7 @@ Not sure? Watch the screen right after startup — it usually shows a message li
 
 **Step 3 — save and exit.** Press **F10** to save and exit, or look for a **Save & Exit** tab and press **Enter** on **Save Changes and Exit**. Confirm with **Yes** when asked.
 
-:::warning Important
-
-Only change the virtualization setting. Do not touch anything else.
-
-:::
+> **Important:** only change the virtualization setting. Do not touch anything else.
 
 Your computer will restart. Open Docker Desktop and it should start normally now.
 

--- a/academy/2026-05-12-hydra-tutorial-1-wat-is-hydra/index.mdx
+++ b/academy/2026-05-12-hydra-tutorial-1-wat-is-hydra/index.mdx
@@ -1,10 +1,10 @@
 ---
 slug: hydra-tutorial-1-wat-is-hydra
-title: "Hydra leerlijn — Deel 1: Wat is Hydra?"
+title: "Hydra tutorial series — Part 1: What is Hydra?"
 contentType: tutorial
 authors: [conduction]
 date: 2026-05-12
-summary: Een korte introductie op Hydra, Conductions agentic CI/CD-platform. Wat doet het, waarom bestaat het, en welke plek het heeft binnen onze app-fabriek. Eerste van zes korte modules.
+summary: A short introduction to Hydra, Conduction's agentic CI/CD platform. What it does, why it exists, and where it sits inside our app factory. The first of six short modules.
 tags: [Hydra, AI, CI/CD, Tutorial series]
 apps: []
 durationMinutes: 10
@@ -15,116 +15,116 @@ partNumber: 1
 import {Outcomes, Outcome, Prerequisites, PrerequisiteItem, NextSteps, NextStep, HexCard, ContactCta} from '@conduction/docusaurus-preset/components';
 import Details from '@theme/Details';
 
-:::tip Aanbevolen vooraf — de OpenSpec-leerlijn
-Hydra werkt op OpenSpec-changes. Ben je nog niet bekend met begrippen als **spec**, **change**, **requirement** en **scenario**? Doe dan eerst de [OpenSpec-leerlijn](/academy/openspec-tutorial-1-wat-is-openspec) (deel 1 + 2, samen ~30 minuten). Dat scheelt veel terugzoeken in de rest van deze modules.
+:::tip Recommended first — the OpenSpec tutorial series
+Hydra runs on OpenSpec changes. If you're not yet familiar with terms like **spec**, **change**, **requirement** and **scenario**, take the [OpenSpec tutorial series](/academy/openspec-tutorial-1-wat-is-openspec) first (parts 1 and 2, roughly 30 minutes together). It will save you a lot of backtracking in the rest of these modules.
 :::
 
-:::tip Ook nuttig vooraf — de Claude Skills-leerlijn
-Een groot deel van Hydra's interne werking leunt op **Claude Skills**: `opsx-*`, `hydra-gate-*`, `team-*`, `test-*`. Als je nog nooit een skill geschreven of bekeken hebt, doe dan eerst [deel 1 van de Claude Skills-leerlijn](/academy/claude-skills-tutorial-1-wat-zijn-claude-skills) (10 minuten). Dat maakt deel 4 van deze leerlijn — waar we de skill-families in Hydra opensnijden — veel makkelijker te volgen.
+:::tip Also useful first — the Claude Skills tutorial series
+A large part of Hydra's internals leans on **Claude Skills**: `opsx-*`, `hydra-gate-*`, `team-*`, `test-*`. If you've never written or read a skill, take [part 1 of the Claude Skills tutorial series](/academy/claude-skills-tutorial-1-wat-zijn-claude-skills) first (10 minutes). That makes part 4 of this series — where we open up the skill families inside Hydra — a lot easier to follow.
 :::
 
-Hydra is Conductions interne **agentic CI/CD-platform**: een fabriek die OpenSpec-voorstellen omzet in gereviewde, geteste code op een feature branch. Deze module legt in tien minuten uit wát Hydra is, waaróm het bestaat, en hoe het past binnen onze app-fabriek. Het is het eerste deel van een leerlijn van zes; aan het eind sta je klaar voor deel 2 over de drie pipelines.
+Hydra is Conduction's internal **agentic CI/CD platform**: a factory that turns OpenSpec proposals into reviewed, tested code on a feature branch. This module explains in ten minutes *what* Hydra is, *why* it exists, and how it fits inside our app factory. It is the first part of a six-part series; by the end you're ready for part 2 on the three pipelines.
 
 {/* truncate */}
 
-<Outcomes title="Wat je leert in dit deel">
-  <Outcome>Wat Hydra is in één zin, en waarom we het hebben gebouwd.</Outcome>
-  <Outcome>De vier container-personas in grote lijnen: Al Gorithm, Juan Claude, Clyde, Axel.</Outcome>
-  <Outcome>Wanneer je Hydra wél inzet, en wanneer juist niet.</Outcome>
+<Outcomes title="What you'll learn in this part">
+  <Outcome>What Hydra is in one sentence, and why we built it.</Outcome>
+  <Outcome>The four container personas at a high level: Al Gorithm, Juan Claude, Clyde, Axel.</Outcome>
+  <Outcome>When to use Hydra, and when not to.</Outcome>
 </Outcomes>
 
-<Prerequisites title="Wat je nodig hebt">
-  <PrerequisiteItem>Basiskennis Git, GitHub issues + PRs, en een idee van wat een Nextcloud-app is.</PrerequisiteItem>
-  <PrerequisiteItem>Bekendheid met Claude Code-CLI op hoofdlijnen (we duiken hier niet in commando's; daarvoor zie deel 4).</PrerequisiteItem>
-  <PrerequisiteItem>Optioneel — de publieke 1-pagina-versie op <a href="https://github.com/ConductionNL/.github/blob/main/docs/hydra/README.md">.github/docs/hydra/README.md</a>. Goede warming-up als je nooit eerder van Hydra hebt gehoord.</PrerequisiteItem>
-  <PrerequisiteItem>Alleen nodig als je Hydra zelf wilt draaien (i.p.v. de leerlijn lezen): toegang tot de private <a href="https://github.com/ConductionNL/hydra">ConductionNL/hydra</a>-repo. Vraag dit aan bij je teamlead.</PrerequisiteItem>
+<Prerequisites title="What you need">
+  <PrerequisiteItem>Basic Git knowledge, familiarity with GitHub issues and PRs, and a notion of what a Nextcloud app is.</PrerequisiteItem>
+  <PrerequisiteItem>A rough familiarity with the Claude Code CLI (we don't dive into commands here; see part 4 for that).</PrerequisiteItem>
+  <PrerequisiteItem>Optional — the public one-pager at <a href="https://github.com/ConductionNL/.github/blob/main/docs/hydra/README.md">.github/docs/hydra/README.md</a>. A good warm-up if you've never heard of Hydra before.</PrerequisiteItem>
+  <PrerequisiteItem>Only needed if you want to run Hydra yourself (rather than just read the series): access to the private <a href="https://github.com/ConductionNL/hydra">ConductionNL/hydra</a> repo. Ask your team lead.</PrerequisiteItem>
 </Prerequisites>
 
-## In één zin
+## In one sentence
 
-Hydra is een **stateless, label-gedreven pipeline** die OpenSpec-voorstellen verandert in feature branches met code, tests, een review-history en een PR — klaar voor menselijke goedkeuring.
+Hydra is a **stateless, label-driven pipeline** that turns OpenSpec proposals into feature branches with code, tests, a review history and a PR — ready for human approval.
 
-Geen "AI assistent die de developer helpt", maar een **fabriek**. Je gooit er een OpenSpec-change in en aan de andere kant rolt er een PR uit waar twee onafhankelijke reviewers naar gekeken hebben.
+Not an "AI assistant that helps the developer", but a **factory**. You throw an OpenSpec change in one end and out the other end rolls a PR that two independent reviewers have looked at.
 
-Concreet: Hydra werkt op het `openspec/changes/<slug>/` mapje — `proposal.md`, `design.md`, `tasks.md` en de spec-delta. Als die termen nieuw zijn, doe eerst de OpenSpec-leerlijn (zie tip bovenaan).
+Concretely: Hydra works on the `openspec/changes/<slug>/` folder — `proposal.md`, `design.md`, `tasks.md` and the spec delta. If those terms are new, take the OpenSpec series first (see tip at the top).
 
-## Waarom bestaat Hydra?
+## Why does Hydra exist?
 
-Conduction bouwt veel open-source apps voor de Nextcloud-werkplek. Het ritme van die fabriek wordt bepaald door twee dingen: hoe snel we **changes** kunnen schrijven, en hoe snel die changes **code** worden. Hydra automatiseert die tweede stap, met drie expliciete doelen:
+Conduction builds a lot of open-source apps for the Nextcloud workplace. The rhythm of that factory is determined by two things: how fast we can write **changes**, and how fast those changes become **code**. Hydra automates that second step, with three explicit goals:
 
-1. **Doorlooptijd verkorten.** Een gemiddeld OpenSpec-voorstel wordt zonder Hydra in een halve dag tot drie dagen geïmplementeerd. Met Hydra is dat een halfuur tot een paar uur, afhankelijk van complexiteit.
-2. **Kwaliteit borgen.** Geen enkele PR komt het systeem uit zonder mechanische quality gates (PHPCS, Psalm, PHPStan, ESLint, PHPUnit), een onafhankelijke code review en een onafhankelijke security review. Twee paar AI-ogen vóór er een mens kijkt.
-3. **4-eyes principle behouden.** Hydra **merge-t niet zelf** — behalve wanneer een issue expliciet de `yolo`-vlag heeft, en zelfs dan moeten alle gates groen zijn. Een mens drukt op de knop.
+1. **Shorten lead time.** Without Hydra, an average OpenSpec proposal takes half a day to three days to implement. With Hydra, it's half an hour to a few hours, depending on complexity.
+2. **Lock in quality.** No PR leaves the system without mechanical quality gates (PHPCS, Psalm, PHPStan, ESLint, PHPUnit), an independent code review and an independent security review. Two pairs of AI eyes before a human looks.
+3. **Preserve the four-eyes principle.** Hydra **does not merge on its own** — except when an issue explicitly carries the `yolo` flag, and even then all gates have to be green. A human presses the button.
 
-## De vier personas
+## The four personas
 
-Hydra is intern opgebouwd uit vier ephemere container-personas. Elk speelt één rol, in één container, met scoped credentials en strakke turn-budgets. Je hoeft hun namen nu niet uit het hoofd te kennen — ze komen terug in deel 2 — maar het helpt om vroeg het rollenpatroon te zien:
+Internally, Hydra is built from four ephemeral container personas. Each plays one role, in one container, with scoped credentials and tight turn budgets. You don't have to memorise their names now — they come back in part 2 — but it helps to spot the role pattern early:
 
 <HexCard title="Al Gorithm (builder, Haiku)">
-  Bouwt code uit de change. Ziet nooit reviews terug. Stopt na een vast turn-budget.
+  Builds the code from the change. Never sees reviews. Stops after a fixed turn budget.
 </HexCard>
 
 <HexCard title="Juan Claude van Damme (code reviewer, Sonnet)">
-  Leest alleen de PR-diff. Kan zelf mechanische fixes doorvoeren binnen scope.
+  Reads only the PR diff. Can apply mechanical fixes within scope.
 </HexCard>
 
 <HexCard title="Clyde Barcode (security reviewer, Sonnet)">
-  Loopt na Juan Claude. Zelfde shape, plus Semgrep en patroon-matching op CWE-klassen.
+  Runs after Juan Claude. Same shape, plus Semgrep and pattern matching on CWE classes.
 </HexCard>
 
-<HexCard title="Axel Pliér (applier, Sonnet — géén schrijfrechten)">
-  Beslist binair: gaat dit door of niet? Leest beide reviews en de uiteindelijke code. Géén fix-tools.
+<HexCard title="Axel Pliér (applier, Sonnet — no write access)">
+  Decides binarily: does this pass or not? Reads both reviews and the final code. No fix tools.
 </HexCard>
 
-Belangrijk: **Al Gorithm draait op Haiku, de andere drie op Sonnet** (met Opus als fallback). Reden: bouwen volgt patronen en is goedkoop te doen met Haiku; oordelen vraagt meer diepgang. Op Claude Max heb je een aparte Sonnet-only en all-models quota, dus deze splitsing rekt het budget op.
+Important: **Al Gorithm runs on Haiku, the other three on Sonnet** (with Opus as fallback). Reason: building follows patterns and is cheap on Haiku; judgement needs more depth. On Claude Max you have separate Sonnet-only and all-models quotas, so this split stretches the budget.
 
-## Wanneer wel, wanneer niet
+## When to use, when not
 
-Hydra is geen wondermiddel. De vuistregel:
+Hydra is no silver bullet. The rule of thumb:
 
-**Wel inzetten als:**
+**Use it when:**
 
-- Het werk past binnen één coherente OpenSpec-change (één feature, niet een refactor van het hele systeem).
-- De acceptatiecriteria mechanisch te toetsen zijn (er bestaan tests of die zijn met PHPUnit/Newman/Playwright snel te schrijven).
-- De doel-repo is **gereed** voor Hydra: heeft `hydra-gate-*` labels, een `app-config.json`, en draait de standaard quality-suite.
+- The work fits inside one coherent OpenSpec change (one feature, not a refactor of the whole system).
+- The acceptance criteria can be checked mechanically (tests exist, or can be written quickly with PHPUnit/Newman/Playwright).
+- The target repo is **ready** for Hydra: has the `hydra-gate-*` labels, an `app-config.json`, and runs the standard quality suite.
 
-**Niet inzetten als:**
+**Don't use it when:**
 
-- Het gaat om een eenmalige spike, prototype, of "even iets uitproberen" zonder reviewer-discipline.
-- De architectuur wijzigt op een manier die niet in één PR past (multi-repo refactor, breaking schema-change met datamigratie).
-- Je geen vertrouwen hebt in de gates op de doel-repo — Hydra is alleen zo veilig als zijn quality checks.
-- Het werk vereist menselijke onderhandeling met een externe partij (klant, leverancier) voordat het kan beginnen.
+- It's a one-off spike, prototype, or "let's try something" without reviewer discipline.
+- The architecture changes in a way that doesn't fit one PR (multi-repo refactor, breaking schema change with data migration).
+- You don't trust the gates on the target repo — Hydra is only as safe as its quality checks.
+- The work requires human negotiation with an external party (customer, vendor) before it can start.
 
-## Wat Hydra **niet** doet
+## What Hydra does **not** do
 
-Een veelgemaakte vergissing: denken dat Hydra je hele product bedenkt. Het tegendeel is waar.
+A common mistake: thinking Hydra invents your whole product. The opposite is true.
 
-- **Hydra schrijft geen changes (of specs).** Die worden vooraf aangeleverd, of een mens schrijft ze handmatig (met `/opsx-ff`).
-- **Hydra doet niet aan visie of strategie.** Welke features we bouwen is een mensenkeuze.
-- **Hydra besluit niet over architectuur.** Daarvoor zijn ADR's, beheerd door mensen (zie `hydra/openspec/architecture/`).
-- **Hydra merge-t niet eigenmachtig.** Behalve `yolo`-issues — en daar zijn alle gates nog steeds harde voorwaarden.
+- **Hydra doesn't write changes (or specs).** Those are provided up front, or a human writes them by hand (with `/opsx-ff`).
+- **Hydra doesn't do vision or strategy.** What features we build is a human choice.
+- **Hydra doesn't decide architecture.** That's what ADRs are for, maintained by humans (see `hydra/openspec/architecture/`).
+- **Hydra doesn't merge on its own authority.** Except for `yolo` issues — and there, all gates are still hard requirements.
 
-## Test jezelf
+## Test yourself
 
-Vier korte vragen om te checken of je dit deel begrepen hebt. Vastgelopen? Klik **Hint**. Curieus naar het antwoord? Klik **Antwoord**.
+Four short questions to check whether you've understood this part. Stuck? Click **Hint**. Curious about the answer? Click **Answer**.
 
 <div className="tutorial-quiz">
 
-**1. Wat is het primaire doel van Hydra?**
+**1. What is Hydra's primary purpose?**
 
 <Details summary="Hint">
 
-Hydra doet één specifieke stap in onze fabriek. Welke stap, en welke twee voordelen levert dat op?
+Hydra does one specific step in our factory. Which step, and which two benefits does that deliver?
 
 </Details>
 
-<Details summary="Antwoord">
+<Details summary="Answer">
 
-Hydra automatiseert de stap van **OpenSpec-change naar gereviewde feature-branch + PR**. Drie expliciete doelen:
+Hydra automates the step from **OpenSpec change to reviewed feature branch + PR**. Three explicit goals:
 
-1. **Doorlooptijd verkorten** — van een halve dag tot drie dagen handmatig naar een halfuur tot een paar uur.
-2. **Kwaliteit borgen** — verplichte mechanische gates (PHPCS, Psalm, PHPStan, ESLint, PHPUnit) + twee onafhankelijke AI-reviews.
-3. **4-eyes-principe behouden** — Hydra merge-t niet zelf; een mens drukt op de knop. Uitzondering: `yolo`-issues, en zelfs dan moeten alle gates groen zijn.
+1. **Shorten lead time** — from half a day to three days by hand, down to half an hour to a few hours.
+2. **Lock in quality** — mandatory mechanical gates (PHPCS, Psalm, PHPStan, ESLint, PHPUnit) + two independent AI reviews.
+3. **Preserve the four-eyes principle** — Hydra doesn't merge itself; a human presses the button. Exception: `yolo` issues, and even then all gates must be green.
 
 </Details>
 
@@ -132,22 +132,22 @@ Hydra automatiseert de stap van **OpenSpec-change naar gereviewde feature-branch
 
 <div className="tutorial-quiz">
 
-**2. Waarom kiest Hydra voor mechanische quality gates (PHPCS, Psalm, PHPStan, ESLint, PHPUnit) in plaats van alleen AI-review?**
+**2. Why does Hydra rely on mechanical quality gates (PHPCS, Psalm, PHPStan, ESLint, PHPUnit) rather than only AI review?**
 
 <Details summary="Hint">
 
-AI-reviewers kunnen overtuigend klinken zonder feitelijk correct te zijn. Mechanische checks hebben één eigenschap die AI-review per definitie mist.
+AI reviewers can sound convincing without being factually correct. Mechanical checks have one property AI review by definition lacks.
 
 </Details>
 
-<Details summary="Antwoord">
+<Details summary="Answer">
 
-Mechanische gates zijn **deterministisch en niet te overtuigen**. PHPStan kun je niet ompraten; ESLint trekt zich niets aan van een goed onderbouwd verhaal. Twee gevolgen:
+Mechanical gates are **deterministic and unpersuadable**. You can't talk PHPStan around; ESLint doesn't care about a well-reasoned story. Two consequences:
 
-1. **Vals-positieven en hallucinaties worden gefilterd** vóórdat een reviewer ernaar kijkt — een PR die de gates niet haalt komt niet eens bij Juan Claude of Clyde langs.
-2. **Standaarden zijn afdwingbaar over de hele fleet** — codestijl, types en testresultaten zijn objectief, niet afhankelijk van wie er die dag reviewed.
+1. **False positives and hallucinations get filtered** before a reviewer looks — a PR that fails the gates never even reaches Juan Claude or Clyde.
+2. **Standards are enforceable across the whole fleet** — code style, types and test results are objective, not dependent on who reviews that day.
 
-AI-review komt erbovenop, niet in plaats ervan. Beide lagen vangen verschillende klassen van problemen.
+AI review sits on top, not in place of. The two layers catch different classes of problems.
 
 </Details>
 
@@ -155,22 +155,22 @@ AI-review komt erbovenop, niet in plaats ervan. Beide lagen vangen verschillende
 
 <div className="tutorial-quiz">
 
-**3. Welke vier personas heeft Hydra, en welke is degene die NIET kan schrijven?**
+**3. What are Hydra's four personas, and which one is the one that CANNOT write?**
 
 <Details summary="Hint">
 
-Eén persona is bewust read-only — zijn rol is een binaire gate ("gaat dit door of niet?"). Hij heeft geen Write- of Edit-tools.
+One persona is deliberately read-only — its role is a binary gate ("does this pass or not?"). It has no Write or Edit tools.
 
 </Details>
 
-<Details summary="Antwoord">
+<Details summary="Answer">
 
-De vier personas:
+The four personas:
 
-- **Al Gorithm** — builder (Haiku). Schrijft code.
-- **Juan Claude van Damme** — code reviewer (Sonnet). Mag bounded fixes pushen.
-- **Clyde Barcode** — security reviewer (Sonnet). Mag ook bounded fixes pushen.
-- **Axel Pliér** — applier (Sonnet, **géén schrijfrechten**). Leest de uiteindelijke diff + beide reviews en geeft één binair antwoord: `pass: true` of `pass: false`. Hij oordeelt, hij grijpt niet in.
+- **Al Gorithm** — builder (Haiku). Writes code.
+- **Juan Claude van Damme** — code reviewer (Sonnet). May push bounded fixes.
+- **Clyde Barcode** — security reviewer (Sonnet). May also push bounded fixes.
+- **Axel Pliér** — applier (Sonnet, **no write access**). Reads the final diff + both reviews and gives one binary answer: `pass: true` or `pass: false`. He judges, he doesn't intervene.
 
 </Details>
 
@@ -178,47 +178,47 @@ De vier personas:
 
 <div className="tutorial-quiz">
 
-**4. Noem twee situaties waarin je Hydra juist NIET inzet en handmatig werkt.**
+**4. Name two situations in which you would NOT use Hydra and work by hand instead.**
 
 <Details summary="Hint">
 
-Denk aan: past het werk in één change, is de doel-repo klaar, en is er iets niet-technisch dat eerst opgelost moet worden.
+Think about: does the work fit in one change, is the target repo ready, and is there a non-technical issue that has to be resolved first?
 
 </Details>
 
-<Details summary="Antwoord">
+<Details summary="Answer">
 
-Een paar veelgenoemde:
+A few common ones:
 
-- **Het werk past niet in één OpenSpec-change** — multi-repo refactor, breaking schema-change met datamigratie.
-- **De doel-repo is niet gereed** — geen `hydra-gate-*` labels, geen `app-config.json`, of een onbetrouwbare quality-suite. Hydra is alleen zo veilig als zijn gates.
-- **Spike of prototype zonder reviewer-discipline** — "even iets uitproberen". De overhead weegt niet op tegen de winst.
-- **Menselijke onderhandeling vereist** — een klant, leverancier of juridisch punt moet eerst opgelost worden voor het werk kan beginnen.
+- **The work doesn't fit in one OpenSpec change** — multi-repo refactor, breaking schema change with data migration.
+- **The target repo isn't ready** — no `hydra-gate-*` labels, no `app-config.json`, or an unreliable quality suite. Hydra is only as safe as its gates.
+- **Spike or prototype without reviewer discipline** — "just trying something out". The overhead isn't worth the gain.
+- **Human negotiation required** — a customer, vendor or legal point has to be resolved first before the work can begin.
 
 </Details>
 
 </div>
 
-<NextSteps title="Volgende stap" lede="Nu je weet wat Hydra is, kijken we in deel 2 binnen in de drie pipelines.">
+<NextSteps title="Next step" lede="Now that you know what Hydra is, in part 2 we look inside the three pipelines.">
   <NextStep
-    title="Deel 2 — De drie pipelines"
+    title="Part 2 — The three pipelines"
     href="/academy/hydra-tutorial-2-drie-pipelines"
-    description="Build, code review, security review. Wie doet wat, in welke volgorde, en hoe komt een issue uiteindelijk bij needs-input of done."
+    description="Build, code review, security review. Who does what, in what order, and how does an issue end up at needs-input or done."
   />
   <NextStep
-    title="Publieke Hydra-overzichtspagina"
+    title="Public Hydra overview page"
     href="https://github.com/ConductionNL/.github/blob/main/docs/hydra/README.md"
-    description="De openbare 1-pagina-versie in onze .github-repo. Bedoeld voor wie alleen het wat-en-hoe op hoofdlijnen hoeft te weten, zonder IP-details."
+    description="The public one-pager in our .github repo. Aimed at anyone who only needs the high-level what-and-how, without IP details."
   />
   <NextStep
-    title="Het volledige architectuur-document (privé)"
+    title="The full architecture document (private)"
     href="https://github.com/ConductionNL/hydra/blob/main/openspec/project.md"
-    description="Voor wie nu al het hele plaatje wil zien — alle details, geen samenvattingen. Vereist toegang tot de privé hydra-repo."
+    description="For anyone who wants the whole picture right now — all the details, no summaries. Requires access to the private hydra repo."
   />
 </NextSteps>
 
 <ContactCta
-  title="Vragen over Hydra of deze leerlijn?"
-  body="Spreek je teamlead aan of stel je vraag in #hydra op Slack. Issues op deze tutorial graag op het bijbehorende GitHub-issue."
-  cta={{ label: "Mail het Hydra-team", href: "mailto:wilco@conduction.nl?subject=Hydra%20leerlijn%20deel%201" }}
+  title="Questions about Hydra or this tutorial series?"
+  body="Talk to your team lead or ask in #hydra on Slack. Issues with this tutorial can go on the corresponding GitHub issue."
+  cta={{ label: "Email the Hydra team", href: "mailto:wilco@conduction.nl?subject=Hydra%20leerlijn%20deel%201" }}
 />

--- a/academy/2026-05-12-hydra-tutorial-2-drie-pipelines/index.mdx
+++ b/academy/2026-05-12-hydra-tutorial-2-drie-pipelines/index.mdx
@@ -1,10 +1,10 @@
 ---
 slug: hydra-tutorial-2-drie-pipelines
-title: "Hydra leerlijn — Deel 2: De drie pipelines"
+title: "Hydra tutorial series — Part 2: The three pipelines"
 contentType: tutorial
 authors: [conduction]
 date: 2026-05-12
-summary: Build, code-review en security-review. Wie doet wat, in welke volgorde, en hoe een label-state-machine de hele rit aan elkaar plakt. Tweede van zes korte modules.
+summary: Build, code review and security review. Who does what, in what order, and how a label state machine stitches the whole ride together. The second of six short modules.
 tags: [Hydra, Pipelines, Personas, Tutorial series]
 apps: []
 durationMinutes: 15
@@ -15,151 +15,151 @@ partNumber: 2
 import {Outcomes, Outcome, Prerequisites, PrerequisiteItem, NextSteps, NextStep, HexCard} from '@conduction/docusaurus-preset/components';
 import Details from '@theme/Details';
 
-In deel 1 zag je dat Hydra vier personas heeft. In dit deel kijken we naar de **pipeline**: hoe die personas na elkaar werken aan één issue, welke labels de overgangen markeren, en wanneer de pijplijn afslaat naar `needs-input`. Aan het eind weet je het label-state-machine van Hydra van buiten en kun je een issue terugleiden naar de juiste fase als hij ergens vastloopt.
+In part 1 you saw that Hydra has four personas. In this part we look at the **pipeline**: how those personas work on one issue one after another, which labels mark the transitions, and when the pipeline diverts to `needs-input`. By the end you'll know Hydra's label state machine inside out and you'll be able to steer an issue back to the right phase if it gets stuck somewhere.
 
 {/* truncate */}
 
-<Outcomes title="Wat je leert in dit deel">
-  <Outcome>De drie pipelines (build, code-review, security-review) en hoe ze sequentieel op elkaar overdragen.</Outcome>
-  <Outcome>Het complete label-state-machine: <code>build:queued → ... → done / needs-input</code>.</Outcome>
-  <Outcome>Wat de applier (Axel Pliér) doet, en waarom hij overgeslagen kan worden.</Outcome>
-  <Outcome>Het verschil tussen <code>retry:queued</code> en <code>rebuild:queued</code>.</Outcome>
+<Outcomes title="What you'll learn in this part">
+  <Outcome>The three pipelines (build, code review, security review) and how they hand off sequentially.</Outcome>
+  <Outcome>The full label state machine: <code>build:queued → ... → done / needs-input</code>.</Outcome>
+  <Outcome>What the applier (Axel Pliér) does, and why he can be skipped.</Outcome>
+  <Outcome>The difference between <code>retry:queued</code> and <code>rebuild:queued</code>.</Outcome>
 </Outcomes>
 
-<Prerequisites title="Wat je nodig hebt">
+<Prerequisites title="What you need">
   <PrerequisiteItem>
-    Deel 1 doorgenomen: <a href="/academy/hydra-tutorial-1-wat-is-hydra">Wat is Hydra?</a>
+    Part 1 read: <a href="/academy/hydra-tutorial-1-wat-is-hydra">What is Hydra?</a>
   </PrerequisiteItem>
-  <PrerequisiteItem>Een idee van wat labels op een GitHub-issue zijn en hoe je die toevoegt.</PrerequisiteItem>
+  <PrerequisiteItem>A notion of what labels on a GitHub issue are and how you add them.</PrerequisiteItem>
 </Prerequisites>
 
-## Drie pipelines, één pijplijn
+## Three pipelines, one pipeline
 
-Hydra heeft technisch gezien drie pipelines: **build**, **code-review** en **security-review**. Maar in praktijk werken ze altijd in dezelfde volgorde, automatisch aangestuurd door labels. Onder de motorkap is dat één state-machine:
+Hydra technically has three pipelines: **build**, **code-review** and **security-review**. But in practice they always run in the same order, automatically driven by labels. Under the hood it's one state machine:
 
 ```
-ready-to-build (of <prefix>-ready-to-build op een dev-werkstation — zie deel 5)
+ready-to-build (or <prefix>-ready-to-build on a dev workstation — see part 5)
     ↓
 build:queued → build:running → build:pass
     ↓
 code-review:queued → :running → :pass / :fail
-    ↓  (altijd doorlopen — ook bij :fail)
+    ↓  (always traversed — even on :fail)
 security-review:queued → :running → :pass / :fail
     ↓
-beslissing:
-    beide reviews :pass + 0 fixes → done (Axel overgeslagen)
-    beide reviews :pass + ≥1 fix → applier:queued → :running → :pass / :fail
-    één van beide reviews :fail   → needs-input (Axel overgeslagen, mens beslist)
+decision:
+    both reviews :pass + 0 fixes → done (Axel skipped)
+    both reviews :pass + ≥1 fix → applier:queued → :running → :pass / :fail
+    one of the reviews :fail     → needs-input (Axel skipped, human decides)
 ```
 
-De pijplijn heeft één belangrijke regel: **iedere uitkomst na review is terminaal**. Hydra fix-t niet automatisch in een loop. Slaagt het in één run, mooi. Slaagt het niet, dan komt het issue op `needs-input` en moet een mens beslissen wat de volgende stap is. Daarover meer in deel 6.
+The pipeline has one important rule: **every outcome after review is terminal**. Hydra doesn't automatically fix in a loop. If it succeeds in one run, great. If not, the issue lands on `needs-input` and a human has to decide the next step. More on that in part 6.
 
 ## Pipeline 1: Build (Al Gorithm, Haiku)
 
-De builder krijgt de change, een schone clone van de doel-repo, en een turn-budget. Geen review-history, geen feedback van eerdere runs. Hij implementeert de tasks uit `tasks.md`, draait de quality-suite, opent een draft-PR.
+The builder receives the change, a clean clone of the target repo, and a turn budget. No review history, no feedback from earlier runs. He implements the tasks from `tasks.md`, runs the quality suite, opens a draft PR.
 
-Volgorde binnen de build-fase:
+Order within the build phase:
 
-1. **Implementatie** — leest `proposal.md`, `design.md` en `tasks.md` uit `openspec/changes/<slug>/` in de doel-repo, schrijft code.
+1. **Implementation** — reads `proposal.md`, `design.md` and `tasks.md` from `openspec/changes/<slug>/` in the target repo, writes code.
 2. **Quality checks** — PHPCS, PHPMD, Psalm, PHPStan, ESLint, Stylelint, `composer audit`, `npm audit`.
-3. **PHPUnit + Newman** — backend en API-tests.
-4. **Browser-tests** — Playwright MCP loopt door de UI heen.
-5. **`fix-quality` / `fix-browser`** — als checks rood worden, krijgt Al Gorithm één tot twee pogingen om mechanisch te repareren. Dit is een *pre-review* fixup, geen review-loop.
-6. **Verdict** — `build:pass` (PR is opengezet) of `build:fail` (kapotte build, `needs-input`).
+3. **PHPUnit + Newman** — backend and API tests.
+4. **Browser tests** — Playwright MCP walks through the UI.
+5. **`fix-quality` / `fix-browser`** — if checks go red, Al Gorithm gets one or two attempts to mechanically repair. This is a *pre-review* fixup, not a review loop.
+6. **Verdict** — `build:pass` (PR has been opened) or `build:fail` (broken build, `needs-input`).
 
-Belangrijk: Al Gorithm draait op **Haiku**. Reden uit deel 1: hij volgt patronen, hij oordeelt niet. Door hem op Haiku te zetten houden we Sonnet-budget vrij voor de reviewers.
+Important: Al Gorithm runs on **Haiku**. Reason from part 1: he follows patterns, he doesn't judge. By putting him on Haiku we keep the Sonnet budget free for the reviewers.
 
-<HexCard title="Wat ziet de builder niet?">
-  Geen reviews, geen verdict-history, geen labels behalve het eigen <code>build:*</code>. Hij weet dus niet dat een eerdere reviewer iets afkeurde — die feedback bereikt hem alleen via een expliciete <code>retry:queued</code>-cyclus (zie onder).
+<HexCard title="What does the builder not see?">
+  No reviews, no verdict history, no labels other than his own <code>build:*</code>. So he doesn't know that an earlier reviewer rejected something — that feedback only reaches him through an explicit <code>retry:queued</code> cycle (see below).
 </HexCard>
 
 ## Pipeline 2: Code review (Juan Claude van Damme, Sonnet)
 
-Zodra `build:pass` gezet wordt, queue-t de supervisor automatisch `code-review:queued`. Juan Claude pakt het op:
+Once `build:pass` is set, the supervisor automatically queues `code-review:queued`. Juan Claude picks it up:
 
-1. Leest **alleen de PR-diff** (`HYDRA_REVIEW_SCOPE=diff`, ADR-020). Zo blijft de scope behapbaar en wordt elke regel die hij commentaar geeft daadwerkelijk in deze PR aangeraakt.
-2. Loopt de ADR-bibliotheek en gate-skills langs (zie deel 3).
-3. Voor **mechanische, in-scope fouten** mag hij zelf fixen (ADR-021: bounded-fix scope). PHPCS-headers ontbreken? Hij voegt ze toe. Pijnlijke variabele-naam? Niet zijn pakkie-an.
-4. Voor elk gevonden probleem schrijft hij een inline-comment op de PR met prefix `[fixed:...]` of `[unfixed:...]`.
-5. Hij commit + pusht zijn fixes naar de feature branch en zet `code-review:pass` of `code-review:fail` op het issue.
+1. Reads **only the PR diff** (`HYDRA_REVIEW_SCOPE=diff`, ADR-020). That keeps the scope manageable and ensures every line he comments on is actually touched in this PR.
+2. Walks the ADR library and gate skills (see part 3).
+3. For **mechanical, in-scope errors** he may fix himself (ADR-021: bounded-fix scope). Missing PHPCS headers? He adds them. Awkward variable name? Not his department.
+4. For each finding he writes an inline comment on the PR with prefix `[fixed:...]` or `[unfixed:...]`.
+5. He commits and pushes his fixes to the feature branch and sets `code-review:pass` or `code-review:fail` on the issue.
 
-Juan's `fixes_applied[]` en `unfixed[]` schrijft hij niet zelf weg als JSON — de orchestrator bundelt ze pas na de volgende stap (Clyde) tot één rondebestand. Zie ["Hoe verdicts gepersisteerd worden"](#hoe-verdicts-gepersisteerd-worden) hieronder.
+Juan doesn't write out his `fixes_applied[]` and `unfixed[]` as JSON himself — the orchestrator only bundles them into one round file after the next step (Clyde). See ["How verdicts are persisted"](#how-verdicts-are-persisted) below.
 
 ## Pipeline 3: Security review (Clyde Barcode, Sonnet)
 
-Direct na code-review (of die nu `:pass` of `:fail` was) queue-t de supervisor `security-review:queued`. Clyde Barcode loopt op de PR-staat ná Juan Claude's fixes:
+Right after code review (whether `:pass` or `:fail`), the supervisor queues `security-review:queued`. Clyde Barcode runs on the PR state *after* Juan Claude's fixes:
 
-- Zelfde shape als code-review, plus **Semgrep** en patroon-matching op CWE-klassen (SQL-injectie, XSS, path-traversal, hardcoded secrets, …).
-- Mag ook bounded fixes pushen in PR-mode.
-- Schrijft `security-review:pass` of `security-review:fail`.
+- Same shape as code review, plus **Semgrep** and pattern matching on CWE classes (SQL injection, XSS, path traversal, hardcoded secrets, …).
+- May also push bounded fixes in PR mode.
+- Writes `security-review:pass` or `security-review:fail`.
 
-Waarom sequentieel en niet parallel? Omdat Clyde reviewed wat Juan Claude heeft achtergelaten. Parallel zou betekenen dat Clyde naar pre-fix code kijkt — dan zou hij security-issues vinden die Juan Claude al weggepoetst had en moet je de verdicts gaan reconciliëren. Sequentieel is simpeler en duidelijker.
+Why sequential and not parallel? Because Clyde reviews what Juan Claude left behind. Parallel would mean Clyde looks at pre-fix code — he would then find security issues that Juan Claude had already cleaned up and you'd have to reconcile verdicts. Sequential is simpler and clearer.
 
-## Hoe verdicts gepersisteerd worden
+## How verdicts are persisted
 
-Na een complete review-ronde (Juan + Clyde achter elkaar) bundelt de orchestrator beide verdicts in **één** bestand op de feature branch: `openspec/changes/<slug>/reviews/<ronde>.json` in de doel-repo. Rondes nummeren sequentieel — `1.json` na de eerste pass, `2.json` na een `retry:queued`-cyclus, enzovoort (gewoon `ls reviews/*.json | wc -l` plus één). Daarin zitten de `fixes_applied[]` én `unfixed[]` van **beide** reviewers samen — dat is wat Axel Pliér straks leest. Een geaggregeerde status-snapshot loopt parallel mee naar `openspec/changes/<slug>/hydra.json` (zie deel 6 voor de structuur en hoe je hem uitleest).
+After a complete review round (Juan + Clyde back to back), the orchestrator bundles both verdicts into **one** file on the feature branch: `openspec/changes/<slug>/reviews/<round>.json` in the target repo. Rounds number sequentially — `1.json` after the first pass, `2.json` after a `retry:queued` cycle, and so on (just `ls reviews/*.json | wc -l` plus one). That file holds the `fixes_applied[]` and `unfixed[]` from **both** reviewers combined — which is what Axel Pliér will read later. An aggregated status snapshot runs alongside in `openspec/changes/<slug>/hydra.json` (see part 6 for the structure and how to read it).
 
-## De applier: Axel Pliér's binaire gate
+## The applier: Axel Pliér's binary gate
 
-Met beide reviews binnen heeft Hydra drie opties:
+With both reviews in, Hydra has three options:
 
-1. **Beide reviews `:pass` én Juan en Clyde hebben samen 0 fixes gepusht.**  
-   Niets veranderd ná de oorspronkelijke build, dus geen nieuwe risico's. **Axel wordt overgeslagen.** Issue krijgt `done`. Bespaart tokens.
+1. **Both reviews `:pass` and Juan and Clyde together pushed 0 fixes.**  
+   Nothing changed after the original build, so no new risks. **Axel is skipped.** Issue gets `done`. Saves tokens.
 
-2. **Beide reviews `:pass` én er is ≥ 1 fix gepusht.**  
-   De code is gewijzigd na de oorspronkelijke build. Voor we vertrouwen op de uiteindelijke staat draait de orchestrator opnieuw de mechanische gates (PHPCS, Psalm, PHPStan, ...). Slagen die, dan komt Axel Pliér aan zet. Hij leest:
-   - de uiteindelijke diff,
-   - de `fixes_applied[]` + `unfixed[]` uit beide reviews,
-   - alle inline-comments op de PR.
+2. **Both reviews `:pass` and ≥ 1 fix was pushed.**  
+   The code has changed since the original build. Before we trust the final state, the orchestrator reruns the mechanical gates (PHPCS, Psalm, PHPStan, ...). If those pass, Axel Pliér is up. He reads:
+   - the final diff,
+   - the `fixes_applied[]` + `unfixed[]` from both reviews,
+   - all inline comments on the PR.
    
-   En geeft één binair antwoord: `{pass: true}` of `{pass: false, blocking: [...]}`. Hij heeft géén Write- of Edit-tools. Hij oordeelt, hij grijpt niet in.
+   And gives one binary answer: `{pass: true}` or `{pass: false, blocking: [...]}`. He has no Write or Edit tools. He judges, he doesn't intervene.
 
-3. **Eén van beide reviews `:fail`.**  
-   De reviewers zijn de autoriteit. Axel wordt overgeslagen. Issue gaat naar `needs-input`. Een mens beslist of dit een `retry:queued` of `rebuild:queued` waard is (zie deel 6).
+3. **One of the reviews `:fail`.**  
+   The reviewers are the authority. Axel is skipped. Issue goes to `needs-input`. A human decides whether this warrants a `retry:queued` or `rebuild:queued` (see part 6).
 
-## Labels: één bron van waarheid
+## Labels: one source of truth
 
-Hydra is **stateless**. Het hele state-machine staat op de issue-labels op GitHub. De supervisor (de daemon) leest om de zoveel seconden de labels en beslist wat te doen. Crasht een container, dan kijkt de supervisor opnieuw naar de labels en pakt op waar het ophield.
+Hydra is **stateless**. The whole state machine lives on the issue labels on GitHub. The supervisor (the daemon) reads the labels every few seconds and decides what to do. If a container crashes, the supervisor looks at the labels again and picks up where it left off.
 
-Per stage zijn er vier mogelijke states: `:queued`, `:running`, `:pass`, `:fail`. Die staan **altijd op het issue, nooit op de PR.** Dat is een bewuste keuze: het issue is de eenheid van werk, de PR is een artefact van een buildcycle.
+Per stage there are four possible states: `:queued`, `:running`, `:pass`, `:fail`. They always live **on the issue, never on the PR.** That's a deliberate choice: the issue is the unit of work, the PR is an artefact of a build cycle.
 
-Naast de stage-labels zijn er metadata-labels die ernaast bestaan:
+Alongside the stage labels there are metadata labels that live next to them:
 
-| Label | Betekenis |
+| Label | Meaning |
 |---|---|
-| `openspec` | Issue volgt het OpenSpec-werkmodel |
-| `yolo` | Mag auto-mergen mits alle gates groen zijn — geen menselijke approve nodig |
-| `agent-maxed-out` | Persona heeft zijn turn-budget opgemaakt; output is mogelijk incompleet |
-| `needs-input` | Hydra heeft de pijplijn gestopt, mens is aan zet |
+| `openspec` | Issue follows the OpenSpec working model |
+| `yolo` | May auto-merge as long as all gates are green — no human approve needed |
+| `agent-maxed-out` | Persona has used up its turn budget; output may be incomplete |
+| `needs-input` | Hydra has stopped the pipeline, human's turn |
 
 ## `retry:queued` versus `rebuild:queued`
 
-Twee menselijk-getriggerde herstel-labels die teruggrijpen in de pijplijn. Allebei **single-shot** (geen loop):
+Two human-triggered recovery labels that reach back into the pipeline. Both **single-shot** (no loop):
 
-- **`retry:queued`** — de bestaande PR blijft staan. Hydra bouwt een efemere `feedback.md` (in een `/tmp/hydra-retry-XXXXXX/`-werkmap, niet gecommit) met daarin de `unfixed[]`-bevindingen + applier-blockers, mount die als `/workspace/feedback.md` in de builder-container, en dispatcht Al Gorithm in `HYDRA_MODE=fix` gescoped tot precies de geflagde bestanden. Goedkoop. Geschikt voor: "de reviewers hadden gelijk, builder moet alleen even bijschaven".
-- **`rebuild:queued`** — bestaande PR sluit, branch reset naar `development`, alle cycle-labels eraf, terug naar `build:queued`. Duur. Geschikt voor: "de aanpak van Al Gorithm klopte niet, we beginnen opnieuw met dezelfde change".
+- **`retry:queued`** — the existing PR stays. Hydra builds an ephemeral `feedback.md` (in a `/tmp/hydra-retry-XXXXXX/` working directory, not committed) containing the `unfixed[]` findings + applier blockers, mounts it as `/workspace/feedback.md` in the builder container, and dispatches Al Gorithm in `HYDRA_MODE=fix` scoped to exactly the flagged files. Cheap. Suitable for: "the reviewers were right, builder just needs to touch up a few things".
+- **`rebuild:queued`** — existing PR closes, branch resets to `development`, all cycle labels removed, back to `build:queued`. Expensive. Suitable for: "Al Gorithm's approach was wrong, we're starting over with the same change".
 
-Stelregel: pak altijd het goedkoopste herstel eerst. Eerst `gh pr update-branch <N>` (development → PR mergen), dan `retry:queued`, dan pas `rebuild:queued`. Deel 6 gaat hier dieper op in.
+Rule of thumb: always go for the cheapest recovery first. First `gh pr update-branch <N>` (merge development → PR), then `retry:queued`, only then `rebuild:queued`. Part 6 goes into this in more depth.
 
-## Test jezelf
+## Test yourself
 
-Vier korte vragen om te checken of je dit deel begrepen hebt. Vastgelopen? Klik **Hint**. Curieus naar het antwoord? Klik **Antwoord**.
+Four short questions to check whether you've understood this part. Stuck? Click **Hint**. Curious about the answer? Click **Answer**.
 
 <div className="tutorial-quiz">
 
-**1. In welke volgorde lopen de drie pipelines, en waarom is security-review sequentieel ná code-review en niet parallel?**
+**1. In what order do the three pipelines run, and why is security review sequential after code review and not parallel?**
 
 <Details summary="Hint">
 
-Denk aan welke versie van de code Clyde Barcode ziet: vóór of ná de fixes van Juan Claude?
+Think about which version of the code Clyde Barcode sees: before or after Juan Claude's fixes?
 
 </Details>
 
-<Details summary="Antwoord">
+<Details summary="Answer">
 
-De volgorde is **build → code-review → security-review** (en daarna applier of `needs-input`).
+The order is **build → code-review → security-review** (and after that applier or `needs-input`).
 
-Security-review draait **na** code-review zodat Clyde Barcode de PR-staat ziet **ná** Juan Claude's bounded fixes. Parallel zou betekenen dat Clyde naar pre-fix code kijkt en security-issues vindt die Juan al weggepoetst had. Je zou dan verdicts moeten gaan reconciliëren. Sequentieel is simpeler en houdt de "wie reviewed wat"-grens scherp.
+Security review runs **after** code review so Clyde Barcode sees the PR state **after** Juan Claude's bounded fixes. Parallel would mean Clyde looks at pre-fix code and finds security issues Juan had already cleaned up. You'd then have to reconcile verdicts. Sequential is simpler and keeps the "who reviews what" boundary sharp.
 
 </Details>
 
@@ -167,20 +167,20 @@ Security-review draait **na** code-review zodat Clyde Barcode de PR-staat ziet *
 
 <div className="tutorial-quiz">
 
-**2. Wat is het verschil tussen `build:fail` en `code-review:fail` qua vervolgactie?**
+**2. What's the difference between `build:fail` and `code-review:fail` in terms of follow-up?**
 
 <Details summary="Hint">
 
-Bij één stopt de pijplijn meteen, bij de andere loopt hij nog door naar de volgende stage. Welke is welke, en waarom?
+In one of them the pipeline stops immediately, in the other it continues to the next stage. Which is which, and why?
 
 </Details>
 
-<Details summary="Antwoord">
+<Details summary="Answer">
 
-- **`build:fail`** = de PR is niet (correct) opengezet, er valt niets te reviewen. Issue gaat **direct naar `needs-input`**. Pijplijn stopt.
-- **`code-review:fail`** = de PR staat, Juan Claude heeft afgekeurd, maar de pijplijn **loopt nog door** naar `security-review` (altijd, ook bij `:fail`). Pas na security-review wordt besloten: minstens één review `:fail` → applier overgeslagen → `needs-input`.
+- **`build:fail`** = the PR has not been (correctly) opened, there's nothing to review. Issue goes **straight to `needs-input`**. Pipeline stops.
+- **`code-review:fail`** = the PR exists, Juan Claude rejected it, but the pipeline **still continues** to `security-review` (always, even on `:fail`). Only after security review is the decision made: at least one review `:fail` → applier skipped → `needs-input`.
 
-Reden voor het verschil: zonder PR is er geen werk om over te oordelen; mét PR willen we beide reviewers laten zien wat er ligt, zodat een mens later een compleet beeld heeft.
+Reason for the difference: without a PR there's no work to judge; with a PR we want both reviewers to surface what's there so a human has a complete picture later.
 
 </Details>
 
@@ -188,22 +188,22 @@ Reden voor het verschil: zonder PR is er geen werk om over te oordelen; mét PR 
 
 <div className="tutorial-quiz">
 
-**3. In welke situatie wordt Axel Pliér (de applier) overgeslagen, en waarom is dat een bewuste keuze?**
+**3. In which situation is Axel Pliér (the applier) skipped, and why is that a deliberate choice?**
 
 <Details summary="Hint">
 
-Er zijn twee scenario's. Het ene draait om "is er na de oorspronkelijke build iets veranderd?", het andere om "wie heeft het laatste woord?"
+There are two scenarios. One revolves around "has anything changed since the original build?", the other around "who has the final word?"
 
 </Details>
 
-<Details summary="Antwoord">
+<Details summary="Answer">
 
-Twee scenario's:
+Two scenarios:
 
-1. **Beide reviews `:pass` én 0 fixes gepusht** door Juan/Clyde. De code is identiek aan wat de builder oplevert; er is niets nieuws om te beoordelen. Axel overgeslagen → `done`. Bespaart Sonnet-tokens.
-2. **Eén van beide reviews `:fail`.** De reviewers zijn de autoriteit; hun afwijzing trumpt de applier. Axel overgeslagen → `needs-input`.
+1. **Both reviews `:pass` and 0 fixes pushed** by Juan/Clyde. The code is identical to what the builder delivered; there's nothing new to judge. Axel skipped → `done`. Saves Sonnet tokens.
+2. **One of the reviews `:fail`.** The reviewers are the authority; their rejection trumps the applier. Axel skipped → `needs-input`.
 
-Axel draait dus **alleen** wanneer er wél fixes zijn gepusht én beide reviews zijn geslaagd — dan oordeelt hij of die fixes de uiteindelijke staat goed maken.
+So Axel only runs when fixes *were* pushed and both reviews passed — then he judges whether those fixes make the final state good.
 
 </Details>
 
@@ -211,39 +211,39 @@ Axel draait dus **alleen** wanneer er wél fixes zijn gepusht én beide reviews 
 
 <div className="tutorial-quiz">
 
-**4. Wanneer kies je `retry:queued` en wanneer `rebuild:queued`?**
+**4. When do you pick `retry:queued` and when `rebuild:queued`?**
 
 <Details summary="Hint">
 
-Het kantelpunt is: **deugde de build-aanpak van Al Gorithm?** Bij ja → goedkoop pad. Bij nee → opnieuw beginnen.
+The pivot is: **was Al Gorithm's build approach sound?** If yes → cheap path. If no → start over.
 
 </Details>
 
-<Details summary="Antwoord">
+<Details summary="Answer">
 
-- **`retry:queued`** als de **builder-aanpak in principe goed was** en de reviewers terechte, lokale bevindingen hadden. De bestaande PR blijft staan; de builder krijgt `feedback.md` en fixed gescoped tot de geflagde files. **Goedkoop, single-shot.**
-- **`rebuild:queued`** als de **build-aanpak zelf verkeerd was** — verkeerde implementatie, stub-methods, requirements gemist. PR sluit, branch reset naar `development`, alle cycle-labels eraf, terug naar `build:queued`. **Duur.**
+- **`retry:queued`** when the **builder approach was fundamentally right** and the reviewers had legitimate, local findings. The existing PR stays; the builder gets `feedback.md` and fixes scoped to the flagged files. **Cheap, single-shot.**
+- **`rebuild:queued`** when **the build approach itself was wrong** — wrong implementation, stub methods, requirements missed. PR closes, branch resets to `development`, all cycle labels removed, back to `build:queued`. **Expensive.**
 
-Stelregel: altijd het goedkoopste eerst — `gh pr update-branch` → `retry:queued` → pas dán `rebuild:queued`.
+Rule of thumb: always cheapest first — `gh pr update-branch` → `retry:queued` → only then `rebuild:queued`.
 
 </Details>
 
 </div>
 
-<NextSteps title="Volgende stap" lede="Nu je het pipeline-skelet ziet, gaan we in deel 3 in op de quality gates — de mechanische scheidsrechters die alle drie de personas in toom houden.">
+<NextSteps title="Next step" lede="Now that you can see the pipeline skeleton, in part 3 we dive into the quality gates — the mechanical referees that keep all three personas in line.">
   <NextStep
-    title="Deel 3 — Quality gates"
+    title="Part 3 — Quality gates"
     href="/academy/hydra-tutorial-3-quality-gates"
-    description="Wat zijn de gates? Waarom mechanisch en niet AI-geoordeeld? Wat doe je als een gate fout positief slaat?"
+    description="What are the gates? Why mechanical and not AI-judged? What do you do when a gate fires a false positive?"
   />
   <NextStep
-    title="Vorige stap — Wat is Hydra?"
+    title="Previous step — What is Hydra?"
     href="/academy/hydra-tutorial-1-wat-is-hydra"
-    description="Korte herhaling van het waarom en de vier personas."
+    description="A short recap of the why and the four personas."
   />
   <NextStep
-    title="De pipeline-architectuur in detail"
+    title="The pipeline architecture in detail"
     href="https://github.com/ConductionNL/hydra/blob/main/docs/pipeline-overview.md"
-    description="De volledige pipeline-overview-doc, met alle subtiliteiten over rate-limit fallback, sloten en cron-schedule."
+    description="The full pipeline overview doc, with all the subtleties about rate-limit fallback, locks and cron schedule."
   />
 </NextSteps>

--- a/academy/2026-05-12-hydra-tutorial-2-drie-pipelines/index.mdx
+++ b/academy/2026-05-12-hydra-tutorial-2-drie-pipelines/index.mdx
@@ -139,7 +139,7 @@ Two human-triggered recovery labels that reach back into the pipeline. Both **si
 - **`retry:queued`** — the existing PR stays. Hydra builds an ephemeral `feedback.md` (in a `/tmp/hydra-retry-XXXXXX/` working directory, not committed) containing the `unfixed[]` findings + applier blockers, mounts it as `/workspace/feedback.md` in the builder container, and dispatches Al Gorithm in `HYDRA_MODE=fix` scoped to exactly the flagged files. Cheap. Suitable for: "the reviewers were right, builder just needs to touch up a few things".
 - **`rebuild:queued`** — existing PR closes, branch resets to `development`, all cycle labels removed, back to `build:queued`. Expensive. Suitable for: "Al Gorithm's approach was wrong, we're starting over with the same change".
 
-Rule of thumb: always go for the cheapest recovery first. First `gh pr update-branch <N>` (merge development → PR), then `retry:queued`, only then `rebuild:queued`. Part 6 goes into this in more depth.
+Rule of thumb: always go for the cheapest recovery first. First `gh pr update-branch <N>` (merge development → PR), then `retry:queued`, only then `rebuild:queued`. Part 6 goes into this in more depth — including the **label cleanup steps required before applying either trigger** (removing `needs-input` and fail labels first, otherwise the supervisor won't pick up the queue entry).
 
 ## Test yourself
 

--- a/academy/2026-05-12-hydra-tutorial-3-quality-gates/index.mdx
+++ b/academy/2026-05-12-hydra-tutorial-3-quality-gates/index.mdx
@@ -1,10 +1,10 @@
 ---
 slug: hydra-tutorial-3-quality-gates
-title: "Hydra leerlijn — Deel 3: Quality gates"
+title: "Hydra tutorial series — Part 3: Quality gates"
 contentType: tutorial
 authors: [conduction]
 date: 2026-05-12
-summary: Wat zijn de mechanische quality gates van Hydra, waarom werken ze juist NIET met AI-oordeel, en wat doe je als een gate per ongeluk fout slaat? Derde van zes korte modules.
+summary: What are Hydra's mechanical quality gates, why do they deliberately NOT rely on AI judgement, and what do you do when a gate misfires? The third of six short modules.
 tags: [Hydra, Gates, Quality, Tutorial series]
 apps: []
 durationMinutes: 12
@@ -15,132 +15,132 @@ partNumber: 3
 import {Outcomes, Outcome, Prerequisites, PrerequisiteItem, NextSteps, NextStep, HexCard} from '@conduction/docusaurus-preset/components';
 import Details from '@theme/Details';
 
-In deel 2 zag je dat de drie personas worden aangevuld door **mechanische quality gates** — checks die deterministisch slagen of falen, zonder AI in de loop. Dit deel legt uit welke gates we hebben, waarom ze mechanisch zijn, en hoe je omgaat met de uitzondering: de fout positief.
+In part 2 you saw that the three personas are backed up by **mechanical quality gates** — checks that pass or fail deterministically, without AI in the loop. This part explains which gates we have, why they are mechanical, and how to handle the exception: the false positive.
 
 {/* truncate */}
 
-<Outcomes title="Wat je leert in dit deel">
-  <Outcome>De twee soorten gates: <strong>generieke</strong> code-quality-tools en Hydra-specifieke <strong><code>hydra-gate-*</code></strong> skills.</Outcome>
-  <Outcome>Waarom mechanische checks naast AI-review hard nodig zijn (en niet "AI lost dat wel op").</Outcome>
-  <Outcome>Hoe je een fout-positieve gate herkent en wat de juiste fix is.</Outcome>
-  <Outcome>Wat ADR-020 betekent: <strong>gates draaien op de PR-diff.</strong></Outcome>
+<Outcomes title="What you'll learn in this part">
+  <Outcome>The two kinds of gates: <strong>generic</strong> code-quality tools and Hydra-specific <strong><code>hydra-gate-*</code></strong> skills.</Outcome>
+  <Outcome>Why mechanical checks alongside AI review are strictly necessary (and not "AI will sort that out").</Outcome>
+  <Outcome>How to recognise a false-positive gate and what the right fix is.</Outcome>
+  <Outcome>What ADR-020 means: <strong>gates run on the PR diff.</strong></Outcome>
 </Outcomes>
 
-<Prerequisites title="Wat je nodig hebt">
-  <PrerequisiteItem>Deel 1 en 2 doorgenomen: <a href="/academy/hydra-tutorial-1-wat-is-hydra">Wat is Hydra?</a> en <a href="/academy/hydra-tutorial-2-drie-pipelines">De drie pipelines</a>.</PrerequisiteItem>
-  <PrerequisiteItem>Basisbegrip van wat een linter is en wat een statische analyser is.</PrerequisiteItem>
+<Prerequisites title="What you need">
+  <PrerequisiteItem>Parts 1 and 2 read: <a href="/academy/hydra-tutorial-1-wat-is-hydra">What is Hydra?</a> and <a href="/academy/hydra-tutorial-2-drie-pipelines">The three pipelines</a>.</PrerequisiteItem>
+  <PrerequisiteItem>Basic understanding of what a linter is and what a static analyser is.</PrerequisiteItem>
 </Prerequisites>
 
-## Waarom mechanische gates?
+## Why mechanical gates?
 
-AI-review schaalt mee, maar is **niet voorspelbaar.** Twee runs op precies dezelfde diff kunnen verschillende bevindingen opleveren. En AI is juist niet sterk in het saaie nakijkwerk dat geen oordeel vraagt — bijvoorbeeld: "heeft elke nieuwe PHP-file bovenaan een SPDX-licentie-header staan?". Zo'n check kun je veel sneller en goedkoper met een simpel `grep`-commando doen.
+AI review scales, but it's **not predictable.** Two runs on exactly the same diff can produce different findings. And AI is especially weak at the boring checking that doesn't require judgement — for example: "does every new PHP file have an SPDX licence header at the top?". You can do that kind of check much faster and cheaper with a simple `grep` command.
 
-De stelregel binnen Hydra:
+The rule inside Hydra:
 
-> **Wat objectief te controleren is, doet een mechanische gate — één script dat per check slaagt of faalt. Pas waar je oordeel nodig hebt, schakelen we een reviewer in.**
+> **Whatever can be checked objectively, a mechanical gate handles — one script that passes or fails per check. Only where judgement is required do we bring in a reviewer.**
 
-Concreet betekent dat: voor we Juan Claude of Clyde duur Sonnet-tijd laten verspillen aan "deze functie heet `doSomething` en dat zou een werkwoord-zelfstandig-naamwoord-paar moeten zijn", draaien we eerst PHPCS. Pas daarna gaan de AI-paar-ogen aan het werk, en die concentreren zich op wat een tool níet kan vangen.
+Concretely: before we let Juan Claude or Clyde waste expensive Sonnet time on "this function is called `doSomething` and that should be a verb-noun pair", we run PHPCS first. Only then do the AI extra pairs of eyes start their work, focused on what a tool can't catch.
 
-## Categorie 1: generieke code-quality tools
+## Category 1: generic code-quality tools
 
-Deze checks draaien in `scripts/run-quality.sh` inside een Docker `php:X.Y-cli` container, met `--keep-server` om Nextcloud daarna voor de browser-tests te laten staan:
+These checks run inside `scripts/run-quality.sh` in a Docker `php:X.Y-cli` container, with `--keep-server` to leave Nextcloud running afterwards for the browser tests:
 
-| Tool | Wat het vangt |
+| Tool | What it catches |
 |---|---|
-| `lint` | Syntax-fouten in PHP. |
-| `phpcs` | Coding standard (PSR-12 + Nextcloud-conventie). |
-| `phpmd` | Code-mess detector (te lange methodes, te diepe nesting, dode code). |
-| `psalm` | Statische type-analyse, level 4 baseline. |
-| `phpstan` | Tweede statische type-analyser (vangt dingen die Psalm mist en vice versa). |
-| `phpmetrics` | Complexiteits-metriek (cyclomatic, maintainability-index). |
-| `composer audit` | CVE-check op `composer.lock`-dependencies. |
-| `eslint` | JS-/TS-lint. |
-| `stylelint` | CSS-/SCSS-lint. |
-| `npm audit` | CVE-check op `package-lock.json`. |
-| `PHPUnit` | Unit + integration tests met een gecontaineriseerd Nextcloud + SQLite. |
-| `Newman` | API-tests tegen de PHP built-in server. |
+| `lint` | Syntax errors in PHP. |
+| `phpcs` | Coding standard (PSR-12 + Nextcloud convention). |
+| `phpmd` | Code-mess detector (overlong methods, deep nesting, dead code). |
+| `psalm` | Static type analysis, level 4 baseline. |
+| `phpstan` | Second static type analyser (catches things Psalm misses and vice versa). |
+| `phpmetrics` | Complexity metrics (cyclomatic, maintainability index). |
+| `composer audit` | CVE check on `composer.lock` dependencies. |
+| `eslint` | JS/TS lint. |
+| `stylelint` | CSS/SCSS lint. |
+| `npm audit` | CVE check on `package-lock.json`. |
+| `PHPUnit` | Unit + integration tests with a containerised Nextcloud + SQLite. |
+| `Newman` | API tests against the PHP built-in server. |
 
-Iedere check is rood of groen. Eén rode check → `build:fail` (in de pre-review-fase) of `code-review:fail` / `security-review:fail` (post-fixes).
+Each check is red or green. One red check → `build:fail` (in the pre-review phase) or `code-review:fail` / `security-review:fail` (post-fixes).
 
-## Categorie 2: Hydra-specifieke gates
+## Category 2: Hydra-specific gates
 
-Naast de generieke tools heeft Hydra **een eigen reeks `hydra-gate-*` skills** voor zaken die Conduction-specifiek zijn. Die zitten in `hydra/.claude/skills/`. De huidige set telt 14 skills: één dispatcher die de andere 13 mechanische gates achter elkaar aanroept.
+On top of the generic tools, Hydra has **its own set of `hydra-gate-*` skills** for things that are Conduction-specific. They live in `hydra/.claude/skills/`. The current set is 14 skills: one dispatcher that calls the other 13 mechanical gates one after another.
 
-| Gate | Wat het controleert |
+| Gate | What it checks |
 |---|---|
-| `hydra-gates` | Dispatcher: roept de 13 gates hieronder achter elkaar aan en levert één pass/fail-overzicht. |
-| `hydra-gate-spdx` | Iedere nieuwe PHP-file heeft een EUPL-1.2 SPDX-header. |
-| `hydra-gate-forbidden-patterns` | Geen `dd(`, `var_dump`, `dump(`, `console.log` blijft over. |
-| `hydra-gate-composer-audit` | Mirror van de generieke composer-audit, voor de reviewer's mandatory block. |
-| `hydra-gate-stub-scan` | Geen lege stub-methods met TODO's blijven over. |
-| `hydra-gate-route-auth` | Iedere route in `appinfo/routes.php` heeft expliciete auth-annotaties. |
-| `hydra-gate-orphan-auth` | Geen `@AuthorizedAdminSetting` op een endpoint dat niet bestaat. |
-| `hydra-gate-unsafe-auth-resolver` | Auth resolvers slaan geen claim-bypass. |
-| `hydra-gate-semantic-auth` | Authorisatie-logica klopt semantisch met de route-doel. |
-| `hydra-gate-admin-router` | Admin-routes hebben de admin-router en niet de gewone. |
-| `hydra-gate-no-admin-idor` | Geen Insecure Direct Object Reference op admin-endpoints. |
-| `hydra-gate-modal-isolation` | Modal components isoleren state correct. |
-| `hydra-gate-nc-input-labels` | Nextcloud `<NcTextField>`-componenten hebben `<label>`-koppeling. |
-| `hydra-gate-initial-state` | Geen `initialState` lekt naar de client zonder bewuste expose. |
+| `hydra-gates` | Dispatcher: calls the 13 gates below one after another and produces one pass/fail summary. |
+| `hydra-gate-spdx` | Every new PHP file has an EUPL-1.2 SPDX header. |
+| `hydra-gate-forbidden-patterns` | No `dd(`, `var_dump`, `dump(`, `console.log` left behind. |
+| `hydra-gate-composer-audit` | Mirror of the generic composer audit, for the reviewer's mandatory block. |
+| `hydra-gate-stub-scan` | No empty stub methods with TODOs left behind. |
+| `hydra-gate-route-auth` | Every route in `appinfo/routes.php` has explicit auth annotations. |
+| `hydra-gate-orphan-auth` | No `@AuthorizedAdminSetting` on an endpoint that doesn't exist. |
+| `hydra-gate-unsafe-auth-resolver` | Auth resolvers don't allow a claim bypass. |
+| `hydra-gate-semantic-auth` | Authorisation logic matches the route's purpose semantically. |
+| `hydra-gate-admin-router` | Admin routes use the admin router and not the regular one. |
+| `hydra-gate-no-admin-idor` | No Insecure Direct Object Reference on admin endpoints. |
+| `hydra-gate-modal-isolation` | Modal components isolate state correctly. |
+| `hydra-gate-nc-input-labels` | Nextcloud `<NcTextField>` components have `<label>` linkage. |
+| `hydra-gate-initial-state` | No `initialState` leaks to the client without deliberate exposure. |
 
-Een groot deel hiervan is geboren uit incidenten: een gate ontstaat als reactie op een bug die door alle eerdere mazen heen glipte. `hydra-gate-stub-scan` bijvoorbeeld kwam uit het [`decidesk-44-45` retrospectief](https://github.com/ConductionNL/hydra/blob/main/docs/retrospectives/decidesk-44-45-phase-g.md), waar een builder een methode opleverde die slechts `return null;` deed met een TODO. PHPCS slikte het, PHPUnit had geen test, code review las het als "in scope", en het brak in productie.
+A large share of these were born out of incidents: a gate arises in response to a bug that slipped through all earlier checks. `hydra-gate-stub-scan`, for example, came out of the [`decidesk-44-45` retrospective](https://github.com/ConductionNL/hydra/blob/main/docs/retrospectives/decidesk-44-45-phase-g.md), where a builder delivered a method that just did `return null;` with a TODO. PHPCS swallowed it, PHPUnit had no test for it, code review read it as "in scope", and it broke in production.
 
-## ADR-020: gate-scope is de PR-diff
+## ADR-020: gate scope is the PR diff
 
-Een belangrijke regel die je in deel 2 al kort tegenkwam: **gates draaien op de PR-diff, niet op de hele repo**. Dat staat in [ADR-020](https://github.com/ConductionNL/hydra/blob/main/openspec/architecture/adr-020-gate-scope-to-pr-diff.md).
+An important rule you already brushed against in part 2: **gates run on the PR diff, not on the whole repo**. That's in [ADR-020](https://github.com/ConductionNL/hydra/blob/main/openspec/architecture/adr-020-gate-scope-to-pr-diff.md).
 
-Waarom? Omdat veel van onze repo's een achterstand aan technische schuld dragen. Als je `phpcs` op de hele repo loslaat krijg je honderden findings die niets met de huidige PR te maken hebben — en wordt elke PR rood. Door de scope te beperken tot de regels die in de PR-diff aangeraakt worden, valt de gate alleen om *wat de huidige builder net heeft toegevoegd of gewijzigd*.
+Why? Because many of our repos carry a backlog of technical debt. If you turn `phpcs` loose on the whole repo you get hundreds of findings that have nothing to do with the current PR — and every PR ends up red. By limiting the scope to the lines touched in the PR diff, the gate only fires on *what the current builder just added or changed*.
 
-Override-mechanisme: `HYDRA_REVIEW_SCOPE=full` in `secrets/.env` zet de scope om naar de hele repo. Gebruik dat als je een nieuwe repo onboardt of een dedicated tech-debt-sweep doet. Verwacht in alle andere gevallen veel rood.
+Override mechanism: `HYDRA_REVIEW_SCOPE=full` in `secrets/.env` flips the scope to the whole repo. Use it when you onboard a new repo or do a dedicated tech-debt sweep. Expect a lot of red in any other case.
 
-## Fout-positieven herkennen
+## Recognising false positives
 
-Mechanische gates zijn deterministisch, maar niet altijd correct. Een klassieker uit eigen huis: `hydra-gate-forbidden-patterns` zocht naar `dd(` zonder word-boundary, en sloeg dus ook foutief alarm op een legitieme `$builder->add(`. Eén grep-flag verkeerd en je hebt een herhaalbare fout-positief.
+Mechanical gates are deterministic, but not always correct. A homegrown classic: `hydra-gate-forbidden-patterns` searched for `dd(` without a word boundary and so falsely tripped on a legitimate `$builder->add(`. One wrong grep flag and you have a repeatable false positive.
 
-Hoe je een fout-positief herkent:
+How to recognise a false positive:
 
-1. **De gate slaat steeds op dezelfde regel** in elke retry, terwijl de regel zelf onschuldig oogt.
-2. **Een handmatige test van de gate-implementatie** (open `scripts/run-quality.sh` of de bijbehorende skill, run hem lokaal) bevestigt het: ja, het patroon matched, maar niet om de bedoelde reden.
-3. **Niemand in het team kan uitleggen waarom dit specifieke regel-niveau erover zou moeten klagen.**
+1. **The gate keeps firing on the same line** in every retry, while the line itself looks innocuous.
+2. **A manual test of the gate implementation** (open `scripts/run-quality.sh` or the associated skill, run it locally) confirms it: yes, the pattern matches, but not for the intended reason.
+3. **Nobody on the team can explain why this specific line should be complained about.**
 
-In dat geval is de fix **niet** "nog een retry". De fix is: ga naar `scripts/run-quality.sh` of de gate-skill, en repareer de detectie. Voorbeeld voor `hydra-gate-forbidden-patterns`: van `grep 'dd('` naar `grep -wE '(^|[^A-Za-z0-9_])dd\('`.
+In that case the fix is **not** "another retry". The fix is: go to `scripts/run-quality.sh` or the gate skill and repair the detection. Example for `hydra-gate-forbidden-patterns`: from `grep 'dd('` to `grep -wE '(^|[^A-Za-z0-9_])dd\('`.
 
-## Recheck na reviewer-fixes
+## Recheck after reviewer fixes
 
-Een subtiele maar belangrijke regel: na elke reviewer-fix-cyclus draait de orchestrator **opnieuw** de mechanische gates op de uiteindelijke PR-staat. Dit is de "quality-recheck"-fase. Reden: een reviewer kan tijdens zijn bounded-fix wel een PHPCS-style fout repareren en daarbij per ongeluk een nieuwe overtreding introduceren.
+A subtle but important rule: after every reviewer-fix cycle the orchestrator **reruns** the mechanical gates on the final PR state. This is the "quality recheck" phase. Reason: during their bounded fix, a reviewer can repair a PHPCS-style error and accidentally introduce a new violation.
 
-Slaat de recheck rood, dan gaat het issue naar `needs-input`. Geen retry. De reviewer is gestopt, de bouwer is gestopt, een mens kijkt.
+If the recheck goes red, the issue moves to `needs-input`. No retry. The reviewer has stopped, the builder has stopped, a human looks.
 
-<HexCard title="Let op: wanneer de retry-loop blijft hangen">
-  De recheck hierboven is je vangnet — maar dat vangnet kan zelf in een lus terechtkomen. Eén patroon om te herkennen:
+<HexCard title="Watch out: when the retry loop gets stuck">
+  The recheck above is your safety net — but that safety net can land in a loop of its own. One pattern to spot:
 
-  De builder vergeet in één file een gate-regel die hij in andere files wél correct toepast (in de praktijk meestal de <code>spdx-headers</code>-licentiekop). De reviewer pikt het niet op, omdat hij de file als "bestaande boilerplate" leest en eroverheen kijkt. De mechanische recheck slaat dan rood, het issue gaat terug naar de builder, en die maakt bij de retry exact dezelfde fout opnieuw. Hetzelfde gate-issue blijft zo terugkomen.
+  The builder forgets, in one file, a gate rule he applies correctly in other files (in practice usually the <code>spdx-headers</code> licence header). The reviewer doesn't pick it up, because he reads the file as "existing boilerplate" and skims past it. The mechanical recheck then goes red, the issue goes back to the builder, and on the retry he makes the exact same mistake again. The same gate issue keeps coming back.
 
-  **Wat te doen:** zie je 3 of meer retries op precies hetzelfde gate-issue, stop dan de loop. Twee opties — fix het handmatig, of scherp de gate-detectie aan zodat de reviewer hem niet meer als boilerplate kan wegklasseren. De volledige post-mortem van dit patroon (incidenten van 19–23 april 2026) staat in <a href="https://github.com/ConductionNL/hydra/blob/main/docs/retrospectives/decidesk-44-45-phase-g.md">decidesk-44-45-phase-g</a>.
+  **What to do:** if you see 3 or more retries on the exact same gate issue, stop the loop. Two options — fix it by hand, or tighten the gate detection so the reviewer can no longer dismiss it as boilerplate. The full post-mortem of this pattern (incidents from 19–23 April 2026) is in <a href="https://github.com/ConductionNL/hydra/blob/main/docs/retrospectives/decidesk-44-45-phase-g.md">decidesk-44-45-phase-g</a>.
 </HexCard>
 
-## Test jezelf
+## Test yourself
 
-Vier korte vragen om te checken of je dit deel begrepen hebt. Vastgelopen? Klik **Hint**. Curieus naar het antwoord? Klik **Antwoord**.
+Four short questions to check whether you've understood this part. Stuck? Click **Hint**. Curious about the answer? Click **Answer**.
 
 <div className="tutorial-quiz">
 
-**1. Waarom heeft Hydra mechanische gates *en* AI-reviewers, en niet alleen één van de twee?**
+**1. Why does Hydra have mechanical gates *and* AI reviewers, instead of just one of the two?**
 
 <Details summary="Hint">
 
-Eén soort check is voorspelbaar en goedkoop, de andere is duur maar kan oordelen. Wat is sterk en zwak aan elk?
+One kind of check is predictable and cheap, the other is expensive but can judge. What's the strength and weakness of each?
 
 </Details>
 
-<Details summary="Antwoord">
+<Details summary="Answer">
 
-Ze vullen elkaar precies aan op de plekken waar de ander zwak is.
+They complement each other exactly where the other is weak.
 
-- **Mechanische gates** zijn **deterministisch**: zelfde input → zelfde uitkomst, slagen of falen. Perfect voor saai, objectief nakijkwerk — bijvoorbeeld "heeft elke nieuwe PHP-file een SPDX-header?". Goedkoop en herhaalbaar.
-- **AI-reviewers** doen **oordeel**: "klopt deze authorization-logica semantisch met het route-doel", "is dit in deze context een veiligheidsrisico". Niet voorspelbaar en duurder, dus zet je ze in waar oordeel nodig is.
+- **Mechanical gates** are **deterministic**: same input → same outcome, pass or fail. Perfect for boring, objective checking — for example "does every new PHP file have an SPDX header?". Cheap and repeatable.
+- **AI reviewers** do **judgement**: "does this authorisation logic semantically match the route's purpose", "is this a security risk in this context". Not predictable and more expensive, so you deploy them where judgement is needed.
 
-Alleen-mechanisch mist context-afhankelijke fouten; alleen-AI is duur, niet voorspelbaar, en verspilt Sonnet-tijd aan dingen die een `grep` kan.
+Mechanical-only misses context-dependent errors; AI-only is expensive, not predictable, and wastes Sonnet time on things a `grep` can do.
 
 </Details>
 
@@ -148,25 +148,25 @@ Alleen-mechanisch mist context-afhankelijke fouten; alleen-AI is duur, niet voor
 
 <div className="tutorial-quiz">
 
-**2. Wat zegt ADR-020 over de gate-scope, en wanneer schakel je dat via `HYDRA_REVIEW_SCOPE=full` uit?**
+**2. What does ADR-020 say about gate scope, and when do you switch that off via `HYDRA_REVIEW_SCOPE=full`?**
 
 <Details summary="Hint">
 
-Denk aan wat er gebeurt als je `phpcs` op een repo met veel oude technische schuld loslaat. En wanneer wil je dat juist wél?
+Think about what happens when you turn `phpcs` loose on a repo with lots of old technical debt. And when do you actually want that?
 
 </Details>
 
-<Details summary="Antwoord">
+<Details summary="Answer">
 
-ADR-020 zegt: **gates draaien op de PR-diff, niet op de hele repo**.
+ADR-020 says: **gates run on the PR diff, not on the whole repo**.
 
-Reden: veel repo's slepen technische schuld mee. `phpcs` over alles geeft honderden findings die niets met de huidige PR te maken hebben — elke PR zou rood worden. Door alleen de geraakte regels te checken slaat de gate alleen om op wat de builder net heeft toegevoegd of gewijzigd.
+Reason: many repos drag along technical debt. `phpcs` across all of it produces hundreds of findings that have nothing to do with the current PR — every PR would be red. By only checking the touched lines, the gate only fires on what the builder just added or changed.
 
-**`HYDRA_REVIEW_SCOPE=full`** in `secrets/.env` schakelt dit uit — gates draaien dan op de hele repo. Gebruik bij:
-- **Onboarding van een nieuwe repo** in Hydra.
-- Een **dedicated tech-debt-sweep**.
+**`HYDRA_REVIEW_SCOPE=full`** in `secrets/.env` disables this — gates then run on the whole repo. Use for:
+- **Onboarding a new repo** into Hydra.
+- A **dedicated tech-debt sweep**.
 
-NIET voor reguliere PRs — verwacht veel rood.
+NOT for regular PRs — expect a lot of red.
 
 </Details>
 
@@ -174,25 +174,25 @@ NIET voor reguliere PRs — verwacht veel rood.
 
 <div className="tutorial-quiz">
 
-**3. Hoe herken je een fout-positieve gate, en wat is de juiste fix? Wat NIET?**
+**3. How do you recognise a false-positive gate, and what's the right fix? What is NOT?**
 
 <Details summary="Hint">
 
-Drie signalen samen wijzen op een fout-positief. En de "verleidelijke maar verkeerde" reflex is hetzelfde nóg een keer doen.
+Three signals together point at a false positive. And the "tempting but wrong" reflex is doing the same thing again.
 
 </Details>
 
-<Details summary="Antwoord">
+<Details summary="Answer">
 
-**Herkenning** — drie signalen samen:
+**Recognition** — three signals together:
 
-1. De gate slaat in elke retry op **dezelfde regel**, terwijl die regel onschuldig oogt.
-2. **Handmatig lokaal de gate runnen** bevestigt: het patroon matched, maar niet om de bedoelde reden (bijv. `grep 'dd('` matcht ook `$builder->add(`).
-3. Niemand in het team kan uitleggen waarom dit specifieke regel-niveau erover zou moeten klagen.
+1. The gate fires on the **same line** in every retry, while that line looks innocuous.
+2. **Running the gate locally by hand** confirms: the pattern matches, but not for the intended reason (e.g. `grep 'dd('` also matches `$builder->add(`).
+3. Nobody on the team can explain why this specific line should be complained about.
 
-**Juiste fix:** scherp de **gate-detectie** aan in `scripts/run-quality.sh` of de bijbehorende skill. Voorbeeld: `grep 'dd('` → `grep -wE '(^|[^A-Za-z0-9_])dd\('`.
+**Right fix:** tighten the **gate detection** in `scripts/run-quality.sh` or the associated skill. Example: `grep 'dd('` → `grep -wE '(^|[^A-Za-z0-9_])dd\('`.
 
-**NIET:** nog een keer `retry:queued`. Dat reproduceert hetzelfde fout-positief en verspilt cycles.
+**NOT:** another `retry:queued`. That reproduces the same false positive and wastes cycles.
 
 </Details>
 
@@ -200,38 +200,38 @@ Drie signalen samen wijzen op een fout-positief. En de "verleidelijke maar verke
 
 <div className="tutorial-quiz">
 
-**4. Waarom draait Hydra de mechanische gates nogmaals NA de reviewer-fixes (de "quality-recheck"-fase)?**
+**4. Why does Hydra rerun the mechanical gates AFTER the reviewer fixes (the "quality recheck" phase)?**
 
 <Details summary="Hint">
 
-De reviewers mogen binnen scope zelf fixen. Wat kan daarbij misgaan?
+The reviewers may fix within scope. What can go wrong while they do that?
 
 </Details>
 
-<Details summary="Antwoord">
+<Details summary="Answer">
 
-Reviewers (Juan + Clyde) mogen binnen scope mechanische fixes pushen (ADR-021). Daarbij kan een reviewer **per ongeluk een nieuwe overtreding introduceren** — bijvoorbeeld een PHPCS-style fix die elders een regel breekt.
+Reviewers (Juan + Clyde) may push mechanical fixes within scope (ADR-021). While doing so a reviewer can **accidentally introduce a new violation** — for instance a PHPCS-style fix that breaks a rule elsewhere.
 
-De **quality-recheck** draait alle mechanische gates opnieuw op de uiteindelijke PR-staat zodat zeker is dat wat er nu staat ook objectief schoon is. Slaat de recheck rood → `needs-input`, geen retry. De reviewer is gestopt, de bouwer is gestopt, een mens kijkt. Het is de laatste deterministische gate vóór er een menselijke beslissing valt.
+The **quality recheck** reruns all mechanical gates on the final PR state to make sure what's there now is also objectively clean. If the recheck goes red → `needs-input`, no retry. The reviewer has stopped, the builder has stopped, a human looks. It's the last deterministic gate before a human decision falls.
 
 </Details>
 
 </div>
 
-<NextSteps title="Volgende stap" lede="In deel 4 kijken we naar de skills en commands die de personas tijdens hun werk gebruiken — inclusief hoe je zelf een nieuwe skill kunt toevoegen.">
+<NextSteps title="Next step" lede="In part 4 we look at the skills and commands the personas use during their work — including how you can add a new skill yourself.">
   <NextStep
-    title="Deel 4 — Skills & commands"
+    title="Part 4 — Skills & commands"
     href="/academy/hydra-tutorial-4-skills"
-    description="Hoe passen <code>opsx-*</code>, <code>hydra-gate-*</code> en <code>team-*</code> skills in de loop. Wanneer schrijf je zelf een nieuwe."
+    description="How <code>opsx-*</code>, <code>hydra-gate-*</code> and <code>team-*</code> skills fit into the loop. When you write a new one yourself."
   />
   <NextStep
-    title="Vorige stap — De drie pipelines"
+    title="Previous step — The three pipelines"
     href="/academy/hydra-tutorial-2-drie-pipelines"
-    description="Korte herhaling van het label-state-machine."
+    description="A short recap of the label state machine."
   />
   <NextStep
     title="ADR-020 — gate scope = PR diff"
     href="https://github.com/ConductionNL/hydra/blob/main/openspec/architecture/adr-020-gate-scope-to-pr-diff.md"
-    description="De officiële motivatie achter de diff-only scope."
+    description="The official motivation behind the diff-only scope."
   />
 </NextSteps>

--- a/academy/2026-05-12-hydra-tutorial-4-skills/index.mdx
+++ b/academy/2026-05-12-hydra-tutorial-4-skills/index.mdx
@@ -1,10 +1,10 @@
 ---
 slug: hydra-tutorial-4-skills
-title: "Hydra leerlijn — Deel 4: Skills"
+title: "Hydra tutorial series — Part 4: Skills"
 contentType: tutorial
 authors: [conduction]
 date: 2026-05-12
-summary: Welke skills draaien in de automatische Hydra-fabriek, welke zijn er voor mensen op de CLI, hoe ze worden aangeroepen, en wanneer je zelf een skill aan de loop toevoegt. Vierde van zes korte modules.
+summary: Which skills run inside the automated Hydra factory, which exist for humans on the CLI, how they get invoked, and when you should add a new skill to the loop yourself. Fourth of six short modules.
 tags: [Hydra, Skills, OPSX, Testing, Tutorial series]
 apps: []
 durationMinutes: 14
@@ -15,231 +15,231 @@ partNumber: 4
 import {Outcomes, Outcome, Prerequisites, PrerequisiteItem, NextSteps, NextStep, HexCard} from '@conduction/docusaurus-preset/components';
 import Details from '@theme/Details';
 
-:::tip Niet bekend met Claude Skills in het algemeen?
-Dit deel duikt direct in de **Hydra-specifieke** skill-families. Wil je eerst weten wat een Claude Skill überhaupt is, hoe de frontmatter werkt, en wanneer je er zelf eentje schrijft? Doe dan de publieke [Claude Skills-leerlijn](/academy/claude-skills-tutorial-1-wat-zijn-claude-skills) (drie korte modules, ~40 minuten). Vanaf hier gaan we ervan uit dat je de basics kent.
+:::tip New to Claude Skills in general?
+This part dives straight into the **Hydra-specific** skill families. If you'd rather first learn what a Claude Skill even is, how the frontmatter works, and when you'd write one yourself, take the public [Claude Skills tutorial series](/academy/claude-skills-tutorial-1-wat-zijn-claude-skills) (three short modules, ~40 minutes). From here on we assume you know the basics.
 :::
 
-In de vorige delen ging het over *wat* Hydra doet. Dit deel gaat over *hoe*: de **skills** die de personas hun werk laten doen. Aan het eind weet je welke skills de automatische pipeline (de "Hydra-fabriek") draait en welke je als mens zelf aanroept, ken je de vijf families, en kun je inschatten wanneer een nieuwe skill de moeite waard is.
+The previous parts were about *what* Hydra does. This part is about *how*: the **skills** that let the personas do their job. By the end you'll know which skills the automated pipeline (the "Hydra factory") runs and which ones you call yourself as a human, you'll know the five families, and you'll be able to judge when a new skill is worth writing.
 
 {/* truncate */}
 
-<Outcomes title="Wat je leert in dit deel">
-  <Outcome>Wat een Claude-Code-skill is en hoe Hydra ze gebruikt om gedrag bij personas te bundelen.</Outcome>
-  <Outcome>Welke skills <strong>de automatische Hydra-fabriek</strong> in zijn Docker-containers heeft staan (per agent: Builder, Reviewer, Security) — en welke skills <strong>alleen voor mensen op de CLI</strong> zijn.</Outcome>
-  <Outcome>De vijf skill-families binnen Hydra: <code>{'opsx-*'}</code>, <code>{'hydra-gate-*'}</code>, <code>{'team-*'}</code>, <code>{'test-*'}</code>, en de utility/maintenance-skills.</Outcome>
-  <Outcome>De twee manieren waarop een skill geactiveerd kan worden — handmatig via <code>/{'<naam>'}</code> of automatisch door Claude — en hoe je dat per skill stuurt.</Outcome>
-  <Outcome>Wanneer je zelf een skill toevoegt en hoe je dat structureel doet.</Outcome>
+<Outcomes title="What you'll learn in this part">
+  <Outcome>What a Claude Code skill is and how Hydra uses them to bundle behaviour onto personas.</Outcome>
+  <Outcome>Which skills <strong>the automated Hydra factory</strong> ships inside its Docker containers (per agent: Builder, Reviewer, Security) — and which skills are <strong>only for humans on the CLI</strong>.</Outcome>
+  <Outcome>The five skill families inside Hydra: <code>{'opsx-*'}</code>, <code>{'hydra-gate-*'}</code>, <code>{'team-*'}</code>, <code>{'test-*'}</code>, and the utility/maintenance skills.</Outcome>
+  <Outcome>The two ways a skill can be activated — manually via <code>/{'<name>'}</code> or automatically by Claude — and how you control that per skill.</Outcome>
+  <Outcome>When to add a skill yourself and how to do that in a structured way.</Outcome>
 </Outcomes>
 
-<Prerequisites title="Wat je nodig hebt">
-  <PrerequisiteItem>Deel 1, 2 en 3 doorgenomen.</PrerequisiteItem>
-  <PrerequisiteItem>Een idee van wat <code>~/.claude/skills/</code> is op je eigen laptop, of in elk geval dat skills bestanden onder die naam zijn.</PrerequisiteItem>
+<Prerequisites title="What you need">
+  <PrerequisiteItem>Parts 1, 2 and 3 worked through.</PrerequisiteItem>
+  <PrerequisiteItem>An idea of what <code>~/.claude/skills/</code> is on your own laptop, or at least that skills are files under that name.</PrerequisiteItem>
 </Prerequisites>
 
-## Skills, in één alinea
+## Skills, in one paragraph
 
-Een **skill** in Claude Code is een mapje met een `SKILL.md` (en optioneel scripts, `examples/`, helpers). Het mapje hangt onder `.claude/skills/<naam>/`. De `description` in de frontmatter vertelt Claude wanneer de skill relevant is; de inhoud is de instructie die Claude volgt zodra de skill geladen wordt.
+A **skill** in Claude Code is a folder with a `SKILL.md` (and optionally scripts, `examples/`, helpers). The folder sits under `.claude/skills/<name>/`. The `description` in the frontmatter tells Claude when the skill is relevant; the contents are the instructions Claude follows once the skill is loaded.
 
-Voor Hydra zijn skills de **bundel-eenheid van gedrag**: in plaats van duizend regels prompt-tekst direct in een persona's `CLAUDE.md` te plakken, zit het in een skill, hergebruikbaar en testbaar.
+For Hydra, skills are the **bundling unit for behaviour**: instead of pasting a thousand lines of prompt text straight into a persona's `CLAUDE.md`, it lives in a skill — reusable and testable.
 
-## Hoe een skill wordt aangeroepen
+## How a skill gets invoked
 
-Eén skill kan op twee manieren in actie komen:
+A single skill can be triggered in two ways:
 
-1. **Handmatig** — je typt `/opsx-apply` in een Claude-sessie. Direct, voorspelbaar, en de skill draait precies wanneer jij dat wilt.
-2. **Automatisch** — Claude leest de `description` van alle beschikbare skills mee en kiest er zelf eentje wanneer de huidige situatie matcht. Vraag "wat is er veranderd?" en Claude triggert vanzelf een skill als `summarize-changes` als die voorhanden is.
+1. **Manually** — you type `/opsx-apply` in a Claude session. Direct, predictable, and the skill runs exactly when you want it to.
+2. **Automatically** — Claude reads the `description` of every available skill and picks one itself when the current situation matches. Ask "what changed?" and Claude will trigger a skill like `summarize-changes` on its own if one is available.
 
-Welke mode is toegestaan, regel je in de frontmatter van de skill zelf:
+Which mode is allowed is set in the skill's own frontmatter:
 
-- `disable-model-invocation: true` — alleen jij kunt 'm aanroepen via `/<naam>`. Gebruik dit voor skills met side-effects (`/opsx-apply` past code aan, `/create-pr` opent een PR). Claude mag dit niet zomaar uit zichzelf doen.
-- `user-invocable: false` — alleen Claude zelf mag 'm laden. Gebruik dit voor achtergrondkennis (bijvoorbeeld een `legacy-system-context` die niet als actie zinvol is).
-- Geen van beide gezet — beide mogen.
+- `disable-model-invocation: true` — only you can call it via `/<name>`. Use this for skills with side-effects (`/opsx-apply` modifies code, `/create-pr` opens a PR). Claude shouldn't just decide to do that on its own.
+- `user-invocable: false` — only Claude itself may load it. Use this for background knowledge (for example a `legacy-system-context` that doesn't make sense as an action).
+- Neither set — both are allowed.
 
-Dat onderscheid — handmatig vs. automatisch — gaat dus over **configuratie van één skill**, niet over twee verschillende soorten bestanden. Een persona in een Docker-container heeft geen toetsenbord en leunt vooral op auto-activatie; een mens op de CLI wil meestal expliciete controle en typt `/`.
+So that distinction — manual vs. automatic — is about **configuration of one skill**, not about two different kinds of files. A persona in a Docker container has no keyboard and leans heavily on auto-activation; a human on the CLI usually wants explicit control and types `/`.
 
-## Twee werelden: de Hydra-fabriek vs. skills voor mensen
+## Two worlds: the Hydra factory vs. skills for humans
 
-Hydra's `hydra/.claude/skills/` bevat ~70 skills, maar de **automatische pipeline gebruikt er maar een handvol**. De rest is gereedschap voor jou, achter een toetsenbord. Belangrijk om uit elkaar te houden:
+Hydra's `hydra/.claude/skills/` contains ~70 skills, but **the automated pipeline only uses a handful**. The rest is tooling for you, behind a keyboard. Important to keep separate:
 
-### Wat de Hydra-fabriek echt draait
+### What the Hydra factory actually runs
 
-Elke pipeline-container heeft een eigen, beperkte set skills in zijn Docker-image gebakken:
+Every pipeline container has its own, limited set of skills baked into its Docker image:
 
-| Container | Persona | Skills in image | Hoofdfunctie |
+| Container | Persona | Skills in image | Main function |
 |---|---|---|---|
-| **Builder** | Al Gorithm | **Alle** `.claude/skills/*` + alle vendor skills | Implementeert taken; primair `opsx-apply`. Heeft de overige opsx-skills bij de hand voor context bij verifiëren, hertrouw zoeken, fixen na quality-fail. |
-| **Reviewer** | Juan Claude | `hydra-gates` + 13 `hydra-gate-*` skills + vendor `code-review` | Mandatory hydra-gates check + diepere code-review via de Anthropic community-skill. |
-| **Security** | Clyde Barcode | `hydra-gates` + 13 `hydra-gate-*` skills + vendor `trailofbits` + vendor `owasp` | Mandatory hydra-gates + SAST (Semgrep) + OWASP-top-10-checklists. |
-| **Applier** | Axel Plier | **Geen skills** | Past kleine, deterministische fixes toe puur via zijn `CLAUDE.md` — geen skill-laag nodig. |
-| **Browser UI Tester** | (sonnet, headless) | Eén skill: `hydra-ui-test` | Logt in, navigeert de live app via Playwright MCP, levert verdict JSON. |
+| **Builder** | Al Gorithm | **All** `.claude/skills/*` + all vendor skills | Implements tasks; primarily `opsx-apply`. Has the other opsx skills on hand for context during verification, finding fits again, and fixing after a quality fail. |
+| **Reviewer** | Juan Claude | `hydra-gates` + 13 `hydra-gate-*` skills + vendor `code-review` | Mandatory hydra-gates check + deeper code review via the Anthropic community skill. |
+| **Security** | Clyde Barcode | `hydra-gates` + 13 `hydra-gate-*` skills + vendor `trailofbits` + vendor `owasp` | Mandatory hydra-gates + SAST (Semgrep) + OWASP top 10 checklists. |
+| **Applier** | Axel Plier | **No skills** | Applies small, deterministic fixes purely through its `CLAUDE.md` — no skill layer needed. |
+| **Browser UI Tester** | (sonnet, headless) | One skill: `hydra-ui-test` | Logs in, navigates the live app via Playwright MCP, delivers verdict JSON. |
 
-Daarnaast draait **`scripts/run-hydra-gates.sh`** in elke container alle **14** hydra-gates mechanisch — los van welke skill-files er in de image staan. De skill-files dienen voor Claude als documentatie bij een fix; het script doet de detectie.
+On top of that, **`scripts/run-hydra-gates.sh`** runs all **14** hydra-gates mechanically in every container — independent of which skill files are in the image. The skill files serve Claude as documentation when fixing; the script does the detection.
 
-### Wat de fabriek **niet** doet — voor mensen op de CLI
+### What the factory **doesn't** do — for humans on the CLI
 
-Alle andere skills (~50 van de 70) zijn voor jou, of voor een collega-dev in een Claude Code sessie op zijn laptop. Voorbeelden:
+All the other skills (~50 out of 70) are for you, or for a fellow dev in a Claude Code session on their laptop. Examples:
 
-- **Een change voorbereiden** — `opsx-new`, `opsx-ff`, `opsx-explore`, `opsx-plan-to-issues` doe je als mens vóór je het werk in de pipeline gooit. De Builder runt alleen `opsx-apply` op een al-bestaande change.
-- **Een role aannemen** — `team-architect`, `team-backend`, `team-po` enz. zijn pure roleplay-frames voor één-mens-één-rol sessies. De pipeline gebruikt ze niet.
-- **Testen draaien** — `/test-counsel` (alle 8 personas) of `/test-app` (één browser-sweep) start je met de hand. De fabriek heeft een eigen browser-tester (`hydra-ui-test`); de `test-*` familie staat los daarvan.
-- **PR's en dag-werk** — `/create-pr`, `/review-pr`, `/report-out` zijn de "drie keer per dag"-tools voor jou, niet voor de pipeline.
+- **Preparing a change** — `opsx-new`, `opsx-ff`, `opsx-explore`, `opsx-plan-to-issues` are things you do as a human before you throw the work into the pipeline. The Builder only runs `opsx-apply` on an existing change.
+- **Taking on a role** — `team-architect`, `team-backend`, `team-po` etc. are pure roleplay frames for one-human-one-role sessions. The pipeline doesn't use them.
+- **Running tests** — `/test-counsel` (all 8 personas) or `/test-app` (one browser sweep) you start by hand. The factory has its own browser tester (`hydra-ui-test`); the `test-*` family is separate from that.
+- **PRs and day-to-day work** — `/create-pr`, `/review-pr`, `/report-out` are the "three times a day" tools for you, not for the pipeline.
 
-Onthoud: **de fabriek pakt 5 skills, een mens kan tegen alle 70 aanroepen**. Dat is het hele verschil.
+Remember: **the factory grabs 5 skills, a human can call all 70**. That's the whole difference.
 
-## De vijf skill-families compleet
+## The five skill families in full
 
-Met die scheiding in het achterhoofd, hier zijn alle vijf families. Het tag-systeem in de tabel: **🤖 fabriek** = staat in een pipeline-container, **⌨️ mens** = alleen via CLI.
+With that split in mind, here are all five families. The tag system in the table: **🤖 factory** = ships inside a pipeline container, **⌨️ human** = CLI only.
 
-### Familie 1: OpenSpec workflow (`opsx-*`, 16 skills)
+### Family 1: OpenSpec workflow (`opsx-*`, 16 skills)
 
-De OPSX-skills implementeren de Conduction-workflow voor OpenSpec-changes — van proposal tot archief.
+The OPSX skills implement the Conduction workflow for OpenSpec changes — from proposal to archive.
 
-| Skill | Voor wie | Doet |
+| Skill | For whom | Does |
 |---|---|---|
-| `opsx-apply` | 🤖 Builder | Implementeert taken uit een change (de pipeline-default). |
-| `opsx-verify` | 🤖 Builder | Controleert dat de implementatie de change-artefacten dekt. |
-| `opsx-archive` | 🤖 Builder + ⌨️ | Archiveert een afgeronde change, syncing delta naar de spec. |
-| `opsx-new` | ⌨️ | Start een nieuwe change (proposal scaffold, schema-keuze). |
-| `opsx-ff` | ⌨️ | "Fast-forward": maakt change + alle artefacten in één pass. |
-| `opsx-continue` | ⌨️ | Pak een onderbroken change op. |
-| `opsx-explore` | ⌨️ | Verken pre-spec wat een change überhaupt zou moeten zijn. |
-| `opsx-onboard` | ⌨️ | Onboarding-flow op een nieuwe repo (zet OpenSpec config + structuur op). |
-| `opsx-plan-to-issues` | ⌨️ | Converteert `tasks.md` naar GitHub-issues + tracking-issue. |
-| `opsx-sync` | ⌨️ | Sync delta-specs terug naar de hoofdspec. |
-| `opsx-bulk-archive` | ⌨️ | Archiveer meerdere afgeronde changes in één keer. |
-| `opsx-apply-loop` | ⌨️ | Headless build → quality-fix lus voor lokale dev-runs. |
-| `opsx-pipeline` | ⌨️ | Parallel meerdere changes tegelijk laten lopen (multi-agent). |
-| `opsx-coverage-scan` | ⌨️ | Audit een legacy app op spec ↔ code coverage. |
-| `opsx-annotate` | ⌨️ | Past `@spec` PHPDoc-tags toe na een coverage-scan. |
-| `opsx-reverse-spec` | ⌨️ | Reverse-engineert een spec uit bestaande code. |
+| `opsx-apply` | 🤖 Builder | Implements tasks from a change (the pipeline default). |
+| `opsx-verify` | 🤖 Builder | Verifies that the implementation covers the change artefacts. |
+| `opsx-archive` | 🤖 Builder + ⌨️ | Archives a completed change, syncing delta into the spec. |
+| `opsx-new` | ⌨️ | Starts a new change (proposal scaffold, schema choice). |
+| `opsx-ff` | ⌨️ | "Fast-forward": creates a change + all artefacts in a single pass. |
+| `opsx-continue` | ⌨️ | Pick up an interrupted change. |
+| `opsx-explore` | ⌨️ | Explore pre-spec what a change should even be. |
+| `opsx-onboard` | ⌨️ | Onboarding flow on a new repo (sets up OpenSpec config + structure). |
+| `opsx-plan-to-issues` | ⌨️ | Converts `tasks.md` into GitHub issues + a tracking issue. |
+| `opsx-sync` | ⌨️ | Sync delta specs back into the main spec. |
+| `opsx-bulk-archive` | ⌨️ | Archive multiple completed changes in one go. |
+| `opsx-apply-loop` | ⌨️ | Headless build → quality-fix loop for local dev runs. |
+| `opsx-pipeline` | ⌨️ | Run multiple changes in parallel (multi-agent). |
+| `opsx-coverage-scan` | ⌨️ | Audit a legacy app for spec ↔ code coverage. |
+| `opsx-annotate` | ⌨️ | Applies `@spec` PHPDoc tags after a coverage scan. |
+| `opsx-reverse-spec` | ⌨️ | Reverse-engineers a spec from existing code. |
 
-### Familie 2: Quality + security gates (`hydra-gate-*`, 14 skills)
+### Family 2: Quality + security gates (`hydra-gate-*`, 14 skills)
 
-De parent-skill **`hydra-gates`** is een dispatcher die alle gates samen afroept. De script-engine onder de motorkap (`scripts/run-hydra-gates.sh`) draait alle 14 gates in elke container; de skill-files dienen Claude als referentie bij het fixen van een failure.
+The parent skill **`hydra-gates`** is a dispatcher that calls all gates together. The script engine under the hood (`scripts/run-hydra-gates.sh`) runs all 14 gates in every container; the skill files serve Claude as reference material when fixing a failure.
 
-| Gate-skill | Wat hij detecteert |
+| Gate skill | What it detects |
 |---|---|
-| `hydra-gates` (dispatcher) | Roept alle 14 gates achter elkaar aan, levert pass/fail-overzicht. |
-| `hydra-gate-spdx` | Ontbrekende `@license`/`@copyright`-headers op PHP/Vue-files. |
-| `hydra-gate-forbidden-patterns` | Debug-calls (`var_dump`, `console.log`), TODO's in productiecode, hardcoded secrets. |
-| `hydra-gate-stub-scan` | Stub-methods die `return null;` of niets doen — geen test, geen logica. |
-| `hydra-gate-composer-audit` | `composer audit` met kwetsbaarheden in afhankelijkheden. |
-| `hydra-gate-route-auth` | `routes.php` zonder auth-attribuut waar dat hoort. |
-| `hydra-gate-orphan-auth` | Auth-checks in methodes die nergens aangeroepen worden (verlaten). |
-| `hydra-gate-no-admin-idor` | `Application::APP_ID` ontbreekt bij admin-only methodes → IDOR-risico. |
-| `hydra-gate-unsafe-auth-resolver` | `catch(\Throwable) { return null; }` rond auth-logica. |
-| `hydra-gate-semantic-auth` | `#[NoAdminRequired]` op een methode die toch `requireAdmin()` aanroept. |
-| `hydra-gate-admin-router` | Admin-routes die niet via de admin-router lopen. |
-| `hydra-gate-initial-state` | Frontend `initialState` zonder serverside hydration. |
-| `hydra-gate-modal-isolation` | Vue-modals die buiten hun container teleporteren. |
-| `hydra-gate-nc-input-labels` | Nextcloud-input-components zonder gekoppeld label (a11y). |
+| `hydra-gates` (dispatcher) | Calls all 14 gates in sequence, delivers pass/fail summary. |
+| `hydra-gate-spdx` | Missing `@license`/`@copyright` headers on PHP/Vue files. |
+| `hydra-gate-forbidden-patterns` | Debug calls (`var_dump`, `console.log`), TODOs in production code, hardcoded secrets. |
+| `hydra-gate-stub-scan` | Stub methods that `return null;` or do nothing — no test, no logic. |
+| `hydra-gate-composer-audit` | `composer audit` with vulnerabilities in dependencies. |
+| `hydra-gate-route-auth` | `routes.php` without an auth attribute where one belongs. |
+| `hydra-gate-orphan-auth` | Auth checks in methods that are never called (orphaned). |
+| `hydra-gate-no-admin-idor` | `Application::APP_ID` missing on admin-only methods → IDOR risk. |
+| `hydra-gate-unsafe-auth-resolver` | `catch(\Throwable) { return null; }` around auth logic. |
+| `hydra-gate-semantic-auth` | `#[NoAdminRequired]` on a method that still calls `requireAdmin()`. |
+| `hydra-gate-admin-router` | Admin routes that don't go through the admin router. |
+| `hydra-gate-initial-state` | Frontend `initialState` without serverside hydration. |
+| `hydra-gate-modal-isolation` | Vue modals that teleport outside their container. |
+| `hydra-gate-nc-input-labels` | Nextcloud input components without an attached label (a11y). |
 
-Alle 14 draaien **🤖 in de Hydra-fabriek** (Reviewer + Security containers; Builder voert ze óók uit als post-flight check tijdens fix-quality).
+All 14 run **🤖 inside the Hydra factory** (Reviewer + Security containers; Builder also runs them as a post-flight check during fix-quality).
 
-### Familie 3: Team-rollen (`team-*`, 7 skills) — **alleen ⌨️ voor mensen**
+### Family 3: Team roles (`team-*`, 7 skills) — **⌨️ humans only**
 
-Skills die een specifiek soort werk modelleren via een persona-frame. Bedoeld voor een mens die naast Hydra in een terminal werkt en even één rol wil invullen.
+Skills that model a specific kind of work via a persona frame. Intended for a human working in a terminal alongside Hydra who wants to step into a single role for a bit.
 
-- `team-po` (Product Owner) — schrijft user stories en acceptatiecriteria.
-- `team-sm` (Scrum Master) — beheert backlog en sprint-planning artefacten.
-- `team-architect` — neemt architectuurbeslissingen, schrijft ADR-drafts.
-- `team-backend` — implementeert backend-werk (PHP, services, mappers).
-- `team-frontend` — implementeert frontend-werk (Vue 2, Pinia, NL Design System).
-- `team-reviewer` — een handmatige variant van het reviewer-werk.
-- `team-qa` — schrijft testcases en testplannen.
+- `team-po` (Product Owner) — writes user stories and acceptance criteria.
+- `team-sm` (Scrum Master) — manages backlog and sprint planning artefacts.
+- `team-architect` — makes architecture decisions, writes ADR drafts.
+- `team-backend` — implements backend work (PHP, services, mappers).
+- `team-frontend` — implements frontend work (Vue 2, Pinia, NL Design System).
+- `team-reviewer` — a manual variant of the reviewer work.
+- `team-qa` — writes test cases and test plans.
 
-Geen van deze staat in een pipeline-container — ze hebben geen plek in de automatische loop.
+None of these ship in a pipeline container — they have no place in the automated loop.
 
-### Familie 4: Test-suites (`test-*`, 19 skills) — bijna allemaal ⌨️ voor mensen
+### Family 4: Test suites (`test-*`, 19 skills) — almost all ⌨️ for humans
 
-De grootste familie qua aantal: rond de twintig skills die agentic browser- en API-testen drijven, in drie clusters:
+The largest family by count: around twenty skills that drive agentic browser and API testing, in three clusters:
 
-**Test-types** (één per test-soort):
-- `test-app` — automatische browsertest van een hele Nextcloud-app (Playwright MCP).
-- `test-functional` — functionele scenario's tegen geïmplementeerde features.
-- `test-api` — API-checks tegen de PHP built-in server.
-- `test-accessibility`, `test-performance`, `test-security`, `test-regression` — gespecialiseerde varianten.
+**Test types** (one per test kind):
+- `test-app` — automated browser test of a whole Nextcloud app (Playwright MCP).
+- `test-functional` — functional scenarios against implemented features.
+- `test-api` — API checks against the PHP built-in server.
+- `test-accessibility`, `test-performance`, `test-security`, `test-regression` — specialised variants.
 
-**Personas** (`test-persona-*`) — acht Nederlandse gebruikersprofielen die elk een eigen blik op een app werpen: `annemarie`, `fatima`, `henk`, `janwillem`, `mark`, `noor`, `priya`, `sem`. Henk leest met grote letters en zoekt eenvoudige navigatie; Noor hamert op RBAC en audit-trails; Annemarie controleert NLGov/GEMMA-mapping. De persona-cards zelf liggen in [`hydra/personas/`](https://github.com/ConductionNL/hydra/tree/main/personas).
+**Personas** (`test-persona-*`) — eight Dutch user profiles, each looking at an app from their own angle: `annemarie`, `fatima`, `henk`, `janwillem`, `mark`, `noor`, `priya`, `sem`. Henk reads with large type and looks for simple navigation; Noor hammers on RBAC and audit trails; Annemarie checks NLGov/GEMMA mapping. The persona cards themselves live in [`hydra/personas/`](https://github.com/ConductionNL/hydra/tree/main/personas).
 
-**Scenario-management** — `test-scenario-create`, `test-scenario-edit`, `test-scenario-run` schrijven, bewerken en draaien herbruikbare `TS-NNN-*.md` scenario's per app.
+**Scenario management** — `test-scenario-create`, `test-scenario-edit`, `test-scenario-run` write, edit and run reusable `TS-NNN-*.md` scenarios per app.
 
-De dispatcher van deze familie is **`test-counsel`**: hij coördineert alle acht personas tegen één feature en levert een gecombineerd rapport. Zelfde patroon als `hydra-gates` voor de quality-gates familie.
+The dispatcher for this family is **`test-counsel`**: it coordinates all eight personas against one feature and delivers a combined report. Same pattern as `hydra-gates` for the quality-gates family.
 
-:::note Geen overlap met de fabriek's browser-tester
-De Hydra-fabriek heeft een **eigen** browser-tester (`hydra-ui-test`) die in de Browser UI Tester-stap draait. Die staat **los** van deze `test-*` familie. De `test-*` skills zijn voor wanneer jij — als mens — een feature wilt testen voordat of nadat de pipeline 'm heeft aangeraakt. Gates uit deel 3 draaien statische checks (regex/AST); `test-*` draait de echte applicatie in een browser.
+:::note No overlap with the factory's browser tester
+The Hydra factory has its **own** browser tester (`hydra-ui-test`) that runs in the Browser UI Tester step. That stands **apart** from this `test-*` family. The `test-*` skills are for when you — as a human — want to test a feature before or after the pipeline has touched it. Gates from part 3 run static checks (regex/AST); `test-*` runs the actual application in a browser.
 :::
 
-### Familie 5: Utility & maintenance (~13 skills) — vrijwel allemaal ⌨️ voor mensen
+### Family 5: Utility & maintenance (~13 skills) — almost all ⌨️ for humans
 
-De rest, dat is de overige ~13 skills. Vooral dev-comfort en meta-werk:
+The rest — those are the remaining ~13 skills. Mostly dev comfort and meta work:
 
-| Skill | Doet |
+| Skill | Does |
 |---|---|
-| `create-pr` | Maakt een PR vanuit een feature-branch — local checks → branch pick → PR-tekst. |
-| `review-pr` | Reviewt een GitHub PR (NB: handmatige variant; de fabriek heeft zijn eigen Juan Claude). |
-| `report-out` | End-of-day rapport: vandaag's commits + GitHub-activiteit → Nederlandse Slack-melding. |
-| `clean-env` | Reset de lokale Docker-dev-omgeving volledig. |
-| `local-run` | Lokale Nextcloud-dev-omgeving opstarten. |
-| `sync-docs` | Sync `{app}/docs/` of `.github/docs/claude/` met de werkelijkheid in de repo. |
-| `skill-creator` | Wizard voor het maken van een nieuwe skill (scaffold, frontmatter, evals). |
-| `feature-counsel` | Pre-build spec-analyse vanuit acht persona-perspectieven (zusje van `test-counsel`). |
-| `persistence-audit` | Audit hoe een app omgaat met data-persistence (objectstore, sessies, etc.). |
-| `journeydoc-init` / `journeydoc-add-story` / `journeydoc-instrument` | Handmatige instrumentatie + uitbreiding van Journey-docs. |
-| `verify-global-settings-version` | Check of `global-settings/VERSION` is opgehoogd na een wijziging. |
+| `create-pr` | Creates a PR from a feature branch — local checks → branch pick → PR body. |
+| `review-pr` | Reviews a GitHub PR (note: manual variant; the factory has its own Juan Claude). |
+| `report-out` | End-of-day report: today's commits + GitHub activity → Dutch Slack notification. |
+| `clean-env` | Fully resets the local Docker dev environment. |
+| `local-run` | Bring up the local Nextcloud dev environment. |
+| `sync-docs` | Sync `{app}/docs/` or `.github/docs/claude/` with reality in the repo. |
+| `skill-creator` | Wizard for building a new skill (scaffold, frontmatter, evals). |
+| `feature-counsel` | Pre-build spec analysis from eight persona perspectives (sibling of `test-counsel`). |
+| `persistence-audit` | Audit how an app handles data persistence (object store, sessions, etc.). |
+| `journeydoc-init` / `journeydoc-add-story` / `journeydoc-instrument` | Manual instrumentation + extension of Journey docs. |
+| `verify-global-settings-version` | Check whether `global-settings/VERSION` was bumped after a change. |
 
-Niets uit deze familie draait in de pipeline. Het zijn jouw dagelijkse `/`-commando's.
+Nothing in this family runs in the pipeline. They are your daily `/` commands.
 
 ## Vendor skills (community)
 
-Naast de eigen skills heeft Hydra **vendor skills** onder `hydra/vendor/skills/`:
+Next to its own skills, Hydra has **vendor skills** under `hydra/vendor/skills/`:
 
-- `code-review` — communautaire review-skill van Anthropic. → 🤖 Reviewer container.
-- `trailofbits` — Semgrep-based static-analysis methodologie van Trail of Bits. → 🤖 Security container.
-- `owasp` — OWASP-top-10:2025 + ASVS 5.0-checklists. → 🤖 Security container.
+- `code-review` — community review skill from Anthropic. → 🤖 Reviewer container.
+- `trailofbits` — Semgrep-based static-analysis methodology from Trail of Bits. → 🤖 Security container.
+- `owasp` — OWASP top 10:2025 + ASVS 5.0 checklists. → 🤖 Security container.
 
-Die drie zitten dus **wél** in de fabriek (containers). Ze worden bij Juan en Clyde geladen voor extra dekking boven op de eigen `hydra-gate-*`. Onderhoud ligt bij externe partijen — updaten gaat door de bron te volgen, niet door zelf te editen.
+So those three **do** ship inside the factory (containers). They get loaded onto Juan and Clyde for extra coverage on top of our own `hydra-gate-*`. Maintenance sits with external parties — updates happen by tracking upstream, not by editing them yourself.
 
-## Wanneer schrijf je een nieuwe skill?
+## When do you write a new skill?
 
-De pragmatische test: schrijf een skill als…
+The pragmatic test: write a skill if…
 
-1. **De check / het gedrag is herhaalbaar** — meer dan eens nodig, op meer dan één plek.
-2. **Het is mechanisch beschrijfbaar** — je kunt het in 1-3 alinea's instrueren, zonder dat het ontaardt in "het hangt van de context af".
-3. **Een persona of een mens zou er baat bij hebben.** Geen skill schrijven omdat het kan.
+1. **The check / behaviour is repeatable** — needed more than once, in more than one place.
+2. **It's mechanically describable** — you can instruct it in 1-3 paragraphs without it devolving into "it depends on the context".
+3. **A persona or a human would benefit from it.** Don't write a skill because you can.
 
-Voor een fout-positieve gate (deel 3): je past de bestaande skill aan, je schrijft geen nieuwe. Voor een nieuw klasse-fout dat je 3x ziet langskomen: ja, daar verdient het een eigen `hydra-gate-*` skill.
+For a false-positive gate (part 3): you adjust the existing skill, you don't write a new one. For a new class of mistake that you see come by 3x: yes, that earns its own `hydra-gate-*` skill.
 
-<HexCard title="Tip: gebruik /skill-creator">
-  Hydra heeft een ingebouwde <code>/skill-creator</code> skill die je door het maken van een nieuwe skill leidt: scaffold, frontmatter, eval-harness, performance-meting. Roep hem aan vanuit een Claude-sessie in de hydra-repo om met de juiste structuur te starten in plaats van zelf een mapje op te bouwen. Een uitgewerkte walkthrough vind je in <a href="/academy/claude-skills-tutorial-2-je-eerste-skill">deel 2 van de Claude Skills-leerlijn</a>; meten en evalueren wordt behandeld in <a href="/academy/claude-skills-tutorial-3-skill-evals">deel 3</a>.
+<HexCard title="Tip: use /skill-creator">
+  Hydra has a built-in <code>/skill-creator</code> skill that walks you through creating a new skill: scaffold, frontmatter, eval harness, performance measurement. Call it from a Claude session in the hydra repo to start with the right structure instead of building a folder yourself. A full walkthrough lives in <a href="/academy/claude-skills-tutorial-2-je-eerste-skill">part 2 of the Claude Skills tutorial series</a>; measuring and evaluating is covered in <a href="/academy/claude-skills-tutorial-3-skill-evals">part 3</a>.
 </HexCard>
 
-## Test jezelf
+## Test yourself
 
-Vier korte vragen om te checken of je dit deel begrepen hebt. Vastgelopen? Klik **Hint**. Curieus naar het antwoord? Klik **Antwoord**.
+Four short questions to check whether you've grasped this part. Stuck? Click **Hint**. Curious about the answer? Click **Answer**.
 
 <div className="tutorial-quiz">
 
-**1. Wat zijn de twee manieren waarop een skill kan worden geactiveerd, en hoe stuur je dat per skill?**
+**1. What are the two ways a skill can be activated, and how do you control that per skill?**
 
 <Details summary="Hint">
 
-Eén manier vergt dat een mens iets typt. De andere laat Claude zelf beslissen op basis van de skill-omschrijving. Welke frontmatter-velden bepalen welke mode mag?
+One way requires a human to type something. The other lets Claude decide for itself based on the skill description. Which frontmatter fields determine which mode is allowed?
 
 </Details>
 
-<Details summary="Antwoord">
+<Details summary="Answer">
 
-- **Handmatig**: jij typt `/<naam>` in een Claude-sessie. Direct, voorspelbaar.
-- **Automatisch**: Claude leest de `description` van alle skills mee en kiest er zelf eentje wanneer de huidige conversatie matcht.
+- **Manual**: you type `/<name>` in a Claude session. Direct, predictable.
+- **Automatic**: Claude reads the `description` of all skills and picks one itself when the current conversation matches.
 
-In de frontmatter van een skill zet je:
+In the skill's frontmatter you set:
 
-- `disable-model-invocation: true` — alleen handmatig. Gebruikt voor skills met side-effects (`/opsx-apply`, `/create-pr`).
-- `user-invocable: false` — alleen automatisch. Gebruikt voor achtergrondkennis die niet als actie zinvol is.
-- Beide leeg → beide mogen. Default voor de meeste Hydra-skills.
+- `disable-model-invocation: true` — manual only. Used for skills with side-effects (`/opsx-apply`, `/create-pr`).
+- `user-invocable: false` — automatic only. Used for background knowledge that isn't useful as an action.
+- Both empty → both allowed. The default for most Hydra skills.
 
-In de Hydra-pipeline gebruiken de containers vooral auto-activatie (Claude pikt zelf de juiste skill op); een mens op de CLI typt meestal expliciet `/`.
+In the Hydra pipeline the containers mostly use auto-activation (Claude picks the right skill itself); a human on the CLI typically types `/` explicitly.
 
 </Details>
 
@@ -247,34 +247,34 @@ In de Hydra-pipeline gebruiken de containers vooral auto-activatie (Claude pikt 
 
 <div className="tutorial-quiz">
 
-**2. Welke skills draaien er nou écht in de pipeline-containers, en welke staan alleen in de repo voor mensen?**
+**2. Which skills actually run inside the pipeline containers, and which ones sit in the repo only for humans?**
 
 <Details summary="Hint">
 
-Drie containers (Builder, Reviewer, Security) hebben elk een specifieke set in hun image. Wat zit erin — en welke families staan er volledig buiten?
+Three containers (Builder, Reviewer, Security) each have a specific set in their image. What's inside — and which families sit entirely outside?
 
 </Details>
 
-<Details summary="Antwoord">
+<Details summary="Answer">
 
-**In de pipeline-containers** (🤖 fabriek):
+**Inside the pipeline containers** (🤖 factory):
 
-- **Builder** — alle `.claude/skills/*` ingebakken, maar de standaard-run is `opsx-apply`. De andere opsx-skills zijn er voor context.
-- **Reviewer** — `hydra-gates` + 13 individuele `hydra-gate-*` + vendor `code-review`.
-- **Security** — `hydra-gates` + 13 individuele `hydra-gate-*` + vendor `trailofbits` + vendor `owasp`.
-- **Applier** — géén skills (puur CLAUDE.md).
-- **Browser UI Tester** — alleen `hydra-ui-test`.
+- **Builder** — all `.claude/skills/*` baked in, but the standard run is `opsx-apply`. The other opsx skills are there for context.
+- **Reviewer** — `hydra-gates` + 13 individual `hydra-gate-*` + vendor `code-review`.
+- **Security** — `hydra-gates` + 13 individual `hydra-gate-*` + vendor `trailofbits` + vendor `owasp`.
+- **Applier** — no skills (pure CLAUDE.md).
+- **Browser UI Tester** — only `hydra-ui-test`.
 
-Plus: `scripts/run-hydra-gates.sh` draait alle **14** gates mechanisch in elke container, ongeacht welke skill-files in de image staan.
+Plus: `scripts/run-hydra-gates.sh` runs all **14** gates mechanically in every container, regardless of which skill files are in the image.
 
-**Niet in de fabriek**, alleen voor mensen op de CLI:
+**Not in the factory**, only for humans on the CLI:
 
-- Vrijwel de hele `team-*` familie (7 skills).
-- Vrijwel de hele `test-*` familie (19 skills) — de fabriek heeft zijn eigen `hydra-ui-test`.
-- De meeste `opsx-*` skills behalve `opsx-apply`/`verify`/`archive` (humans starten changes; de pipeline implementeert ze).
-- De hele utility-familie (`create-pr`, `review-pr`, `report-out`, `clean-env`, `sync-docs`, `skill-creator`, `feature-counsel`, `persistence-audit`, `journeydoc-*`, `verify-global-settings-version`).
+- Almost the entire `team-*` family (7 skills).
+- Almost the entire `test-*` family (19 skills) — the factory has its own `hydra-ui-test`.
+- Most `opsx-*` skills except `opsx-apply`/`verify`/`archive` (humans start changes; the pipeline implements them).
+- The whole utility family (`create-pr`, `review-pr`, `report-out`, `clean-env`, `sync-docs`, `skill-creator`, `feature-counsel`, `persistence-audit`, `journeydoc-*`, `verify-global-settings-version`).
 
-In totaal: van ~70 skills in de repo gebruikt de automatische pipeline er een handvol; de rest is jouw gereedschap.
+In total: of ~70 skills in the repo, the automated pipeline uses a handful; the rest is your toolkit.
 
 </Details>
 
@@ -282,20 +282,20 @@ In totaal: van ~70 skills in de repo gebruikt de automatische pipeline er een ha
 
 <div className="tutorial-quiz">
 
-**3. Wanneer pas je een bestaande gate-skill aan en wanneer schrijf je een nieuwe?**
+**3. When do you adjust an existing gate skill and when do you write a new one?**
 
 <Details summary="Hint">
 
-Eén beslissing gaat over "de gate doet niet wat we al wilden". De ander over "we hebben een nieuwe categorie fout ontdekt".
+One decision is about "the gate doesn't do what we already wanted it to do". The other is about "we've discovered a new category of mistake".
 
 </Details>
 
-<Details summary="Antwoord">
+<Details summary="Answer">
 
-- **Bestaande aanpassen** bij een **fout-positief**: de gate triggert te breed of te smal op iets dat al bedoeld werd te checken. Voorbeeld: `hydra-gate-forbidden-patterns` matchte `$builder->add(` ten onrechte — je past de regex aan, je voegt geen tweede gate toe.
-- **Nieuwe schrijven** voor een **nieuw klasse-fout** dat je 3× ziet langskomen en dat door alle bestaande mazen heen glipt. Voorbeeld: `hydra-gate-stub-scan` ontstond toen een builder een `return null;`-methode oplevert die PHPCS slikte en geen test had — dat was een nieuwe categorie, niet een fix op een bestaande check.
+- **Adjust existing** for a **false positive**: the gate triggers too broadly or too narrowly on something it was already meant to check. Example: `hydra-gate-forbidden-patterns` matched `$builder->add(` incorrectly — you tighten the regex, you don't add a second gate.
+- **Write new** for a **new class of mistake** that you see come by 3× and that slips through all existing meshes. Example: `hydra-gate-stub-scan` was born when a builder shipped a `return null;` method that PHPCS swallowed and had no test — that was a new category, not a fix on an existing check.
 
-Rule of three: één keer is toeval, twee keer toeval, drie keer is een patroon dat een eigen gate verdient.
+Rule of three: once is chance, twice is coincidence, three times is a pattern that deserves its own gate.
 
 </Details>
 
@@ -303,50 +303,50 @@ Rule of three: één keer is toeval, twee keer toeval, drie keer is een patroon 
 
 <div className="tutorial-quiz">
 
-**4. Wat doen de "vendor skills" en waarom houden we die apart van onze eigen `hydra-gate-*`?**
+**4. What do the "vendor skills" do and why do we keep them separate from our own `hydra-gate-*`?**
 
 <Details summary="Hint">
 
-Denk aan herkomst (wie heeft ze geschreven?), bij welke pipeline-container ze worden ingeladen, en wat er gebeurt als je een externe partij hun werk moet updaten.
+Think about provenance (who wrote them?), which pipeline container they get loaded into, and what happens when you need an external party to update their work.
 
 </Details>
 
-<Details summary="Antwoord">
+<Details summary="Answer">
 
-Vendor-skills (`hydra/vendor/skills/`) zijn skills die **niet door ons** zijn geschreven, en zitten **wél** in de fabriek:
+Vendor skills (`hydra/vendor/skills/`) are skills that were **not written by us**, and that **do** ship inside the factory:
 
-- `code-review` (Anthropic-community) → Reviewer-container (Juan Claude).
-- `trailofbits` (Trail of Bits, Semgrep-methodologie) → Security-container (Clyde).
-- `owasp` (OWASP-top-10:2025 + ASVS 5.0) → Security-container.
+- `code-review` (Anthropic community) → Reviewer container (Juan Claude).
+- `trailofbits` (Trail of Bits, Semgrep methodology) → Security container (Clyde).
+- `owasp` (OWASP top 10:2025 + ASVS 5.0) → Security container.
 
-Apart houden omdat:
+We keep them separate because:
 
-- **Onderhoud** ligt bij externe partijen — we updaten ze door de bron te volgen (zie `vendor/skills/VERSIONS.md`), niet door zelf te editen. Onze eigen gates muteren we vrij; vendor-skills laten we met rust.
-- **Audit-spoor** blijft duidelijk: wat is van ons vs. wat is community/extern? Bij een failure weet je meteen welk kamp verantwoordelijk is voor de fix.
+- **Maintenance** sits with external parties — we update them by tracking upstream (see `vendor/skills/VERSIONS.md`), not by editing them ourselves. Our own gates we mutate freely; vendor skills we leave alone.
+- **Audit trail** stays clear: what's ours vs. what's community/external? On a failure you immediately know which camp is responsible for the fix.
 
 </Details>
 
 </div>
 
-<NextSteps title="Volgende stap" lede="In deel 5 gaan we praktisch worden: een echte Hydra-run starten op een echte app, inclusief de label-prefix-truc voor parallelle dev-runs.">
+<NextSteps title="Next step" lede="In part 5 we get practical: starting a real Hydra run on a real app, including the label-prefix trick for parallel dev runs.">
   <NextStep
-    title="Deel 5 — Een Hydra-run starten op een echte app"
+    title="Part 5 — Starting a Hydra run on a real app"
     href="/academy/hydra-tutorial-5-een-hydra-run-starten"
-    description="Het hele recept: van issue openen tot PR groen krijgen. Met de juiste config in <code>secrets/.env</code> en de <code>HYDRA_LABEL_PREFIX</code>-truc voor wie naast collega-devs werkt."
+    description="The full recipe: from opening an issue to getting the PR green. With the right config in <code>secrets/.env</code> and the <code>HYDRA_LABEL_PREFIX</code> trick for anyone working alongside fellow devs."
   />
   <NextStep
-    title="Vorige stap — Quality gates"
+    title="Previous step — Quality gates"
     href="/academy/hydra-tutorial-3-quality-gates"
-    description="De mechanische scheidsrechters die deze skills aanvullen."
+    description="The mechanical referees that these skills complement."
   />
   <NextStep
     title="Skills directory"
     href="https://github.com/ConductionNL/hydra/tree/main/.claude/skills"
-    description="Browse de volledige lijst skills in de hydra-repo."
+    description="Browse the full list of skills in the hydra repo."
   />
   <NextStep
-    title="Claude Skills-leerlijn (publiek)"
+    title="Claude Skills tutorial series (public)"
     href="/academy/claude-skills-tutorial-1-wat-zijn-claude-skills"
-    description="Een aparte, publieke leerlijn die wat dieper ingaat op Claude Skills in het algemeen: wat ze zijn, hoe je er een schrijft, en hoe je hem meet met evals. Goed voor de bredere achtergrond."
+    description="A separate, public tutorial series that goes a bit deeper on Claude Skills in general: what they are, how to write one, and how to measure it with evals. Good for the broader background."
   />
 </NextSteps>

--- a/academy/2026-05-12-hydra-tutorial-5-een-hydra-run-starten/index.mdx
+++ b/academy/2026-05-12-hydra-tutorial-5-een-hydra-run-starten/index.mdx
@@ -1,10 +1,10 @@
 ---
 slug: hydra-tutorial-5-een-hydra-run-starten
-title: "Hydra leerlijn — Deel 5: Een Hydra-run starten op een echte app"
+title: "Hydra tutorial series — Part 5: Starting a Hydra run on a real app"
 contentType: tutorial
 authors: [conduction]
 date: 2026-05-12
-summary: Het hele recept van issue tot groene PR, inclusief de HYDRA_LABEL_PREFIX-instelling waarmee meerdere devs gelijktijdig Hydra kunnen draaien zonder elkaars labels te overschrijven. Vijfde van zes korte modules.
+summary: The full recipe from issue to green PR, including the HYDRA_LABEL_PREFIX setting that lets multiple devs run Hydra at the same time without overwriting each other's labels. Fifth of six short modules.
 tags: [Hydra, Operations, Setup, Labels, Tutorial series]
 apps: []
 durationMinutes: 20
@@ -15,27 +15,27 @@ partNumber: 5
 import {Outcomes, Outcome, Prerequisites, PrerequisiteItem, NextSteps, NextStep, HexCard, Troubleshooting, TroubleshootingItem} from '@conduction/docusaurus-preset/components';
 import Details from '@theme/Details';
 
-In de eerste vier delen ging het om concept, pipelines, gates en skills. Tijd om te draaien. In dit deel start je een complete Hydra-run op een doel-app, met aandacht voor de praktische valkuilen: tokens, images, en — als je met meerdere devs aan dezelfde repo's werkt — de `HYDRA_LABEL_PREFIX`-truc.
+The first four parts were about concept, pipelines, gates and skills. Time to actually run. In this part you start a full Hydra run on a target app, paying attention to the practical pitfalls: tokens, images, and — if you work with multiple devs against the same repos — the `HYDRA_LABEL_PREFIX` trick.
 
 {/* truncate */}
 
-<Outcomes title="Wat je leert in dit deel">
-  <Outcome>Hoe je <code>secrets/.env</code> + <code>secrets/credentials.json</code> opzet voor een lokale Hydra-run.</Outcome>
-  <Outcome>Hoe je de container images lokaal bouwt (of uit GHCR pulled).</Outcome>
-  <Outcome>Hoe je een OpenSpec-change klaar maakt en het issue triggert.</Outcome>
-  <Outcome>Hoe je via <strong><code>HYDRA_LABEL_PREFIX</code></strong> een eigen label-namespace claimt zodat je met meerdere devs niet op elkaars stage-labels staat.</Outcome>
-  <Outcome>Hoe je de pijplijn volgt: <code>logs/supervisor.log</code>, sloten, en pipeline-comments op de PR.</Outcome>
+<Outcomes title="What you'll learn in this part">
+  <Outcome>How to set up <code>secrets/.env</code> + <code>secrets/credentials.json</code> for a local Hydra run.</Outcome>
+  <Outcome>How to build the container images locally (or pull them from GHCR).</Outcome>
+  <Outcome>How to prepare an OpenSpec change and trigger the issue.</Outcome>
+  <Outcome>How to claim your own label namespace via <strong><code>HYDRA_LABEL_PREFIX</code></strong> so multiple devs don't trample each other's stage labels.</Outcome>
+  <Outcome>How to follow the pipeline: <code>logs/supervisor.log</code>, slots, and pipeline comments on the PR.</Outcome>
 </Outcomes>
 
-<Prerequisites title="Wat je nodig hebt">
-  <PrerequisiteItem>Deel 1 t/m 4 doorgenomen.</PrerequisiteItem>
-  <PrerequisiteItem>De hydra-repo gecloned: <code>git clone git@github.com:ConductionNL/hydra.git</code>.</PrerequisiteItem>
-  <PrerequisiteItem>Een werkende Docker engine (rootless of root maakt niet uit). Lokaal draaien we de drie images zonder kubernetes.</PrerequisiteItem>
-  <PrerequisiteItem>Een Claude Max-account met OAuth ingelogd (Hydra gebruikt geen API keys; zie <code>secrets/credentials.json</code> verderop).</PrerequisiteItem>
-  <PrerequisiteItem>GitHub PATs met de juiste scopes voor builder/reviewer/security — vraag aan je teamlead als je ze nog niet hebt.</PrerequisiteItem>
+<Prerequisites title="What you need">
+  <PrerequisiteItem>Parts 1 through 4 worked through.</PrerequisiteItem>
+  <PrerequisiteItem>The hydra repo cloned: <code>git clone git@github.com:ConductionNL/hydra.git</code>.</PrerequisiteItem>
+  <PrerequisiteItem>A working Docker engine (rootless or root doesn't matter). Locally we run the three images without Kubernetes.</PrerequisiteItem>
+  <PrerequisiteItem>A Claude Max account logged in via OAuth (Hydra uses no API keys; see <code>secrets/credentials.json</code> further down).</PrerequisiteItem>
+  <PrerequisiteItem>GitHub PATs with the right scopes for builder/reviewer/security — ask your team lead if you don't have them yet.</PrerequisiteItem>
 </Prerequisites>
 
-## Stap 1: clone en bekijk
+## Step 1: clone and look around
 
 ```bash
 git clone git@github.com:ConductionNL/hydra.git
@@ -43,11 +43,11 @@ cd hydra
 cat CLAUDE.md
 ```
 
-`CLAUDE.md` is de canonieke architectuur-doc. Goed om voor de eerste keer doorheen te scrollen. Daarna naar `secrets/` — die map zit niet in git en moet je zelf vullen.
+`CLAUDE.md` is the canonical architecture doc. Worth scrolling through the first time. Then on to `secrets/` — that folder is not in git and you have to fill it yourself.
 
-## Stap 2: credentials.json
+## Step 2: credentials.json
 
-Hydra leest één bestand voor alle Claude-OAuth-tokens en alle GitHub-PATs:
+Hydra reads one file for all Claude OAuth tokens and all GitHub PATs:
 
 ```json title="secrets/credentials.json"
 {
@@ -63,47 +63,47 @@ Hydra leest één bestand voor alle Claude-OAuth-tokens en alle GitHub-PATs:
 }
 ```
 
-Drie aparte GitHub-PATs. Geen gedeelde org-admin tokens. De reden zag je in deel 1: elk persona heeft zijn eigen scope.
+Three separate GitHub PATs. No shared org-admin tokens. You saw the reason in part 1: each persona has its own scope.
 
-Heb je meerdere Claude Max accounts? Zet ze allemaal in `claude_tokens` in volgorde van voorkeur. `run_container_with_fallback()` rouleert automatisch op rate-limit.
+Got multiple Claude Max accounts? Put them all in `claude_tokens` in order of preference. `run_container_with_fallback()` rotates them automatically on rate-limit.
 
-## Stap 3: `secrets/.env`
+## Step 3: `secrets/.env`
 
-De **niet**-credential overrides. Cruciaal — verschillende voor productie/CI dan voor je laptop.
+The **non**-credential overrides. Critical — different for production/CI than for your laptop.
 
-```bash title="secrets/.env (lokaal werkstation)"
-# Welke images en tag te gebruiken. Lokaal bouw je vaak met -t localhost/hydra-*:test.
+```bash title="secrets/.env (local workstation)"
+# Which images and tag to use. Locally you often build with -t localhost/hydra-*:test.
 HYDRA_IMAGE_PREFIX=localhost/hydra
 HYDRA_IMAGE_TAG=test
 
-# Optioneel: label-namespace zodat je collega's niet op je tenen staat.
+# Optional: label namespace so colleagues don't step on your toes.
 HYDRA_LABEL_PREFIX=wilco
 
-# Default review-scope (ADR-020): alleen PR-diff. Zet op 'full' alleen bij onboarding van een repo.
+# Default review scope (ADR-020): PR diff only. Set to 'full' only when onboarding a repo.
 HYDRA_REVIEW_SCOPE=diff
 ```
 
-Tip: de defaults zijn `ghcr.io/conductionnl/hydra` als prefix en `latest` als tag. Op productie/CI laat je `HYDRA_IMAGE_*` weg en pakt Hydra die defaults op.
+Tip: the defaults are `ghcr.io/conductionnl/hydra` as prefix and `latest` as tag. In production/CI you leave `HYDRA_IMAGE_*` off and Hydra picks up those defaults.
 
-:::tip secrets/.env wordt automatisch geladen
-`scripts/hydra-supervisor.sh` en `scripts/orchestrate.sh` sourcen dit bestand **zelf** bij opstart. Eerder moest je het in je shell exporteren — een silly bug die maanden onopgemerkt bleef en gefixt is als onderdeel van het [decidesk-44-45 retrospectief](https://github.com/ConductionNL/hydra/blob/main/docs/retrospectives/decidesk-44-45-phase-g.md) (april 2026). Iedere nieuwe long-running entrypoint MOET dit bestand sourcen aan de start; dat is een repo-wide contract.
+:::tip secrets/.env is loaded automatically
+`scripts/hydra-supervisor.sh` and `scripts/orchestrate.sh` source this file **themselves** at startup. Previously you had to export it in your shell — a silly bug that went unnoticed for months and was fixed as part of the [decidesk-44-45 retrospective](https://github.com/ConductionNL/hydra/blob/main/docs/retrospectives/decidesk-44-45-phase-g.md) (April 2026). Every new long-running entrypoint MUST source this file at startup; that's a repo-wide contract.
 :::
 
-## Stap 4: HYDRA_LABEL_PREFIX — waarom en hoe
+## Step 4: HYDRA_LABEL_PREFIX — why and how
 
-Default werkt Hydra met **kale** labels: `build:queued`, `code-review:running`, `security-review:pass`, enzovoort. Eén supervisor draait, eén pipeline tegelijk per issue. Geen probleem.
+By default Hydra works with **bare** labels: `build:queued`, `code-review:running`, `security-review:pass`, and so on. One supervisor running, one pipeline at a time per issue. No problem.
 
-**Maar:** zodra meerdere devs lokaal Hydra draaien tegen **dezelfde** target-repo's gaat het knetteren. Jouw supervisor schrijft `build:queued`. De supervisor van een collega ziet datzelfde label, pakt het op, gaat *zijn* build doen. Resultaat: race-conditions, dubbele PRs, labels die over elkaar pingen.
+**But:** as soon as multiple devs run Hydra locally against **the same** target repos things start crackling. Your supervisor writes `build:queued`. A colleague's supervisor sees that same label, picks it up, runs *their* build. Result: race conditions, duplicate PRs, labels ping-ponging over each other.
 
-`HYDRA_LABEL_PREFIX` is de oplossing. Zet hem in `secrets/.env`:
+`HYDRA_LABEL_PREFIX` is the fix. Set it in `secrets/.env`:
 
 ```bash
 HYDRA_LABEL_PREFIX=wilco
 ```
 
-Vanaf dat moment prefixed Hydra **ELK door hem beheerd label** met `wilco-`:
+From that moment on, Hydra prefixes **EVERY label it manages** with `wilco-`:
 
-| Default (geen prefix)        | Met `HYDRA_LABEL_PREFIX=wilco`     |
+| Default (no prefix)          | With `HYDRA_LABEL_PREFIX=wilco`    |
 |---|---|
 | `ready-to-build`             | `wilco-ready-to-build`             |
 | `build:queued`               | `wilco-build:queued`               |
@@ -113,64 +113,64 @@ Vanaf dat moment prefixed Hydra **ELK door hem beheerd label** met `wilco-`:
 | `applier:fail`               | `wilco-applier:fail`               |
 | `needs-input`                | `wilco-needs-input`                |
 | `retry:queued`, `rebuild:queued` | `wilco-retry:queued`, `wilco-rebuild:queued` |
-| `yolo`, `openspec` (metadata) | **niet** geprefixed — gedeelde metadata |
+| `yolo`, `openspec` (metadata) | **not** prefixed — shared metadata |
 
-Jouw Hydra leest én schrijft **alleen** labels in zijn eigen namespace. De supervisor van een collega met `HYDRA_LABEL_PREFIX=jan` werkt in een andere namespace, dus jullie zien elkaars in-flight werk niet en blokkeren elkaar niet.
+Your Hydra reads and writes **only** labels in its own namespace. A colleague's supervisor with `HYDRA_LABEL_PREFIX=jan` operates in a different namespace, so you don't see each other's in-flight work and you don't block each other.
 
-### Constraints op de waarde
+### Constraints on the value
 
-- Regex: `^[a-z0-9]([a-z0-9-]{0,14}[a-z0-9])?$` — 1 t/m 16 tekens, lowercase a-z 0-9 en koppelteken, niet beginnen of eindigen met een streepje.
-- Empty / unset = default-gedrag (geen prefix). Dat is ook wat productie/CI altijd draait.
-- Wijzigen tijdens een lopende run = NIET DOEN. Eerst pijplijn drainen.
+- Regex: `^[a-z0-9]([a-z0-9-]{0,14}[a-z0-9])?$` — 1 to 16 characters, lowercase a-z 0-9 and hyphen, not starting or ending with a hyphen.
+- Empty / unset = default behaviour (no prefix). That's also what production/CI always runs.
+- Changing during a running run = DO NOT. Drain the pipeline first.
 
-### Labels seeden op een target-repo
+### Seeding labels on a target repo
 
-Voor je eerste run met een nieuwe prefix moet je de labels op de doel-repo's eenmalig aanmaken:
+Before your first run with a new prefix you have to create the labels on the target repos once:
 
 ```bash
 ./scripts/create-labels.sh --repo ConductionNL/<app> --prefix wilco
 ```
 
-Idempotent — herhaalde aanroepen overschrijven alleen kleuren. Het script seedt ook de juiste kleurcodes (rood/oranje/geel/groen/blauw) zodat het board in één oogopslag leesbaar blijft.
+Idempotent — repeated calls only overwrite colours. The script also seeds the right colour codes (red/orange/yellow/green/blue) so the board stays legible at a glance.
 
-### Wanneer wel, wanneer niet
+### When to use it, when not
 
-| Situatie | Prefix gebruiken? |
+| Situation | Use prefix? |
 |---|---|
-| Productie / GitHub Actions / cron-managed deployment | **Nee.** Laat hem leeg. Productie = de canonieke labels. |
-| Lokale dev-werkstation, één Hydra-instance | Kan, hoeft niet. Werkt zonder ook. |
-| Lokaal, meerdere devs, gedeelde target-repo's | **Ja.** Iedereen z'n eigen prefix. |
-| Demo / experiment op een target-repo waar productie ook draait | **Ja, zeker.** Anders pakt productie-Hydra je demo-issue op. |
+| Production / GitHub Actions / cron-managed deployment | **No.** Leave it empty. Production = the canonical labels. |
+| Local dev workstation, single Hydra instance | Optional. Works without too. |
+| Local, multiple devs, shared target repos | **Yes.** Everyone their own prefix. |
+| Demo / experiment on a target repo where production also runs | **Yes, definitely.** Otherwise production-Hydra picks up your demo issue. |
 
-<HexCard title="Gerelateerd: HYDRA_REVIEW_SCOPE=full">
-  Naast prefix is er nog een tweede knop voor lokaal werken: <code>HYDRA_REVIEW_SCOPE=full</code> zet de reviewer-scope van diff-only naar de hele repo. Handig voor onboarding van een nieuwe repo of een dedicated tech-debt-sweep, NIET voor reguliere PRs (verwacht veel rood — zie deel 3).
+<HexCard title="Related: HYDRA_REVIEW_SCOPE=full">
+  Besides the prefix there's a second knob for local work: <code>HYDRA_REVIEW_SCOPE=full</code> switches the reviewer scope from diff-only to the entire repo. Handy when onboarding a new repo or for a dedicated tech-debt sweep, NOT for regular PRs (expect lots of red — see part 3).
 </HexCard>
 
-## Stap 5: build de container images
+## Step 5: build the container images
 
-In CI worden alle images door GitHub Actions gepushd naar GHCR. Lokaal — als je `HYDRA_IMAGE_PREFIX=localhost/hydra` hebt staan — bouw je ze zelf:
+In CI all images are pushed to GHCR by GitHub Actions. Locally — if you have `HYDRA_IMAGE_PREFIX=localhost/hydra` set — you build them yourself:
 
 ```bash
-# Base image: Nextcloud + PostgreSQL + OpenRegister (afhankelijkheid van builder)
+# Base image: Nextcloud + PostgreSQL + OpenRegister (builder dependency)
 docker build -t ghcr.io/conductionnl/hydra-nextcloud-test:stable32 \
     -f images/nextcloud-test/Dockerfile .
 
-# De drie pipeline images
+# The three pipeline images
 docker build -t localhost/hydra-builder:test  -f images/builder/Dockerfile  .
 docker build -t localhost/hydra-reviewer:test -f images/reviewer/Dockerfile .
 docker build -t localhost/hydra-security:test -f images/security/Dockerfile .
 ```
 
-Daarna controleer met `docker images | grep hydra` of de drie tags er staan. Reviewer en security zijn standalone (geen NC-dependency); de builder leunt op de `hydra-nextcloud-test` base.
+Then verify with `docker images | grep hydra` that the three tags are there. Reviewer and security are standalone (no NC dependency); the builder leans on the `hydra-nextcloud-test` base.
 
-## Stap 6: start de supervisor
+## Step 6: start the supervisor
 
 ```bash
-# Foreground voor je eerste run zodat je live ziet wat gebeurt
+# Foreground for your first run so you see live what's happening
 ./scripts/hydra-supervisor.sh
 ```
 
-Wat je verwacht te zien:
+What you expect to see:
 
 ```
 [supervisor] loaded HYDRA_LABEL_PREFIX=wilco — restricting to own namespace
@@ -179,36 +179,36 @@ Wat je verwacht te zien:
 [supervisor] polling …
 ```
 
-In een tweede terminal kun je de logs volgen:
+In a second terminal you can follow the logs:
 
 ```bash
 tail -f logs/supervisor.log
-ls /tmp/hydra-slots/    # zien welke slots in gebruik zijn
+ls /tmp/hydra-slots/    # see which slots are in use
 ```
 
-## Stap 7: trigger een issue
+## Step 7: trigger an issue
 
-In de doel-repo open je een issue. Op dat issue zet je:
+In the target repo you open an issue. On that issue you set:
 
-- Het trigger-label. **Met prefix:** `wilco-ready-to-build`. Zonder prefix: `ready-to-build`.
-- Optioneel `yolo` — niet geprefixed, want metadata.
-- Optioneel `openspec` als je via OpenSpec werkt.
+- The trigger label. **With prefix:** `wilco-ready-to-build`. Without prefix: `ready-to-build`.
+- Optionally `yolo` — not prefixed, since it's metadata.
+- Optionally `openspec` if you're working via OpenSpec.
 
-Voorbeeld via `gh`:
+Example via `gh`:
 
 ```bash
-# Met prefix (lokale dev-run):
+# With prefix (local dev run):
 gh issue edit <N> --repo ConductionNL/<app> --add-label "wilco-ready-to-build"
 
-# Of via de Hydra-helper (synct meteen het board):
+# Or via the Hydra helper (syncs the board straight away):
 ./scripts/hydra-label.sh ConductionNL/<app> <N> add ready-to-build
 ```
 
-`scripts/hydra-label.sh` is de **voorkeursweg**: hij respecteert `HYDRA_LABEL_PREFIX` automatisch, gebruikt de label-helpers uit `scripts/lib/labels.sh`, en synct het bijbehorende GitHub Project-bord in real-time. Direct `gh issue edit --add-label` werkt ook, maar dan blijft het board "in de oude kolom" tot reconcile (om de 10 minuten) het opraapt.
+`scripts/hydra-label.sh` is the **preferred path**: it respects `HYDRA_LABEL_PREFIX` automatically, uses the label helpers from `scripts/lib/labels.sh`, and syncs the associated GitHub Project board in real-time. Direct `gh issue edit --add-label` works too, but then the board stays "in the old column" until reconcile (every 10 minutes) picks it up.
 
-## Stap 8: volg de pijplijn
+## Step 8: follow the pipeline
 
-Zodra de supervisor het issue ziet, gebeurt dit (geprefixed of niet, afhankelijk van je config):
+As soon as the supervisor sees the issue, this happens (prefixed or not, depending on your config):
 
 ```
 ready-to-build → build:queued → build:running → build:pass
@@ -217,56 +217,56 @@ ready-to-build → build:queued → build:running → build:pass
               ↳ applier:queued → :running → :pass / :fail → done / needs-input
 ```
 
-Je volgt het op drie plekken:
+You follow it in three places:
 
-1. **`logs/supervisor.log`** — wat de supervisor doet.
-2. **GitHub-issue** — labels veranderen automatisch.
-3. **GitHub PR** — pipeline-status-comment wordt elke fase bijgewerkt door `scripts/lib/pipeline-comment.sh`.
+1. **`logs/supervisor.log`** — what the supervisor is doing.
+2. **GitHub issue** — labels change automatically.
+3. **GitHub PR** — pipeline status comment is updated every phase by `scripts/lib/pipeline-comment.sh`.
 
-Heb je `yolo` gezet en is alles groen? Dan zie je `done` op het issue verschijnen, een goedkeuring op de PR, en een auto-merge. Geen `yolo`? Dan staat de PR klaar voor een mens om te mergen.
+Set `yolo` and is everything green? Then you'll see `done` appear on the issue, an approval on the PR, and an auto-merge. No `yolo`? Then the PR is ready for a human to merge.
 
 ## Troubleshooting
 
-<Troubleshooting title="Eerste-run problemen">
-  <TroubleshootingItem symptom="Supervisor kiest standaard ghcr.io images terwijl ik lokaal heb gebouwd">
-    Controleer dat <code>secrets/.env</code> daadwerkelijk <code>HYDRA_IMAGE_PREFIX=localhost/hydra</code> en <code>HYDRA_IMAGE_TAG=test</code> bevat — en dat het bestand bestaat in <code>secrets/</code> en niet in je home-dir. De supervisor en orchestrate.sh sourcen <code>secrets/.env</code> via een vast pad relatief aan de repo-root.
+<Troubleshooting title="First-run problems">
+  <TroubleshootingItem symptom="Supervisor picks default ghcr.io images even though I built locally">
+    Check that <code>secrets/.env</code> actually contains <code>HYDRA_IMAGE_PREFIX=localhost/hydra</code> and <code>HYDRA_IMAGE_TAG=test</code> — and that the file lives in <code>secrets/</code> and not in your home dir. The supervisor and orchestrate.sh source <code>secrets/.env</code> via a fixed path relative to the repo root.
   </TroubleshootingItem>
-  <TroubleshootingItem symptom="Issue blijft op wilco-ready-to-build staan, supervisor pakt 'm niet op">
-    Heb je <code>./scripts/create-labels.sh --repo ... --prefix wilco</code> al gedraaid? Zonder de geprefixeerde labels op de doel-repo kan de supervisor wel polled, maar GitHub geeft geen matches terug. Verifieer met <code>gh label list --repo ConductionNL/&lt;app&gt; | grep wilco</code>.
+  <TroubleshootingItem symptom="Issue stays on wilco-ready-to-build, supervisor doesn't pick it up">
+    Have you already run <code>./scripts/create-labels.sh --repo ... --prefix wilco</code>? Without the prefixed labels on the target repo the supervisor polls fine, but GitHub returns no matches. Verify with <code>gh label list --repo ConductionNL/&lt;app&gt; | grep wilco</code>.
   </TroubleshootingItem>
-  <TroubleshootingItem symptom="Build start, geen image found error">
-    <code>docker images | grep hydra-builder</code>. Geen treffer? Bouw eerst de base image (<code>hydra-nextcloud-test</code>) en daarna pas de builder. De builder-Dockerfile heeft de base als <code>FROM</code>.
+  <TroubleshootingItem symptom="Build starts, no image found error">
+    <code>docker images | grep hydra-builder</code>. No hit? Build the base image first (<code>hydra-nextcloud-test</code>) and then the builder. The builder Dockerfile has the base as <code>FROM</code>.
   </TroubleshootingItem>
-  <TroubleshootingItem symptom="Issue gaat direct naar wilco-needs-input zonder dat ik iets zie">
-    Stale labels van een vorige run blijven hangen. Strip de oude stage-labels met <code>./scripts/hydra-label.sh ConductionNL/&lt;app&gt; &lt;N&gt; transition ready-to-build</code> — dat zet de issue terug in een definieerde startstate.
+  <TroubleshootingItem symptom="Issue jumps straight to wilco-needs-input without me seeing anything">
+    Stale labels from a previous run are still hanging around. Strip the old stage labels with <code>./scripts/hydra-label.sh ConductionNL/&lt;app&gt; &lt;N&gt; transition ready-to-build</code> — that puts the issue back into a defined starting state.
   </TroubleshootingItem>
-  <TroubleshootingItem symptom="HYDRA_LABEL_PREFIX validatie faalt op startup">
-    Regex is <code>^[a-z0-9]([a-z0-9-]{0,14}[a-z0-9])?$</code>. Geen hoofdletters, geen leestekens, geen underscore, geen leading/trailing streepje. Max 16 tekens.
+  <TroubleshootingItem symptom="HYDRA_LABEL_PREFIX validation fails on startup">
+    Regex is <code>^[a-z0-9]([a-z0-9-]{0,14}[a-z0-9])?$</code>. No uppercase, no punctuation, no underscore, no leading/trailing hyphen. Max 16 characters.
   </TroubleshootingItem>
 </Troubleshooting>
 
-## Test jezelf
+## Test yourself
 
-Vier korte vragen om te checken of je dit deel begrepen hebt. Vastgelopen? Klik **Hint**. Curieus naar het antwoord? Klik **Antwoord**.
+Four short questions to check whether you've grasped this part. Stuck? Click **Hint**. Curious about the answer? Click **Answer**.
 
 <div className="tutorial-quiz">
 
-**1. Wat is het probleem dat `HYDRA_LABEL_PREFIX` oplost, en wanneer hoef je hem expliciet NIET te zetten?**
+**1. What problem does `HYDRA_LABEL_PREFIX` solve, and when should you explicitly NOT set it?**
 
 <Details summary="Hint">
 
-Wat gebeurt er als twee Hydra-instances tegelijk dezelfde target-repo bekijken? En waarom is dat juist géén probleem in productie?
+What happens when two Hydra instances look at the same target repo at the same time? And why is that exactly not a problem in production?
 
 </Details>
 
-<Details summary="Antwoord">
+<Details summary="Answer">
 
-**Probleem dat het oplost:** zodra meerdere devs lokaal tegelijk Hydra draaien tegen dezelfde target-repos zien hun supervisors elkaars labels en pakken elkaars werk op. Race-conditions, dubbele PRs, labels die over elkaar pingen. Met een eigen prefix (`wilco-build:queued`) heeft elke dev zijn eigen namespace.
+**Problem it solves:** as soon as multiple devs run Hydra locally at the same time against the same target repos, their supervisors see each other's labels and pick up each other's work. Race conditions, duplicate PRs, labels ping-ponging over each other. With your own prefix (`wilco-build:queued`) every dev gets their own namespace.
 
-**Wanneer NIET zetten:**
+**When NOT to set it:**
 
-- **Productie / GitHub Actions / cron-managed deployment** — daar wil je juist de canonieke (kale) labels: één bron van waarheid, geen verdwaalde dev-prefix.
-- **Lokale solo-run** zonder collega's op dezelfde repos — werkt zonder ook; mag wel maar hoeft niet.
+- **Production / GitHub Actions / cron-managed deployment** — there you specifically want the canonical (bare) labels: a single source of truth, no stray dev prefix.
+- **Local solo run** without colleagues on the same repos — works without too; allowed but not required.
 
 </Details>
 
@@ -274,18 +274,18 @@ Wat gebeurt er als twee Hydra-instances tegelijk dezelfde target-repo bekijken? 
 
 <div className="tutorial-quiz">
 
-**2. Welke labels worden door `HYDRA_LABEL_PREFIX` WEL en welke NIET geprefixed?**
+**2. Which labels ARE and which ARE NOT prefixed by `HYDRA_LABEL_PREFIX`?**
 
 <Details summary="Hint">
 
-Wat Hydra zelf doorzet in zijn state-machine wordt geprefixed. Wat over het werk-zélf gaat (eigenschap van het issue, geen pipeline-state) wordt gedeeld.
+What Hydra itself drives in its state machine gets prefixed. What is about the work itself (a property of the issue, not pipeline state) is shared.
 
 </Details>
 
-<Details summary="Antwoord">
+<Details summary="Answer">
 
-- **WEL geprefixed**: **stage-labels** (`ready-to-build`, `build:queued/running/pass/fail`, `code-review:*`, `security-review:*`, `applier:*`) en **herstel-labels** (`retry:queued`, `rebuild:queued`, `needs-input`). Allemaal labels die Hydra zelf beheert in de state-machine.
-- **NIET geprefixed**: **metadata** die over de aard van het werk gaat, niet over een Hydra-instance: **`yolo`** (mag auto-mergen) en **`openspec`** (volgt OpenSpec-werkmodel). Twee devs op één issue zijn het immers eens over of het een yolo-issue is — geen reden om dat per-dev op te splitsen.
+- **Prefixed**: **stage labels** (`ready-to-build`, `build:queued/running/pass/fail`, `code-review:*`, `security-review:*`, `applier:*`) and **recovery labels** (`retry:queued`, `rebuild:queued`, `needs-input`). All labels Hydra manages itself in the state machine.
+- **NOT prefixed**: **metadata** that describes the nature of the work, not a Hydra instance: **`yolo`** (may auto-merge) and **`openspec`** (follows the OpenSpec working model). Two devs on one issue agree on whether it's a yolo issue — no reason to split that per dev.
 
 </Details>
 
@@ -293,20 +293,20 @@ Wat Hydra zelf doorzet in zijn state-machine wordt geprefixed. Wat over het werk
 
 <div className="tutorial-quiz">
 
-**3. Waarom roep je `./scripts/hydra-label.sh` aan in plaats van `gh issue edit --add-label` bij het triggeren van een run?**
+**3. Why call `./scripts/hydra-label.sh` instead of `gh issue edit --add-label` when triggering a run?**
 
 <Details summary="Hint">
 
-Twee dingen waar het script automatisch voor zorgt en de directe `gh`-aanroep niet.
+Two things the script handles automatically that the direct `gh` call does not.
 
 </Details>
 
-<Details summary="Antwoord">
+<Details summary="Answer">
 
-Twee redenen:
+Two reasons:
 
-1. **Respecteert `HYDRA_LABEL_PREFIX` automatisch** — je tikt `add ready-to-build`, het script maakt er `wilco-ready-to-build` van. Met `gh issue edit --add-label` moet je de prefix met de hand meetypen en bij elke verandering aanpassen — recipe voor typos en namespace-drift.
-2. **Synct het GitHub Project-bord direct.** `gh issue edit` werkt ook, maar het board blijft dan "in de oude kolom" tot `reconcile.sh` (om de 10 minuten) het opraapt. Met `hydra-label.sh` zie je de kolom-overgang meteen.
+1. **Respects `HYDRA_LABEL_PREFIX` automatically** — you type `add ready-to-build`, the script turns it into `wilco-ready-to-build`. With `gh issue edit --add-label` you'd have to type the prefix by hand and update it on every change — recipe for typos and namespace drift.
+2. **Syncs the GitHub Project board immediately.** `gh issue edit` works too, but the board then stays "in the old column" until `reconcile.sh` (every 10 minutes) picks it up. With `hydra-label.sh` you see the column transition immediately.
 
 </Details>
 
@@ -314,43 +314,43 @@ Twee redenen:
 
 <div className="tutorial-quiz">
 
-**4. Wat gebeurt er als je `HYDRA_LABEL_PREFIX` wijzigt terwijl er nog een Hydra-run loopt? En wat is de juiste werkwijze als je toch wilt wijzigen?**
+**4. What happens if you change `HYDRA_LABEL_PREFIX` while a Hydra run is still in progress? And what's the right way to change it?**
 
 <Details summary="Hint">
 
-De lopende run kijkt naar labels in de oude namespace, jouw nieuwe supervisor in een andere. Wat blijft er over?
+The running run looks at labels in the old namespace, your new supervisor at another. What's left?
 
 </Details>
 
-<Details summary="Antwoord">
+<Details summary="Answer">
 
-**Wat er gebeurt:** de lopende run kijkt naar labels in de oude namespace; jouw supervisor met nieuwe prefix kijkt naar een andere set. Lopend werk wordt door niemand meer opgepakt (orphaned), of erger — labels van beide namespaces komen op één issue terecht.
+**What happens:** the running run looks at labels in the old namespace; your supervisor with the new prefix looks at a different set. Work in progress is picked up by no one (orphaned), or worse — labels from both namespaces end up on a single issue.
 
-**Juiste werkwijze:**
+**Right way:**
 
-1. Zet geen nieuw werk meer in de oude prefix.
-2. **Drain de pijplijn**: wacht tot alle issues met de oude prefix op `done` of `needs-input` staan.
-3. Pas dán `HYDRA_LABEL_PREFIX` aanpassen in `secrets/.env` en de supervisor herstarten.
-4. `./scripts/create-labels.sh --repo ... --prefix <nieuw>` om de nieuwe namespace op de doel-repo's te seeden.
+1. Stop putting new work into the old prefix.
+2. **Drain the pipeline**: wait until all issues with the old prefix are at `done` or `needs-input`.
+3. Only **then** change `HYDRA_LABEL_PREFIX` in `secrets/.env` and restart the supervisor.
+4. `./scripts/create-labels.sh --repo ... --prefix <new>` to seed the new namespace on the target repos.
 
 </Details>
 
 </div>
 
-<NextSteps title="Volgende stap" lede="Pijplijn loopt? Mooi. Maar wat doe je als het mis gaat? Deel 6 behandelt herstel- en escalatie-patronen.">
+<NextSteps title="Next step" lede="Pipeline running? Great. But what do you do when it goes wrong? Part 6 covers recovery and escalation patterns.">
   <NextStep
-    title="Deel 6 — Troubleshooting & escalatie"
+    title="Part 6 — Troubleshooting & escalation"
     href="/academy/hydra-tutorial-6-troubleshooting-escalatie"
-    description="<code>needs-input</code>, <code>retry:queued</code>, <code>rebuild:queued</code>: welke kies je wanneer en wat kost het."
+    description="<code>needs-input</code>, <code>retry:queued</code>, <code>rebuild:queued</code>: which to choose when and what it costs."
   />
   <NextStep
-    title="Vorige stap — Skills & commands"
+    title="Previous step — Skills & commands"
     href="/academy/hydra-tutorial-4-skills"
-    description="Wat de personas tijdens hun werk gebruiken."
+    description="What the personas use during their work."
   />
   <NextStep
-    title="dev-run.md — operationele referentie"
+    title="dev-run.md — operational reference"
     href="https://github.com/ConductionNL/hydra/blob/main/docs/operations/dev-run.md"
-    description="De volledige operationele doc met alle dev-run-flags en label-prefix-uitleg."
+    description="The full operational doc with all dev-run flags and label-prefix explanation."
   />
 </NextSteps>

--- a/academy/2026-05-12-hydra-tutorial-6-troubleshooting-escalatie/index.mdx
+++ b/academy/2026-05-12-hydra-tutorial-6-troubleshooting-escalatie/index.mdx
@@ -1,10 +1,10 @@
 ---
 slug: hydra-tutorial-6-troubleshooting-escalatie
-title: "Hydra leerlijn — Deel 6: Troubleshooting & escalatie"
+title: "Hydra tutorial series — Part 6: Troubleshooting & escalation"
 contentType: tutorial
 authors: [conduction]
 date: 2026-05-12
-summary: Wat te doen als de pijplijn vastloopt. Het keuzemenu tussen development-merge, label-reset, retry:queued, en rebuild:queued — geordend van goedkoop naar duur. Laatste van zes korte modules.
+summary: What to do when the pipeline gets stuck. The menu of choices between development merge, label reset, retry:queued, and rebuild:queued — ordered from cheap to expensive. Last of six short modules.
 tags: [Hydra, Troubleshooting, Recovery, Tutorial series]
 apps: []
 durationMinutes: 15
@@ -15,146 +15,146 @@ partNumber: 6
 import {Outcomes, Outcome, Prerequisites, PrerequisiteItem, NextSteps, NextStep, HexCard, Troubleshooting, TroubleshootingItem, ContactCta} from '@conduction/docusaurus-preset/components';
 import Details from '@theme/Details';
 
-In deel 5 stond de pijplijn. Nu het laatste deel: **wat doe je als hij niet groen wordt?** Dit deel geeft je de keuzeboom — geordend van goedkoopste interventie naar duurste — en de patronen waarmee je `needs-input`-issues weer in beweging krijgt.
+In part 5 the pipeline was running. Now the final part: **what do you do when it doesn't go green?** This part gives you the decision tree — ordered from cheapest intervention to most expensive — and the patterns that get `needs-input` issues moving again.
 
 {/* truncate */}
 
-<Outcomes title="Wat je leert in dit deel">
-  <Outcome>De drie typische oorzaken van een vastgelopen pijplijn: stale dependencies, terechte review-findings, en fundamenteel verkeerde build-aanpak.</Outcome>
-  <Outcome>De interventie-ladder: development-merge → review-labels resetten → <code>retry:queued</code> → <code>rebuild:queued</code> → handmatige fix.</Outcome>
-  <Outcome>Waarom <code>needs-input</code> NIET hetzelfde is als "Hydra is kapot".</Outcome>
-  <Outcome>Waar je de retrospectives vindt en hoe je terugkerende patronen herkent.</Outcome>
+<Outcomes title="What you'll learn in this part">
+  <Outcome>The three typical causes of a stuck pipeline: stale dependencies, legitimate review findings, and fundamentally wrong build approach.</Outcome>
+  <Outcome>The intervention ladder: development merge → reset review labels → <code>retry:queued</code> → <code>rebuild:queued</code> → manual fix.</Outcome>
+  <Outcome>Why <code>needs-input</code> is NOT the same as "Hydra is broken".</Outcome>
+  <Outcome>Where to find the retrospectives and how to recognise recurring patterns.</Outcome>
 </Outcomes>
 
-<Prerequisites title="Wat je nodig hebt">
-  <PrerequisiteItem>Deel 1 t/m 5 doorgenomen.</PrerequisiteItem>
-  <PrerequisiteItem>Een mentaal model van het label-state-machine (uit deel 2).</PrerequisiteItem>
+<Prerequisites title="What you need">
+  <PrerequisiteItem>Parts 1 through 5 worked through.</PrerequisiteItem>
+  <PrerequisiteItem>A mental model of the label state machine (from part 2).</PrerequisiteItem>
 </Prerequisites>
 
-## Wat betekent `needs-input`?
+## What does `needs-input` mean?
 
-`needs-input` is **geen failure-state in de zin van "Hydra heeft gefaald"**. Het is een expliciete escalatie: Hydra heeft gedaan wat hij kon, één run, en is tot een terminaal punt gekomen waar hij niet zelf verder kan zonder een menselijke beslissing.
+`needs-input` is **not a failure state in the sense of "Hydra has failed"**. It's an explicit escalation: Hydra has done what it could, one run, and has reached a terminal point where it can't proceed on its own without a human decision.
 
-Mogelijke oorzaken:
+Possible causes:
 
-- Beide reviewers `pass` maar de quality-recheck na hun fixes is rood (een fix introduceerde een nieuwe overtreding).
-- Eén van beide reviews `:fail`.
+- Both reviewers `pass` but the quality recheck after their fixes is red (a fix introduced a new violation).
+- One of the two reviews `:fail`.
 - Applier Axel Pliér `:fail`.
-- Build crashed mid-stage (container OOM, rate-limit op alle accounts, …).
-- Agent-maxed-out: een persona heeft zijn turn-budget opgemaakt.
+- Build crashed mid-stage (container OOM, rate-limit on all accounts, …).
+- Agent-maxed-out: a persona used up its turn budget.
 
-Je rol als mens: bepaal welke van de vier opties hieronder het meest passend is en pas die toe. **Niet** een nieuwe `retry:queued` blind plakken in de hoop dat het deze keer wel werkt.
+Your role as a human: decide which of the four options below is the best fit and apply it. **Don't** blindly slap on another `retry:queued` in the hope that this time it works.
 
-## De interventie-ladder
+## The intervention ladder
 
-| # | Situatie | Interventie | Kosten | Wat behoud je |
+| # | Situation | Intervention | Cost | What you keep |
 |---|---|---|---|---|
-| 1 | Development is doorgegroeid, PR staat stale (nieuwe lint-rules, ADRs, fixtures op development) | <code>gh pr update-branch &lt;N&gt;</code> (of de cron pakt het op) | Gratis | Alle build/review/applier-werk. Alleen dependencies vernieuwen. |
-| 2 | Review-contracten zijn aangepast en je wilt reviewers opnieuw laten oordelen zonder rebuild | Reviewer-labels resetten: stage-labels strippen, <code>code-review:queued</code> opnieuw zetten. PR blijft. | 2× reviewer + applier | De builder-output. Alleen het review-deel rewindt. |
-| 3 | Reviewers/applier flagden concrete findings en de builder hoeft alleen even bij te schaven | <code>retry:queued</code> op het issue plakken | 1× builder + 2× reviewer + applier | Branch + PR blijven. Orchestrator bouwt <code>feedback.md</code> uit <code>hydra.json</code> (unfixed + applier-blockers + reeds gefixed) en dispatcht builder in <code>HYDRA_MODE=fix</code>. Single-shot — geen loop. |
-| 4 | Builder-output was fundamenteel verkeerd (verkeerde aanpak, stub-implementatie, fundamentele requirements gemist) | <code>rebuild:queued</code> op het issue plakken | Volledige cyclus | Orchestrator sluit de open PR, hard-reset <code>feature/&lt;issue&gt;/*</code> naar development, strip alle cycle-labels, zet <code>build:queued</code>. Volgende cyclus begint van scratch. |
-| 5 | Je hebt zelf de PR al gesloten en stale labels staan nog op het issue | Wachten op <code>reconcile.sh</code> (om de 10 min) | Volgende reconcile-run | <code>check_stage_without_open_pr</code> ziet de inconsistentie en zet automatisch <code>build:queued</code>. Self-healing. |
-| 6 | Pipeline-infra is stuk (container crash, alle tokens op, image niet vindbaar) | Escaleer naar mens (jij of een teamlead), los infra op, en kies pas DAN één van 1-4 hierboven | Tijd | — |
+| 1 | Development has moved on, PR is stale (new lint rules, ADRs, fixtures on development) | <code>gh pr update-branch &lt;N&gt;</code> (or the cron picks it up) | Free | All build/review/applier work. Just refresh dependencies. |
+| 2 | Review contracts were adjusted and you want reviewers to judge again without a rebuild | Reset reviewer labels: strip stage labels, set <code>code-review:queued</code> again. PR stays. | 2× reviewer + applier | The builder output. Only the review part rewinds. |
+| 3 | Reviewers/applier flagged concrete findings and the builder just needs to polish | Stick <code>retry:queued</code> on the issue | 1× builder + 2× reviewer + applier | Branch + PR stay. Orchestrator builds <code>feedback.md</code> from <code>hydra.json</code> (unfixed + applier blockers + already-fixed) and dispatches builder in <code>HYDRA_MODE=fix</code>. Single shot — no loop. |
+| 4 | Builder output was fundamentally wrong (wrong approach, stub implementation, missed core requirements) | Stick <code>rebuild:queued</code> on the issue | Full cycle | Orchestrator closes the open PR, hard-resets <code>feature/&lt;issue&gt;/*</code> to development, strips all cycle labels, sets <code>build:queued</code>. Next cycle starts from scratch. |
+| 5 | You closed the PR yourself and stale labels are still on the issue | Wait for <code>reconcile.sh</code> (every 10 min) | Next reconcile run | <code>check_stage_without_open_pr</code> sees the inconsistency and automatically sets <code>build:queued</code>. Self-healing. |
+| 6 | Pipeline infra is broken (container crash, all tokens exhausted, image not findable) | Escalate to a human (you or a team lead), fix infra, and only THEN pick one of 1-4 above | Time | — |
 
-**Volgorde:** altijd 1 → 2 → 3 → 4. Pak het goedkoopste herstel eerst. Reach voor `rebuild:queued` alleen als de build zelf fundamenteel verkeerd was.
+**Order:** always 1 → 2 → 3 → 4. Take the cheapest recovery first. Reach for `rebuild:queued` only if the build itself was fundamentally wrong.
 
 ### `retry:queued` in detail
 
-1. Jij (of een automated rule) plakt `retry:queued` op het issue. Met label-prefix wordt dat `<prefix>-retry:queued` — `scripts/hydra-label.sh` regelt dat automatisch.
-2. Supervisor pakt het op als reguliere queue-job.
-3. Orchestrator vindt de open PR op `feature/<issue>/*`.
-4. Orchestrator cloned development, kopieert `openspec/changes/<slug>/hydra.json` en draait `scripts/lib/build-feedback-brief.py` → schrijft `feedback.md` met (a) applier-blockers, (b) unfixed reviewer-findings, (c) reeds-gefixed items, (d) Scope-lijst van alle geflagde files.
-5. Orchestrator flipped `retry:queued` → `retry:running`, dispatcht de builder met `HYDRA_MODE=fix` en `feedback.md` gemount op `/workspace/feedback.md`.
-6. Builder leest de brief, fixed álle bevindingen in één pass, beperkt zich tot Scope-files (plus nieuwe files die expliciet door een blocker geëist worden), commit met `fix (retry):` messages, pusht.
-7. Succes: orchestrator strip alle review/applier-labels + `retry:running` + `needs-input`, zet `code-review:queued`. Reviewers draaien opnieuw tegen de gefixede code.
-8. Faal: `retry:running` → `needs-input`, comment op het issue legt uit waarom en wijst naar `rebuild:queued` als de volgende hefboom.
+1. You (or an automated rule) stick `retry:queued` on the issue. With a label prefix that becomes `<prefix>-retry:queued` — `scripts/hydra-label.sh` handles that automatically.
+2. Supervisor picks it up as a regular queue job.
+3. Orchestrator finds the open PR on `feature/<issue>/*`.
+4. Orchestrator clones development, copies `openspec/changes/<slug>/hydra.json` and runs `scripts/lib/build-feedback-brief.py` → writes `feedback.md` with (a) applier blockers, (b) unfixed reviewer findings, (c) already-fixed items, (d) Scope list of all flagged files.
+5. Orchestrator flips `retry:queued` → `retry:running`, dispatches the builder with `HYDRA_MODE=fix` and `feedback.md` mounted at `/workspace/feedback.md`.
+6. Builder reads the brief, fixes **all** findings in one pass, restricts itself to Scope files (plus new files explicitly required by a blocker), commits with `fix (retry):` messages, pushes.
+7. Success: orchestrator strips all review/applier labels + `retry:running` + `needs-input`, sets `code-review:queued`. Reviewers run again against the fixed code.
+8. Failure: `retry:running` → `needs-input`, a comment on the issue explains why and points to `rebuild:queued` as the next lever.
 
-**Geen loop.** Eén `retry:queued` = één iteratie. Als de fix-builder pusht en de volgende review weer faalt, kun je opnieuw `retry:queued` aanvragen — maar dat is dan een **nieuwe** single-shot, niet een auto-retry.
+**No loop.** One `retry:queued` = one iteration. If the fix builder pushes and the next review fails again, you can request another `retry:queued` — but that's then a **new** single-shot, not an auto-retry.
 
-## Wanneer is het de gate, en wanneer is het de builder?
+## When is it the gate, and when is it the builder?
 
-Een terugkerende valkuil uit eigen retrospectives: het issue gaat 3 keer naar `needs-input` om dezelfde reden — typisch `spdx-headers: fail` of een gelijksoortige mechanische gate. Iedere `retry:queued` reproduceert hetzelfde patroon.
+A recurring pitfall from our own retrospectives: the issue goes to `needs-input` 3 times for the same reason — typically `spdx-headers: fail` or a similar mechanical gate. Each `retry:queued` reproduces the same pattern.
 
-In dat geval is een vierde retry **niet** de juiste move. Wees discplineerd:
+In that case a fourth retry is **not** the right move. Be disciplined:
 
-1. **Sanity-check de gate zelf.** Is dit een fout-positief? (Zie deel 3.) Een klassieker: een grep zonder word-boundary die meer matcht dan bedoeld. Fix in dat geval `scripts/run-quality.sh` of de gate-skill.
-2. **Hand-fix de mechanische overtreding.** Soms is het sneller om zelf de SPDX-headers toe te voegen, te committen op de feature branch en de reviewers opnieuw aan te roepen via label-reset (situatie 2 hierboven). Tijd: minuten.
-3. **Overweeg een sterkere agent.** Als hetzelfde klasse-fout op meerdere repos dezelfde "blind spot" vertoont, is dat een signaal dat de huidige builder-prompt of de mechanische gate niet voldoende is. Open een issue in `hydra/` om de gate aan te scherpen of een "housekeeping"-agent te bouwen.
+1. **Sanity-check the gate itself.** Is this a false positive? (See part 3.) A classic: a grep without a word-boundary that matches more than intended. In that case fix `scripts/run-quality.sh` or the gate skill.
+2. **Hand-fix the mechanical violation.** Sometimes it's faster to add the SPDX headers yourself, commit on the feature branch, and call the reviewers again via a label reset (situation 2 above). Time: minutes.
+3. **Consider a stronger agent.** If the same class of mistake shows the same "blind spot" across multiple repos, that's a signal that the current builder prompt or the mechanical gate isn't enough. Open an issue in `hydra/` to tighten the gate or build a "housekeeping" agent.
 
-## Watch-list patronen
+## Watch-list patterns
 
-Patronen die we al hebben gezien en die het waard zijn om eerst tegen je situatie te leggen:
+Patterns we've already seen and that are worth comparing against your situation first:
 
 <HexCard title="spdx-headers + forbidden-patterns loop (2026-04-19)">
-  Op decidesk <a href="https://github.com/ConductionNL/decidesk/issues/44">#44</a>/<a href="https://github.com/ConductionNL/decidesk/issues/71">#71</a>/<a href="https://github.com/ConductionNL/decidesk/issues/72">#72</a> hetzelfde patroon: builder mist EUPL-1.2 header op nieuwe PHP-files, reviewer claimt 0 fixes nodig, recheck slaat rood. Forbidden-patterns bleek deels fout-positief (grep zonder word-boundary). Fix: handmatig SPDX toegevoegd + grep aangescherpt.
+  On decidesk <a href="https://github.com/ConductionNL/decidesk/issues/44">#44</a>/<a href="https://github.com/ConductionNL/decidesk/issues/71">#71</a>/<a href="https://github.com/ConductionNL/decidesk/issues/72">#72</a> the same pattern: builder missed the EUPL-1.2 header on new PHP files, reviewer claimed 0 fixes needed, recheck went red. Forbidden-patterns turned out to be partly false positive (grep without word-boundary). Fix: manually added SPDX + tightened the grep.
 </HexCard>
 
 <HexCard title="decidesk #44/#45 — gate-7 stub-method exploit (2026-04-23)">
-  Vijf onderscheiden pipeline-bugs in één retrospectief. Builder leverde op decidesk <a href="https://github.com/ConductionNL/decidesk/issues/44">#44</a>/<a href="https://github.com/ConductionNL/decidesk/issues/45">#45</a> een methode op met <code>return null;</code> + TODO; PHPCS slikte het; geen test; productie-bug. Resulteerde in <code>hydra-gate-stub-scan</code> + ADR-021 (bounded-fix scope op shape, niet op lijntelling). Volledige lessen in <a href="https://github.com/ConductionNL/hydra/blob/main/docs/retrospectives/decidesk-44-45-phase-g.md">decidesk-44-45-phase-g.md</a>.
+  Five distinct pipeline bugs in one retrospective. Builder delivered on decidesk <a href="https://github.com/ConductionNL/decidesk/issues/44">#44</a>/<a href="https://github.com/ConductionNL/decidesk/issues/45">#45</a> a method with <code>return null;</code> + TODO; PHPCS swallowed it; no test; production bug. Resulted in <code>hydra-gate-stub-scan</code> + ADR-021 (bounded-fix scope on shape, not on line count). Full lessons in <a href="https://github.com/ConductionNL/hydra/blob/main/docs/retrospectives/decidesk-44-45-phase-g.md">decidesk-44-45-phase-g.md</a>.
 </HexCard>
 
 <HexCard title="134 duplicate needs-input comments overnight (2026-04-23)">
-  Completion-handler in een tight loop poste elke tick een nieuwe escalation-comment op een al-terminaal issue. Fix: terminal-state guard vóór alle side-effects (zie CLAUDE.md sectie "Terminal-state guards"). Als jij een issue ziet met &gt;3 identieke needs-input comments: open een infra-bug, niet een retry.
+  Completion handler in a tight loop posted a new escalation comment every tick on an already-terminal issue. Fix: terminal-state guard before all side-effects (see CLAUDE.md section "Terminal-state guards"). If you see an issue with &gt;3 identical needs-input comments: open an infra bug, not a retry.
 </HexCard>
 
-## Diagnostics: waar kijk je?
+## Diagnostics: where do you look?
 
-Snelle checklist als een issue naar `needs-input` gaat:
+Quick checklist when an issue goes to `needs-input`:
 
 ```bash
-# 1. Welke labels staan er nu?
+# 1. Which labels are currently set?
 gh issue view <N> --repo ConductionNL/<app> --json labels --jq '[.labels[].name]'
 
-# 2. Wat zegt hydra.json (mits aanwezig op de feature branch)?
+# 2. What does hydra.json say (if present on the feature branch)?
 gh api repos/ConductionNL/<app>/contents/openspec/changes/<slug>/hydra.json?ref=feature/<N>/<slug> \
     --jq '.content' | base64 -d | jq '.cycles[-1] | {outcome, outcome_reason, pattern_tags}'
 
-# 3. De supervisor-log van de relevante tijdspanne
+# 3. The supervisor log for the relevant time window
 grep "issue/<N>" logs/supervisor.log | tail -50
 
-# 4. Pipeline-logs (per stage) op de feature branch
+# 4. Pipeline logs (per stage) on the feature branch
 gh api repos/ConductionNL/<app>/contents/openspec/changes/<slug>/pipeline-logs?ref=feature/<N>/<slug>
 ```
 
-`hydra.json` is je belangrijkste bron. De `outcome_reason` en `pattern_tags` van de laatste cycle leggen meestal in één regel uit wat er misging.
+`hydra.json` is your most important source. The `outcome_reason` and `pattern_tags` of the last cycle usually explain in a single line what went wrong.
 
-## Wanneer is "menselijk overnemen" gewoon goed?
+## When is "human takes over" simply the right call?
 
-Niet elk `needs-input`-issue verdient een geautomatiseerd fix-pad. Soms is de meest pragmatische actie: **mens neemt over, los het op in een eigen commit op de feature branch, push, mark resolved**.
+Not every `needs-input` issue deserves an automated fix path. Sometimes the most pragmatic action is: **human takes over, fixes it in a commit on the feature branch, pushes, marks resolved**.
 
-Voorbeelden:
+Examples:
 
-- Een kleine semantische beslissing die de Builder niet kan maken zonder context buiten de change (bijv. "moet dit veld optional of required zijn?").
-- Een interactie met een externe partij (open ticket bij een leverancier).
-- Een gate die fout-positief is en een fix in `hydra/` zelf vereist (waarover je niet binnen één retry-cyclus uit bent).
+- A small semantic decision the Builder can't make without context outside the change (e.g. "should this field be optional or required?").
+- An interaction with an external party (open ticket with a vendor).
+- A gate that is a false positive and requires a fix in `hydra/` itself (which you won't resolve within one retry cycle).
 
-Hydra is een fabriek, geen ideologie. Pak de menselijke shortcut als die billijker is.
+Hydra is a factory, not an ideology. Take the human shortcut when it's the fairer call.
 
-## Test jezelf
+## Test yourself
 
-Vier korte vragen om te checken of je dit deel begrepen hebt. Vastgelopen? Klik **Hint**. Curieus naar het antwoord? Klik **Antwoord**.
+Four short questions to check whether you've grasped this part. Stuck? Click **Hint**. Curious about the answer? Click **Answer**.
 
 <div className="tutorial-quiz">
 
-**1. In welke volgorde probeer je de interventies in de ladder, en waarom?**
+**1. In what order do you try the interventions in the ladder, and why?**
 
 <Details summary="Hint">
 
-Eén dimensie: kosten. De andere: hoeveel reeds-gedaan werk je verliest.
+One dimension: cost. The other: how much already-done work you lose.
 
 </Details>
 
-<Details summary="Antwoord">
+<Details summary="Answer">
 
-Van **goedkoop naar duur**, met als doel zo veel mogelijk reeds-gedaan werk te behouden:
+From **cheap to expensive**, with the goal of preserving as much already-done work as possible:
 
-1. **`gh pr update-branch`** — gratis. Alle build/review/applier-werk blijft staan, alleen dependencies vernieuwen.
-2. **Reviewer-labels resetten** — kost 2× reviewer + applier. Builder-output blijft.
-3. **`retry:queued`** — kost 1× builder + 2× reviewer + applier. Branch + PR blijven; builder fixed gescoped via `feedback.md`.
-4. **`rebuild:queued`** — volledige cyclus. PR sluit, branch reset, vanaf scratch.
-5. **Handmatige fix** — als de loop op een fout-positieve gate hangt of een mens een semantische beslissing moet maken.
+1. **`gh pr update-branch`** — free. All build/review/applier work stays, just refresh dependencies.
+2. **Reset reviewer labels** — costs 2× reviewer + applier. Builder output stays.
+3. **`retry:queued`** — costs 1× builder + 2× reviewer + applier. Branch + PR stay; builder fixes scoped via `feedback.md`.
+4. **`rebuild:queued`** — full cycle. PR closes, branch resets, from scratch.
+5. **Manual fix** — when the loop hangs on a false-positive gate or a human needs to make a semantic decision.
 
-Reach voor `rebuild:queued` alleen als de oorspronkelijke build fundamenteel verkeerd was; anders verspil je goed werk.
+Reach for `rebuild:queued` only if the original build was fundamentally wrong; otherwise you waste good work.
 
 </Details>
 
@@ -162,18 +162,18 @@ Reach voor `rebuild:queued` alleen als de oorspronkelijke build fundamenteel ver
 
 <div className="tutorial-quiz">
 
-**2. Wat is het verschil tussen "Reviewer-labels resetten" en `retry:queued`?**
+**2. What's the difference between "reset reviewer labels" and `retry:queued`?**
 
 <Details summary="Hint">
 
-De vraag is: **wordt de builder opnieuw aangeroepen, ja of nee?**
+The question is: **is the builder called again, yes or no?**
 
 </Details>
 
-<Details summary="Antwoord">
+<Details summary="Answer">
 
-- **Reviewer-labels resetten** (stage-labels strippen + `code-review:queued` opnieuw zetten): **de builder wordt NIET opnieuw aangeroepen**. PR + builder-output blijven exact zoals ze waren; alleen Juan en Clyde draaien opnieuw. Geschikt als de **review-contracten** zijn aangepast (nieuwe ADR, nieuwe gate-skill) en je wilt herbeoordelen zonder de code te veranderen.
-- **`retry:queued`**: **builder wordt wél opnieuw aangeroepen**, in `HYDRA_MODE=fix`, met `feedback.md` (uit `hydra.json`) als input. Hij maakt nieuwe commits, dan draaien reviewers opnieuw. Geschikt als reviewers **terechte findings** hadden en de builder alleen even moet bijschaven.
+- **Reset reviewer labels** (strip stage labels + set `code-review:queued` again): **the builder is NOT called again**. PR + builder output stay exactly as they were; only Juan and Clyde run again. Appropriate when the **review contracts** were adjusted (new ADR, new gate skill) and you want to re-judge without changing the code.
+- **`retry:queued`**: **the builder IS called again**, in `HYDRA_MODE=fix`, with `feedback.md` (from `hydra.json`) as input. It makes new commits, then reviewers run again. Appropriate when reviewers had **legitimate findings** and the builder just needs to polish.
 
 </Details>
 
@@ -181,24 +181,24 @@ De vraag is: **wordt de builder opnieuw aangeroepen, ja of nee?**
 
 <div className="tutorial-quiz">
 
-**3. Wanneer is het zinvoller om met de hand de fix te maken in plaats van opnieuw `retry:queued`?**
+**3. When does it make more sense to do the fix by hand instead of another `retry:queued`?**
 
 <Details summary="Hint">
 
-Als hetzelfde patroon zich herhaalt op dezelfde mechanische gate is meer geld erin gooien niet de oplossing.
+If the same pattern keeps repeating on the same mechanical gate, throwing more money at it is not the answer.
 
 </Details>
 
-<Details summary="Antwoord">
+<Details summary="Answer">
 
-Als hetzelfde issue **3 keer of vaker** naar `needs-input` is gegaan om dezelfde reden — typisch een mechanische gate zoals `spdx-headers: fail`. Iedere `retry:queued` reproduceert hetzelfde patroon: builder maakt dezelfde fout, reviewer ziet het als boilerplate, recheck slaat rood.
+When the same issue has gone to `needs-input` **3 times or more** for the same reason — typically a mechanical gate like `spdx-headers: fail`. Each `retry:queued` reproduces the same pattern: builder makes the same mistake, reviewer sees it as boilerplate, recheck goes red.
 
-In dat geval:
+In that case:
 
-- Check eerst of het een **fout-positieve gate** is (zie deel 3). Zo ja: gate-detectie aanscherpen.
-- Zo nee: **fix het met de hand** (bijv. zelf SPDX-headers committen op de feature branch) en gebruik label-reset om de reviewers opnieuw te laten oordelen.
+- First check whether it's a **false-positive gate** (see part 3). If so: tighten gate detection.
+- If not: **fix it by hand** (e.g. commit SPDX headers yourself on the feature branch) and use a label reset to have the reviewers judge again.
 
-Tijd: minuten. Goedkoper dan nog een Sonnet-cyclus verspillen aan iets wat steeds opnieuw fout gaat.
+Time: minutes. Cheaper than wasting another Sonnet cycle on something that keeps going wrong.
 
 </Details>
 
@@ -206,54 +206,54 @@ Tijd: minuten. Goedkoper dan nog een Sonnet-cyclus verspillen aan iets wat steed
 
 <div className="tutorial-quiz">
 
-**4. Wat doe je als je 3+ identieke `needs-input`-comments ziet binnen korte tijd?**
+**4. What do you do if you see 3+ identical `needs-input` comments within a short period?**
 
 <Details summary="Hint">
 
-Dit zegt iets over de pijplijn-zélf, niet over één issue. Welk soort fix is dat?
+This says something about the pipeline itself, not about one issue. What kind of fix is that?
 
 </Details>
 
-<Details summary="Antwoord">
+<Details summary="Answer">
 
-**Dit is een infra-bug, geen retry-vraag.** Ergens in de completion-handler ontbreekt een terminal-state guard, waardoor een tight loop elke tick een nieuwe escalation-comment plaatst op een al-terminaal issue. Voorbeeld: 134 duplicate comments overnight op 23 april 2026 — fix was een terminal-state guard vóór alle side-effects (zie CLAUDE.md sectie "Terminal-state guards").
+**This is an infra bug, not a retry question.** Somewhere in the completion handler a terminal-state guard is missing, causing a tight loop to post a new escalation comment every tick on an already-terminal issue. Example: 134 duplicate comments overnight on 23 April 2026 — the fix was a terminal-state guard before all side-effects (see CLAUDE.md section "Terminal-state guards").
 
-**Wat doe je:** open een **infra-issue** in `hydra/`, niet een nieuwe `retry:queued`. Een retry doet niets met de comment-storm en kan zelfs meer chaos toevoegen.
+**What you do:** open an **infra issue** in `hydra/`, not another `retry:queued`. A retry does nothing about the comment storm and may even add more chaos.
 
 </Details>
 
 </div>
 
-<NextSteps title="Klaar — wat nu?" lede="Je hebt de hele leerlijn doorlopen. Wat is verstandig daarna?">
+<NextSteps title="Done — what now?" lede="You've worked through the whole tutorial series. What's sensible next?">
   <NextStep
-    title="Vorige stap — Een Hydra-run starten"
+    title="Previous step — Starting a Hydra run"
     href="/academy/hydra-tutorial-5-een-hydra-run-starten"
-    description="Voor de praktische config en HYDRA_LABEL_PREFIX-uitleg."
+    description="For the practical config and HYDRA_LABEL_PREFIX explanation."
   />
   <NextStep
-    title="OpenSpec-leerlijn"
+    title="OpenSpec tutorial series"
     href="/academy/openspec-tutorial-1-wat-is-openspec"
-    description="De spec-first basis waar Hydra op draait. Nuttig als je nog niet helemaal vlot bent met proposal, change en spec-delta — termen die in elke retrospectief terugkomen."
+    description="The spec-first foundation Hydra runs on. Useful if you're not yet fluent with proposal, change and spec delta — terms that come back in every retrospective."
   />
   <NextStep
-    title="Claude Skills-leerlijn"
+    title="Claude Skills tutorial series"
     href="/academy/claude-skills-tutorial-1-wat-zijn-claude-skills"
-    description="Wil je een eigen skill toevoegen aan de Hydra-loop (een nieuwe quality gate, een team-skill voor je eigen app)? Hier leer je hoe."
+    description="Want to add your own skill to the Hydra loop (a new quality gate, a team skill for your own app)? Here you'll learn how."
   />
   <NextStep
     title="Retrospectives"
     href="https://github.com/ConductionNL/hydra/tree/main/docs/retrospectives"
-    description="Pak een retrospectief — bijvoorbeeld decidesk-44-45-phase-g — en herken de patronen die we hier behandelden."
+    description="Pick a retrospective — say decidesk-44-45-phase-g — and recognise the patterns we covered here."
   />
   <NextStep
-    title="Doe een peer review"
+    title="Do a peer review"
     href="mailto:wilco@conduction.nl?subject=Hydra%20leerlijn%20-%20peer%20review"
-    description="Laat iemand uit het Hydra-team door je eerste eigen run lopen. Verplichte stap volgens het oorspronkelijke issue."
+    description="Have someone from the Hydra team walk through your first own run with you. Required step per the original issue."
   />
 </NextSteps>
 
 <ContactCta
-  title="Je hebt de Hydra-leerlijn afgerond"
-  body="Vragen, feedback, of suggesties voor uitbreiding? Laat het weten — deze leerlijn evolueert met ons begrip van de pijplijn."
-  cta={{ label: "Stuur feedback", href: "mailto:wilco@conduction.nl?subject=Hydra%20leerlijn%20feedback" }}
+  title="You've completed the Hydra tutorial series"
+  body="Questions, feedback, or suggestions for extension? Let us know — this tutorial series evolves with our understanding of the pipeline."
+  cta={{ label: "Send feedback", href: "mailto:wilco@conduction.nl?subject=Hydra%20leerlijn%20feedback" }}
 />

--- a/academy/2026-05-12-hydra-tutorial-6-troubleshooting-escalatie/index.mdx
+++ b/academy/2026-05-12-hydra-tutorial-6-troubleshooting-escalatie/index.mdx
@@ -51,8 +51,8 @@ Your role as a human: decide which of the four options below is the best fit and
 |---|---|---|---|---|
 | 1 | Development has moved on, PR is stale (new lint rules, ADRs, fixtures on development) | <code>gh pr update-branch &lt;N&gt;</code> (or the cron picks it up) | Free | All build/review/applier work. Just refresh dependencies. |
 | 2 | Review contracts were adjusted and you want reviewers to judge again without a rebuild | Reset reviewer labels: strip stage labels, set <code>code-review:queued</code> again. PR stays. | 2× reviewer + applier | The builder output. Only the review part rewinds. |
-| 3 | Reviewers/applier flagged concrete findings and the builder just needs to polish | Stick <code>retry:queued</code> on the issue | 1× builder + 2× reviewer + applier | Branch + PR stay. Orchestrator builds <code>feedback.md</code> from <code>hydra.json</code> (unfixed + applier blockers + already-fixed) and dispatches builder in <code>HYDRA_MODE=fix</code>. Single shot — no loop. |
-| 4 | Builder output was fundamentally wrong (wrong approach, stub implementation, missed core requirements) | Stick <code>rebuild:queued</code> on the issue | Full cycle | Orchestrator closes the open PR, hard-resets <code>feature/&lt;issue&gt;/*</code> to development, strips all cycle labels, sets <code>build:queued</code>. Next cycle starts from scratch. |
+| 3 | Reviewers/applier flagged concrete findings and the builder just needs to polish | Remove <code>needs-input</code> + fail labels first, then add <code>retry:queued</code> (see below) | 1× builder + 2× reviewer + applier | Branch + PR stay. Orchestrator builds <code>feedback.md</code> from <code>hydra.json</code> (unfixed + applier blockers + already-fixed) and dispatches builder in <code>HYDRA_MODE=fix</code>. Single shot — no loop. |
+| 4 | Builder output was fundamentally wrong (wrong approach, stub implementation, missed core requirements) | Remove <code>needs-input</code> + fail labels first, then add <code>rebuild:queued</code> (see below) | Full cycle | Orchestrator closes the open PR, hard-resets <code>feature/&lt;issue&gt;/*</code> to development, strips all cycle labels, sets <code>build:queued</code>. Next cycle starts from scratch. |
 | 5 | You closed the PR yourself and stale labels are still on the issue | Wait for <code>reconcile.sh</code> (every 10 min) | Next reconcile run | <code>check_stage_without_open_pr</code> sees the inconsistency and automatically sets <code>build:queued</code>. Self-healing. |
 | 6 | Pipeline infra is broken (container crash, all tokens exhausted, image not findable) | Escalate to a human (you or a team lead), fix infra, and only THEN pick one of 1-4 above | Time | — |
 
@@ -60,16 +60,57 @@ Your role as a human: decide which of the four options below is the best fit and
 
 ### `retry:queued` in detail
 
-1. You (or an automated rule) stick `retry:queued` on the issue. With a label prefix that becomes `<prefix>-retry:queued` — `scripts/hydra-label.sh` handles that automatically.
-2. Supervisor picks it up as a regular queue job.
-3. Orchestrator finds the open PR on `feature/<issue>/*`.
-4. Orchestrator clones development, copies `openspec/changes/<slug>/hydra.json` and runs `scripts/lib/build-feedback-brief.py` → writes `feedback.md` with (a) applier blockers, (b) unfixed reviewer findings, (c) already-fixed items, (d) Scope list of all flagged files.
-5. Orchestrator flips `retry:queued` → `retry:running`, dispatches the builder with `HYDRA_MODE=fix` and `feedback.md` mounted at `/workspace/feedback.md`.
-6. Builder reads the brief, fixes **all** findings in one pass, restricts itself to Scope files (plus new files explicitly required by a blocker), commits with `fix (retry):` messages, pushes.
-7. Success: orchestrator strips all review/applier labels + `retry:running` + `needs-input`, sets `code-review:queued`. Reviewers run again against the fixed code.
-8. Failure: `retry:running` → `needs-input`, a comment on the issue explains why and points to `rebuild:queued` as the next lever.
+:::warning Label cleanup is required first
+The supervisor **will not dispatch `retry:queued` while `needs-input` is still on the issue.** You must remove stale labels before applying the trigger — otherwise the issue sits in the queue forever and nothing moves.
+:::
+
+**Before adding `retry:queued`, run these commands** (use `scripts/hydra-label.sh` — it keeps the project board in sync):
+
+```bash
+# Remove stale labels
+./scripts/hydra-label.sh ConductionNL/<app> <issue> remove needs-input
+./scripts/hydra-label.sh ConductionNL/<app> <issue> remove code-review:fail
+./scripts/hydra-label.sh ConductionNL/<app> <issue> remove security-review:fail
+
+# Now apply the trigger
+./scripts/hydra-label.sh ConductionNL/<app> <issue> add retry:queued
+```
+
+If you're running with `HYDRA_LABEL_PREFIX` (e.g. `wilco`), strip the prefixed variants too:
+
+```bash
+./scripts/hydra-label.sh ConductionNL/<app> <issue> remove wilco-needs-input
+./scripts/hydra-label.sh ConductionNL/<app> <issue> remove wilco-code-review:fail
+./scripts/hydra-label.sh ConductionNL/<app> <issue> remove wilco-security-review:fail
+./scripts/hydra-label.sh ConductionNL/<app> <issue> add wilco-retry:queued
+```
+
+See the [retry-and-rebuild operations guide](https://github.com/ConductionNL/hydra/blob/main/docs/operations/retry-and-rebuild.md) for the full checklist and `rebuild:queued` equivalent.
+
+**What happens next:**
+
+1. Supervisor picks up `retry:queued` as a regular queue job.
+2. Orchestrator finds the open PR on `feature/<issue>/*`.
+3. Orchestrator clones development, copies `openspec/changes/<slug>/hydra.json` and runs `scripts/lib/build-feedback-brief.py` → writes `feedback.md` with (a) applier blockers, (b) unfixed reviewer findings, (c) already-fixed items, (d) Scope list of all flagged files.
+4. Orchestrator flips `retry:queued` → `retry:running`, dispatches the builder with `HYDRA_MODE=fix` and `feedback.md` mounted at `/workspace/feedback.md`.
+5. Builder reads the brief, fixes **all** findings in one pass, restricts itself to Scope files (plus new files explicitly required by a blocker), commits with `fix (retry):` messages, pushes.
+6. Success: orchestrator strips all review/applier labels + `retry:running`, sets `code-review:queued`. Reviewers run again against the fixed code.
+7. Failure: `retry:running` → `needs-input`, a comment on the issue explains why and points to `rebuild:queued` as the next lever.
 
 **No loop.** One `retry:queued` = one iteration. If the fix builder pushes and the next review fails again, you can request another `retry:queued` — but that's then a **new** single-shot, not an auto-retry.
+
+### `rebuild:queued` in detail
+
+Same label cleanup requirement as `retry:queued` — the supervisor won't dispatch while `needs-input` is set:
+
+```bash
+./scripts/hydra-label.sh ConductionNL/<app> <issue> remove needs-input
+./scripts/hydra-label.sh ConductionNL/<app> <issue> remove code-review:fail
+./scripts/hydra-label.sh ConductionNL/<app> <issue> remove security-review:fail
+./scripts/hydra-label.sh ConductionNL/<app> <issue> add rebuild:queued
+```
+
+Do **not** close the PR yourself first — the orchestrator closes it as part of the reset sequence. If you already closed it, `reconcile.sh` (runs every 10 min) will detect the inconsistency and auto-set `build:queued`.
 
 ## When is it the gate, and when is it the builder?
 

--- a/academy/2026-05-12-openspec-tutorial-1-wat-is-openspec/index.mdx
+++ b/academy/2026-05-12-openspec-tutorial-1-wat-is-openspec/index.mdx
@@ -1,10 +1,10 @@
 ---
 slug: openspec-tutorial-1-wat-is-openspec
-title: "OpenSpec leerlijn — Deel 1: Wat is OpenSpec?"
+title: "OpenSpec tutorial series — Part 1: What is OpenSpec?"
 contentType: tutorial
 authors: [conduction]
 date: 2026-05-12
-summary: Een korte introductie op OpenSpec, het spec-first framework dat onder vrijwel al onze projecten draait. Wat een spec is, wat een change is, en waarom we dingen eerst opschrijven voor we ze bouwen. Eerste van twee korte modules.
+summary: A short introduction to OpenSpec, the spec-first framework underneath almost every Conduction project. What a spec is, what a change is, and why we write things down before we build them. First of two short modules.
 tags: [OpenSpec, Spec-first, Tutorial series, Documentation]
 apps: []
 durationMinutes: 12
@@ -15,195 +15,195 @@ partNumber: 1
 import {Outcomes, Outcome, Prerequisites, PrerequisiteItem, NextSteps, NextStep, HexCard, ContactCta} from '@conduction/docusaurus-preset/components';
 import Details from '@theme/Details';
 
-[OpenSpec](https://openspec.dev) is een lichtgewicht framework voor **spec-driven development**: eerst opschrijven wat een feature moet doen, dan pas code schrijven. In deze module van twaalf minuten leer je wat OpenSpec is, welke begrippen erin zitten, en waarom we het bij Conduction onder vrijwel elk project gebruiken. Aan het eind sta je klaar voor deel 2, waarin je je eerste change daadwerkelijk schrijft.
+[OpenSpec](https://openspec.dev) is a lightweight framework for **spec-driven development**: first write down what a feature should do, only then write the code. In this twelve-minute module you'll learn what OpenSpec is, which concepts it builds on, and why we use it underneath almost every Conduction project. By the end you're ready for Part 2, where you'll actually write your first change.
 
 {/* truncate */}
 
-<Outcomes title="Wat je leert in dit deel">
-  <Outcome>Wat OpenSpec is in één zin, en wat het verschil is met een losse README of een ticket.</Outcome>
-  <Outcome>De vier kernbegrippen: <strong>spec</strong>, <strong>requirement</strong>, <strong>scenario</strong> en <strong>change</strong> — en hoe ze samenhangen.</Outcome>
-  <Outcome>Waarom we spec-first werken, en wanneer dat zichzelf terugverdient.</Outcome>
-  <Outcome>Hoe een OpenSpec-project op schijf is opgebouwd, zodat je weet waar je moet kijken.</Outcome>
+<Outcomes title="What you'll learn in this part">
+  <Outcome>What OpenSpec is in one sentence, and how it differs from a stray README or a ticket.</Outcome>
+  <Outcome>The four core concepts: <strong>spec</strong>, <strong>requirement</strong>, <strong>scenario</strong> and <strong>change</strong> — and how they relate.</Outcome>
+  <Outcome>Why we work spec-first, and when that investment pays off.</Outcome>
+  <Outcome>How an OpenSpec project is laid out on disk, so you know where to look.</Outcome>
 </Outcomes>
 
-<Prerequisites title="Wat je nodig hebt">
-  <PrerequisiteItem>Basiskennis Git en Markdown. We schrijven specs in <code>.md</code>-bestanden die in je repo leven.</PrerequisiteItem>
-  <PrerequisiteItem>Een werkende ontwikkelmachine. Heb je die nog niet? Volg eerst <a href="/academy/nextcloud-lokaal-draaien">Nextcloud lokaal draaien met Docker</a>.</PrerequisiteItem>
-  <PrerequisiteItem>Toegang tot een Conduction-project waarin je rondkijken kan — een willekeurige app zoals <a href="https://github.com/ConductionNL/openregister">openregister</a> of <a href="https://github.com/ConductionNL/opencatalogi">opencatalogi</a> volstaat.</PrerequisiteItem>
+<Prerequisites title="What you'll need">
+  <PrerequisiteItem>Basic Git and Markdown. We write specs in <code>.md</code> files that live in your repo.</PrerequisiteItem>
+  <PrerequisiteItem>A working dev machine. Don't have one yet? Start with <a href="/academy/nextcloud-lokaal-draaien">Running Nextcloud locally with Docker</a>.</PrerequisiteItem>
+  <PrerequisiteItem>Access to a Conduction project to poke around in — any app like <a href="https://github.com/ConductionNL/openregister">openregister</a> or <a href="https://github.com/ConductionNL/opencatalogi">opencatalogi</a> will do.</PrerequisiteItem>
 </Prerequisites>
 
-## In één zin
+## In one sentence
 
-OpenSpec is een **lichtgewicht conventie voor het bijhouden van requirements naast je code**. De spec leeft in je repo, in Markdown, en evolueert per change in een nette spec-delta — net zoals je code evolueert per commit.
+OpenSpec is a **lightweight convention for keeping requirements alongside your code**. The spec lives in your repo, in Markdown, and evolves change by change as a clean spec-delta — just like your code evolves commit by commit.
 
-Geen Confluence-pagina die uit sync raakt met de code. Geen Jira-ticket dat alleen jij begrijpt. Geen losse README waarin de echte regels verstopt zitten tussen voorbeelden. Eén plek voor het *wat*, één plek voor het *hoe*.
+No Confluence page drifting out of sync with the code. No Jira ticket only you understand. No stray README with the real rules buried between examples. One place for the *what*, one place for the *how*.
 
-## Waarom spec-first?
+## Why spec-first?
 
-In de praktijk gaat code schrijven sneller dan een spec bedenken. Dus waarom eerst die extra stap?
+In practice, writing code is faster than coming up with a spec. So why the extra step?
 
-1. **Aannames vroeg blootleggen.** Wat lijkt op één feature blijkt vaak vier features tegelijk. Door eerst de scenario's op te schrijven, ontdek je gaten en tegenstrijdigheden vóór de code geschreven is — niet erna in een PR-review.
-2. **AI-agenten productief maken.** Onze [Hydra-pipeline](/academy/hydra-tutorial-1-wat-is-hydra) bouwt code uit specs. Hoe scherper de spec, hoe minder bijsturen achteraf. Dezelfde wet geldt voor je menselijke teamleden in een handover.
-3. **Een audit-trail die niet jokt.** Elke change zit in een eigen mapje met een proposal, een spec-delta, een design en een takenlijst. Een halfjaar later weet je nog precies wat er besloten is en waarom.
-4. **Reviewers één bron.** Reviewer ziet de spec-delta en de code naast elkaar. Klopt de code met de spec? Niet "wat had de ontwikkelaar bedoeld", maar "wat staat er".
+1. **Surface assumptions early.** What looks like one feature often turns out to be four features at once. By writing the scenarios first, you spot gaps and contradictions *before* the code is written — not after, in a PR review.
+2. **Make AI agents productive.** Our [Hydra pipeline](/academy/hydra-tutorial-1-wat-is-hydra) builds code from specs. The sharper the spec, the less course-correction afterwards. The same rule applies to a human teammate picking up a handover.
+3. **An audit trail that doesn't lie.** Every change lives in its own folder with a proposal, a spec-delta, a design and a task list. Six months later you can still see exactly what was decided and why.
+4. **One source for reviewers.** The reviewer sees the spec-delta and the code side by side. Does the code match the spec? Not "what did the developer mean", but "what does it say".
 
-## De vier kernbegrippen
+## The four core concepts
 
-OpenSpec rust op vier woorden die je terug zult zien in elk project. Een halfuur investeren in deze begrippen scheelt later veel verwarring.
+OpenSpec rests on four words you'll keep seeing across projects. Half an hour invested in these terms saves a lot of confusion later.
 
 <HexCard title="Spec (capability)">
-  De stabiele beschrijving van een capability — een coherent stuk gedrag dat de app aanbiedt. Eén spec per capability. Lange leefduur.
+  The stable description of a capability — a coherent piece of behaviour the app offers. One spec per capability. Long-lived.
 </HexCard>
 
 <HexCard title="Requirement">
-  Eén regel binnen een spec. Geschreven met <strong>MUST / SHOULD / MAY</strong> (RFC 2119). Genummerd als <code>REQ-001</code>, <code>REQ-002</code>, enzovoort.
+  A single rule inside a spec. Written with <strong>MUST / SHOULD / MAY</strong> (RFC 2119). Numbered <code>REQ-001</code>, <code>REQ-002</code>, and so on.
 </HexCard>
 
 <HexCard title="Scenario">
-  Concreet voorbeeld bij een requirement, in <strong>GIVEN / WHEN / THEN</strong>-vorm. Toetsbaar, niet beschrijvend. Per requirement minstens één.
+  A concrete example for a requirement, in <strong>GIVEN / WHEN / THEN</strong> form. Testable, not descriptive. At least one per requirement.
 </HexCard>
 
 <HexCard title="Change">
-  Eén verandering aan een of meer specs. Tijdelijk: begint als voorstel, eindigt gearchiveerd. Bevat een proposal, een spec-delta en een takenlijst.
+  A single edit to one or more specs. Temporary: starts as a proposal, ends archived. Contains a proposal, a spec-delta and a task list.
 </HexCard>
 
-### Hoe ze samenhangen
+### How they fit together
 
 ```
 openspec/
-├── specs/                          ← stabiel — capabilities
-│   └── publications/spec.md        ← bevat REQ-001, REQ-002, … en scenarios
-└── changes/                        ← tijdelijk — wijzigingen in flight
+├── specs/                          ← stable — capabilities
+│   └── publications/spec.md        ← contains REQ-001, REQ-002, … and scenarios
+└── changes/                        ← temporary — in-flight changes
     └── add-publication-search/
-        ├── proposal.md             ← waarom en wat
+        ├── proposal.md             ← why and what
         ├── specs/publications/     ← ADDED / MODIFIED / REMOVED requirements
         │   └── spec.md
-        ├── design.md               ← hoe (technisch)
-        └── tasks.md                ← implementatie-checklist
+        ├── design.md               ← how (technical)
+        └── tasks.md                ← implementation checklist
 ```
 
-Een **change** voegt requirements toe aan, wijzigt of verwijdert requirements uit een **spec**. Zolang de change open staat, leeft de delta in `changes/`. Bij archivering verhuist de delta naar de hoofd-spec en gaat het hele mapje naar `changes/archive/YYYY-MM-DD-<name>/`. Daarmee houd je een complete geschiedenis.
+A **change** adds, modifies or removes requirements in a **spec**. While the change is open, the delta lives in `changes/`. On archive, the delta merges into the main spec and the entire folder moves to `changes/archive/YYYY-MM-DD-<name>/`. That keeps the full history intact.
 
-## Een requirement in het wild
+## A requirement in the wild
 
-Even concreet. Dit is een echte requirement zoals je ze in onze repos tegenkomt:
+To make it concrete — here is an actual requirement of the kind you'll meet in our repos:
 
 ```markdown
-### REQ-001: Volledige tekstzoekfunctie
-Het systeem MOET full-text zoeken ondersteunen over publicatie-titels
-en -inhoud met behulp van PostgreSQL's tsvector.
+### REQ-001: Full-text search
+The system MUST support full-text search across publication titles
+and content using PostgreSQL's tsvector.
 
-#### Scenario: Zoekopdracht levert overeenkomende publicaties op
-- GIVEN publicaties met titels "Klimaatrapport 2026" en "Begrotingsoverzicht"
-- WHEN een gebruiker zoekt op "klimaat"
-- THEN MOETEN de resultaten "Klimaatrapport 2026" bevatten
-- AND MOGEN de resultaten "Begrotingsoverzicht" NIET bevatten
-- AND MOETEN de resultaten op relevantiescore gesorteerd zijn
+#### Scenario: Search query returns matching publications
+- GIVEN publications with titles "Climate Report 2026" and "Budget Overview"
+- WHEN a user searches for "climate"
+- THEN the results MUST contain "Climate Report 2026"
+- AND the results MUST NOT contain "Budget Overview"
+- AND the results MUST be sorted by relevance score
 ```
 
-Drie dingen om te zien:
+Three things to notice:
 
-- **MOET** is geen stijlkeuze. RFC 2119 maakt onderscheid tussen MUST (absoluut), SHOULD (sterk aanbevolen, uitzonderingen mogelijk) en MAY (optioneel). Een reviewer leest dat woord en weet wat de bedoeling is.
-- Het **scenario** is concreet genoeg om een test uit te schrijven. Iemand anders zou hetzelfde gedrag moeten kunnen bouwen zonder met je te overleggen.
-- **Implementatie-vrij.** Geen klassennamen, geen controllers, geen tabelnamen. Die horen in `design.md`, niet hier. De spec beschrijft *gedrag*, niet *implementatie*.
+- **MUST** is not a stylistic choice. RFC 2119 distinguishes MUST (absolute), SHOULD (strongly recommended, exceptions allowed) and MAY (optional). A reviewer reads that word and knows the intent.
+- The **scenario** is concrete enough that you could write a test from it. Someone else should be able to build the same behaviour without checking back with you.
+- **Implementation-free.** No class names, no controllers, no table names. Those belong in `design.md`, not here. The spec describes *behaviour*, not *implementation*.
 
 ## Spec versus README versus issue
 
-Een veel gestelde vraag bij nieuwe mensen: "wat schrijf ik dan nog in de README, en wat in een issue?" Eenvoudige vuistregel:
+A common question from newcomers: "so what do I still put in the README, and what goes in an issue?" Simple rule of thumb:
 
-| Document | Bevat | Lezer | Updatefrequentie |
+| Document | Contains | Reader | Update frequency |
 | --- | --- | --- | --- |
-| **`openspec/specs/`** | Het *wat* — requirements en scenario's. Stabiel gedrag van de app. | Reviewers, AI-agenten, latere developers | Per change |
-| **`openspec/changes/`** | Een *verandering* — voorstel, delta, design en tasks van één in-flight change. | Reviewers tijdens de PR | Eénmalig per change |
-| **`README.md`** | Hoe zet je de app op. Hoe draai je hem. Hoe lever je iets aan. | Nieuwe developers, eerste sessie | Bij doorbroken setup-stap |
-| **GitHub Issue** | Eén concrete taak — gekoppeld aan een change. Status, blocker, discussie. | Wie de taak oppakt | Continu tijdens het werk |
+| **`openspec/specs/`** | The *what* — requirements and scenarios. Stable behaviour of the app. | Reviewers, AI agents, future developers | Per change |
+| **`openspec/changes/`** | A *change* — proposal, delta, design and tasks for one in-flight change. | Reviewers during the PR | Once per change |
+| **`README.md`** | How to set up the app. How to run it. How to contribute. | New developers, first session | When a setup step breaks |
+| **GitHub Issue** | One concrete task — tied to a change. Status, blocker, discussion. | Whoever picks up the task | Continuously during the work |
 
-De gulden regel: **gedrag van de app hoort in de spec**. Als je merkt dat je hetzelfde uitlegt in een ticket, een Slack-bericht en de PR-beschrijving, mis je vermoedelijk een spec.
+The golden rule: **behaviour of the app belongs in the spec**. If you find yourself explaining the same thing in a ticket, a Slack message and the PR description, you're probably missing a spec.
 
-## Wanneer geen OpenSpec?
+## When not to use OpenSpec?
 
-Spec-first is geen religie. Twee situaties waarin we het overslaan:
+Spec-first is not a religion. Two situations where we skip it:
 
-- **Een eenmalige tweak** — typo's, één rij toevoegen aan een vertaalbestand, een dependency bumpen. Spec-overhead is hier groter dan de tweak zelf.
-- **Een exploratief prototype** — als je nog niet weet of het idee überhaupt werkt. Toets je aannames eerst met een wegwerp-prototype; schrijf pas daarna de spec voor de versie die wél in productie gaat.
+- **A one-off tweak** — typos, adding a single row to a translation file, bumping a dependency. The spec overhead outweighs the tweak itself.
+- **An exploratory prototype** — when you don't even know whether the idea works yet. Test your assumptions with a throwaway prototype first; only write the spec for the version that's actually going into production.
 
-Voor alles daartussen — een nieuwe feature, een breaking change, een refactor met gevolgen voor consumers — loont OpenSpec zich.
+For everything in between — a new feature, a breaking change, a refactor that affects consumers — OpenSpec earns its keep.
 
-## Hoe ziet een Conduction-repo eruit?
+## What does a Conduction repo look like?
 
-Onze projecten hebben allemaal dezelfde OpenSpec-mappenstructuur. Eén keer kijken in [openregister/openspec](https://github.com/ConductionNL/openregister/tree/development/openspec) geeft je een goed beeld:
+All our projects share the same OpenSpec folder layout. One look at [openregister/openspec](https://github.com/ConductionNL/openregister/tree/development/openspec) gives you a good picture:
 
-- `openspec/specs/` — de capabilities van deze app, één map per domein
-- `openspec/changes/` — de in-flight changes (vaak één per open PR)
-- `openspec/changes/archive/` — afgeronde changes, met datum vooraan, voor de geschiedenis
-- `openspec/architecture/` — **app-specifieke** ADR's (architecturele besluiten die alleen voor deze app gelden)
-- `openspec/config.yaml` — project-config (verwijst naar het gedeelde Conduction-schema)
-- `project.md` — high-level beschrijving van de app, in de **root** van de repo (niet in `openspec/`)
+- `openspec/specs/` — the capabilities of this app, one folder per domain
+- `openspec/changes/` — in-flight changes (often one per open PR)
+- `openspec/changes/archive/` — completed changes, date-prefixed, for the history
+- `openspec/architecture/` — **app-specific** ADRs (architectural decisions that only apply to this app)
+- `openspec/config.yaml` — project config (points at the shared Conduction schema)
+- `project.md` — high-level description of the app, in the repo **root** (not under `openspec/`)
 
-**Bedrijfsbrede** ADR's leven niet in elke app, maar in [hydra/openspec/architecture](https://github.com/ConductionNL/hydra/tree/main/openspec/architecture). Bouw je in een app van Conduction? Dan gelden die ADR's ook voor jou — de Hydra-pipeline laadt ze mee in elke build. Vuistregel: alleen iets wat écht uniek is voor deze app gaat in `openspec/architecture/`; al het andere hoort bedrijfsbreed in `hydra/openspec/architecture/`.
+**Company-wide** ADRs do not live in every app — they live in [hydra/openspec/architecture](https://github.com/ConductionNL/hydra/tree/main/openspec/architecture). Building inside a Conduction app? Then those ADRs apply to you too — the Hydra pipeline loads them into every build. Rule of thumb: only something that is *truly unique* to this app goes in `openspec/architecture/`; everything else belongs company-wide in `hydra/openspec/architecture/`.
 
-## Wie schrijft de specs?
+## Who writes the specs?
 
-Twee patronen, naast elkaar:
+Two patterns, side by side:
 
-1. **Handmatig door een developer of architect** — met [`/opsx-new`](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md#opsx-new) om de change-map aan te maken, gevolgd door [`/opsx-ff`](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md#opsx-ff) (alles in één run) of [`/opsx-continue`](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md#opsx-continue) (artefact voor artefact) in Claude Code. Dat is wat je in deel 2 gaat doen.
-2. **Retrofit op een bestaande app** — voor legacy-code die er was vóór OpenSpec. Zie [retrofit.md](https://github.com/ConductionNL/.github/blob/main/docs/claude/retrofit.md). Niet je eerste klus.
+1. **Manually, by a developer or architect** — use [`/opsx-new`](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md#opsx-new) to create the change folder, then [`/opsx-ff`](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md#opsx-ff) (everything in one run) or [`/opsx-continue`](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md#opsx-continue) (artefact by artefact) in Claude Code. That's what you'll do in Part 2.
+2. **Retrofit on an existing app** — for legacy code that predates OpenSpec. See [retrofit.md](https://github.com/ConductionNL/.github/blob/main/docs/claude/retrofit.md). Not your first job.
 
-Welke route ook gebruikt wordt, het eindresultaat ziet er identiek uit: een nette change in `openspec/changes/` met de vier verwachte artefacten.
+Whichever route you take, the end result is identical: a clean change in `openspec/changes/` with the four expected artefacts.
 
-## De OpenSpec-pipeline in één oogopslag
+## The OpenSpec pipeline at a glance
 
-Een volledige change loopt door vier stages, met een eigen `/opsx-`-commando per stap. Bron: [spec-driven-development.md](https://github.com/ConductionNL/.github/blob/main/docs/WayOfWork/spec-driven-development.md).
+A complete change moves through four stages, each with its own `/opsx-` command. Source: [spec-driven-development.md](https://github.com/ConductionNL/.github/blob/main/docs/WayOfWork/spec-driven-development.md).
 
-| Stage | Commando | Wat doet het |
+| Stage | Command | What it does |
 | --- | --- | --- |
-| **Obtain** | [`/opsx-explore`](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md#opsx-explore) | Verken een topic of probleem voor je een change start (optioneel) |
-| **Specify** | [`/opsx-new`](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md#opsx-new) | Lege change met metadata aanmaken |
-| | [`/opsx-ff`](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md#opsx-ff) | Fast-forward: proposal + specs + design + tasks in één run |
-| | [`/opsx-continue`](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md#opsx-continue) | Per-artefact opbouwen i.p.v. alles in één keer |
-| | [`/opsx-plan-to-issues`](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md) | Tasks → tracking-issue + één GitHub-issue per task |
-| **Build** | [`/opsx-apply`](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md#opsx-apply) | Implementeer de tasks, één voor één, tegen de spec |
-| **Validate** | [`/opsx-verify`](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md#opsx-verify) | Check dat de code de spec ook echt levert |
-| **Done** | [`/opsx-archive`](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md#opsx-archive) | Spec-delta → hoofd-spec; change → `archive/` |
-| | [`/opsx-sync`](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md#opsx-sync) | Alleen de delta in de hoofd-spec mergen (zonder archiveren). `/opsx-archive` doet dit ook — sync apart is voor als je de spec eerder wilt bijwerken dan de change afsluiten. |
+| **Obtain** | [`/opsx-explore`](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md#opsx-explore) | Explore a topic or problem before starting a change (optional) |
+| **Specify** | [`/opsx-new`](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md#opsx-new) | Create an empty change with metadata |
+| | [`/opsx-ff`](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md#opsx-ff) | Fast-forward: proposal + specs + design + tasks in one run |
+| | [`/opsx-continue`](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md#opsx-continue) | Build artefact by artefact instead of all at once |
+| | [`/opsx-plan-to-issues`](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md) | Tasks → tracking issue + one GitHub issue per task |
+| **Build** | [`/opsx-apply`](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md#opsx-apply) | Implement the tasks one by one, against the spec |
+| **Validate** | [`/opsx-verify`](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md#opsx-verify) | Check that the code actually delivers the spec |
+| **Done** | [`/opsx-archive`](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md#opsx-archive) | Spec-delta → main spec; change → `archive/` |
+| | [`/opsx-sync`](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md#opsx-sync) | Merge only the delta into the main spec (without archiving). `/opsx-archive` also does this — running sync separately is for when you want the spec updated before closing the change. |
 
-**De gulden vuistregel uit de Conduction-docs**: *de meeste changes hebben alleen `/opsx-ff` → `/opsx-apply` → `/opsx-verify` nodig*. De rest is opt-in. Volledig automatisch werken kan ook — zie [`/opsx-apply-loop`](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md#opsx-apply-loop) (één change, containerized) en [`/opsx-pipeline`](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md#opsx-pipeline) (meerdere changes parallel).
+**The golden rule from the Conduction docs**: *most changes only need `/opsx-ff` → `/opsx-apply` → `/opsx-verify`*. The rest is opt-in. Fully automated runs are also an option — see [`/opsx-apply-loop`](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md#opsx-apply-loop) (one change, containerized) and [`/opsx-pipeline`](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md#opsx-pipeline) (multiple changes in parallel).
 
-### Visueel — de pipeline van begin tot eind
+### Visual — the pipeline end to end
 
 ```text
                 ┌─────────────────┐
-                │  /opsx-explore  │   (optioneel — verkennen, geen artefacten)
+                │  /opsx-explore  │   (optional — explore, no artefacts)
                 └────────┬────────┘
                          │
                          ▼
                 ┌─────────────────┐
-                │  /opsx-new      │   start de change (alleen metadata)
+                │  /opsx-new      │   start the change (metadata only)
                 └────────┬────────┘
                          │
                          ▼
         ┌────────────────────────────────────┐
-        │  /opsx-ff        OF  /opsx-continue│
-        │  (alles in één)       (per stap)   │   artefacten genereren:
+        │  /opsx-ff        OR  /opsx-continue│
+        │  (all in one)         (per step)   │   generate artefacts:
         │                                    │   proposal → specs → design → tasks
         └────────────────┬───────────────────┘
                          │
                          ▼
                 ┌─────────────────────────┐
-                │ openspec validate       │   spec-syntax check (CLI, geen slash)
+                │ openspec validate       │   spec-syntax check (CLI, no slash)
                 │   --strict              │
                 └────────────┬────────────┘
                              │
-                             ▼              ── PR voor de spec (review op specs, niet op code) ──
+                             ▼              ── PR for the spec (review specs, not code) ──
                              │
                              ▼
                 ┌─────────────────────────┐
-                │ /opsx-plan-to-issues    │   tasks → GitHub issues + tracking-epic
+                │ /opsx-plan-to-issues    │   tasks → GitHub issues + tracking epic
                 └────────────┬────────────┘
                              │
                              ▼
                 ┌─────────────────────────┐
-                │ /opsx-apply             │   implementeren (per task: backend + UI + tests)
+                │ /opsx-apply             │   implement (per task: backend + UI + tests)
                 └────────────┬────────────┘
                              │
                              ▼
@@ -213,32 +213,32 @@ Een volledige change loopt door vier stages, met een eigen `/opsx-`-commando per
                              │
                              ▼
                 ┌─────────────────────────┐
-                │ /opsx-archive           │   sync delta → hoofd-spec, change → archive/
+                │ /opsx-archive           │   sync delta → main spec, change → archive/
                 └─────────────────────────┘
 ```
 
-Deel 2 van deze leerlijn loopt door deze pipeline heen, beginnend bij `/opsx-explore` (optioneel) en eindigend bij `/opsx-archive`.
+Part 2 of this track walks through this pipeline end to end, starting at `/opsx-explore` (optional) and finishing at `/opsx-archive`.
 
-## Test jezelf
+## Test yourself
 
-Vijf korte vragen om te checken of je dit deel begrepen hebt. Vastgelopen? Klik **Hint**. Curieus naar het antwoord? Klik **Antwoord**.
+Five short questions to check that this part landed. Stuck? Click **Hint**. Curious about the answer? Click **Answer**.
 
 <div className="tutorial-quiz">
 
-**1. Wat is het kernverschil tussen een spec en een change?**
+**1. What is the core difference between a spec and a change?**
 
 <Details summary="Hint">
 
-Eén leeft jaren mee, de ander leeft van voorstel tot merge. Waar staat elk in het repo?
+One lives for years, the other from proposal to merge. Where does each live in the repo?
 
 </Details>
 
-<Details summary="Antwoord">
+<Details summary="Answer">
 
-- **Spec** beschrijft een stabiele capability — een coherent stuk gedrag van de app. Lange leefduur, één spec per capability. Alle requirements + scenarios staan erin. Leeft in `openspec/specs/<capability>/spec.md`.
-- **Change** is een tijdelijke verandering aan één of meer specs. Bevat een proposal, spec-delta (ADDED/MODIFIED/REMOVED), design en tasks. Leeft in `openspec/changes/<naam>/` zolang hij open staat, en verhuist bij archivering naar `openspec/changes/archive/YYYY-MM-DD-<naam>/`.
+- A **spec** describes a stable capability — a coherent piece of app behaviour. Long-lived, one spec per capability. All requirements + scenarios sit inside it. Lives in `openspec/specs/<capability>/spec.md`.
+- A **change** is a temporary edit to one or more specs. Contains a proposal, spec-delta (ADDED/MODIFIED/REMOVED), design and tasks. Lives in `openspec/changes/<name>/` as long as it's open, and moves on archive to `openspec/changes/archive/YYYY-MM-DD-<name>/`.
 
-Een spec leeft jaren mee; een change leeft van voorstel tot merge en wordt daarna geschiedenis.
+A spec lives for years; a change lives from proposal to merge and then becomes history.
 
 </Details>
 
@@ -246,22 +246,22 @@ Een spec leeft jaren mee; een change leeft van voorstel tot merge en wordt daarn
 
 <div className="tutorial-quiz">
 
-**2. Waarom schrijven we eerst een spec-delta voordat we code aanpassen?**
+**2. Why write a spec-delta before changing code?**
 
 <Details summary="Hint">
 
-Denk aan: aannames, AI-agenten, audit-trail, en reviewers. Welke winst pakt elk?
+Think about: assumptions, AI agents, audit trail, and reviewers. What does each one buy?
 
 </Details>
 
-<Details summary="Antwoord">
+<Details summary="Answer">
 
-Vier voordelen die in deze module worden genoemd:
+Four benefits from this module:
 
-- **Aannames vroeg blootleggen.** Wat lijkt op één feature blijkt vaak vier features tegelijk. Scenario's schrijven brengt gaten en tegenstrijdigheden naar boven vóór de code in plaats van erna in een PR-review.
-- **AI-agenten productief maken.** Onze Hydra-pipeline bouwt code uit specs — hoe scherper de spec, hoe minder bijsturen achteraf. Dezelfde wet geldt voor menselijke teamleden in een handover.
-- **Audit-trail die niet jokt.** Per change één mapje met proposal, delta, design, tasks. Een halfjaar later weet je nog precies wat besloten is en waarom.
-- **Reviewers één bron.** De reviewer ziet spec-delta en code naast elkaar — "klopt de code met de spec" in plaats van "wat had de ontwikkelaar bedoeld".
+- **Surface assumptions early.** What looks like one feature often turns out to be four features at once. Writing the scenarios brings gaps and contradictions to the surface *before* the code instead of after, in a PR review.
+- **Make AI agents productive.** Our Hydra pipeline builds code from specs — the sharper the spec, the less course-correction afterwards. The same applies to a human teammate picking up a handover.
+- **An audit trail that doesn't lie.** One folder per change with proposal, delta, design, tasks. Six months later you can still see exactly what was decided and why.
+- **One source for reviewers.** The reviewer sees the spec-delta and the code side by side — "does the code match the spec" instead of "what did the developer mean".
 
 </Details>
 
@@ -269,23 +269,23 @@ Vier voordelen die in deze module worden genoemd:
 
 <div className="tutorial-quiz">
 
-**3. Wat zijn de drie bouwstenen waarmee je in OpenSpec gedrag beschrijft, en welke functie heeft een scenario?**
+**3. What are the three building blocks for describing behaviour in OpenSpec, and what's the role of a scenario?**
 
 <Details summary="Hint">
 
-Top-down: van capability, naar regel, naar concreet voorbeeld. De laatste maakt de regel _toetsbaar_.
+Top-down: from capability, to rule, to concrete example. The last one makes the rule _testable_.
 
 </Details>
 
-<Details summary="Antwoord">
+<Details summary="Answer">
 
-De drie bouwstenen (top-down):
+The three building blocks (top-down):
 
-- **Spec** — de stabiele capability-beschrijving, top niveau.
-- **Requirement** — één regel binnen een spec, geschreven met **MUST / SHOULD / MAY** (RFC 2119). Genummerd: `REQ-001`, `REQ-002`, …
-- **Scenario** — concreet **GIVEN / WHEN / THEN**-voorbeeld bij een requirement. Per requirement minstens één.
+- **Spec** — the stable capability description, top level.
+- **Requirement** — one rule inside a spec, written with **MUST / SHOULD / MAY** (RFC 2119). Numbered: `REQ-001`, `REQ-002`, …
+- **Scenario** — concrete **GIVEN / WHEN / THEN** example for a requirement. At least one per requirement.
 
-Het scenario maakt de requirement **toetsbaar**: iemand anders zou hetzelfde gedrag moeten kunnen bouwen of testen zonder met je te overleggen. Geen beschrijving, maar een toets.
+The scenario makes the requirement **testable**: someone else should be able to build or test the same behaviour without consulting you. Not a description, but a test.
 
 </Details>
 
@@ -293,23 +293,23 @@ Het scenario maakt de requirement **toetsbaar**: iemand anders zou hetzelfde ged
 
 <div className="tutorial-quiz">
 
-**4. Waar staan de in-flight changes in een Conduction-project, en wat gebeurt er met een change als hij klaar is?**
+**4. Where do in-flight changes live in a Conduction project, and what happens to a change when it's done?**
 
 <Details summary="Hint">
 
-Twee mappen: één voor lopend werk, één voor afgeronde geschiedenis. En wat verhuist er waarheen?
+Two folders: one for work in progress, one for completed history. And what moves where?
 
 </Details>
 
-<Details summary="Antwoord">
+<Details summary="Answer">
 
-- **In-flight changes** staan in `openspec/changes/<naam>/` — proposal, spec-delta in `specs/`, design en tasks.
-- **Bij archivering** (na implementatie + merge naar `development`) gebeurt drie dingen:
-  1. De spec-delta wordt gesynct naar de hoofd-spec in `openspec/specs/`.
-  2. Het hele change-mapje verhuist naar `openspec/changes/archive/YYYY-MM-DD-<naam>/`.
-  3. De geschiedenis blijft compleet — je kunt teruglezen welke change wélke regel introduceerde.
+- **In-flight changes** live in `openspec/changes/<name>/` — proposal, spec-delta in `specs/`, design and tasks.
+- **On archive** (after implementation + merge into `development`) three things happen:
+  1. The spec-delta is synced into the main spec at `openspec/specs/`.
+  2. The whole change folder moves to `openspec/changes/archive/YYYY-MM-DD-<name>/`.
+  3. The history stays complete — you can trace which change introduced which rule.
 
-Stap 1 en 2 doe je niet handmatig — `/opsx-archive` (deel 2) regelt het.
+Steps 1 and 2 you don't do by hand — `/opsx-archive` (Part 2) handles it.
 
 </Details>
 
@@ -317,47 +317,47 @@ Stap 1 en 2 doe je niet handmatig — `/opsx-archive` (deel 2) regelt het.
 
 <div className="tutorial-quiz">
 
-**5. Noem een situatie waarin je OpenSpec juist NIET inzet en gewoon direct codeert.**
+**5. Name a situation where you specifically do NOT use OpenSpec and just code directly.**
 
 <Details summary="Hint">
 
-De overhead moet kleiner zijn dan de winst. Bij welke twee situaties is dat duidelijk niet zo?
+The overhead has to be smaller than the win. Which two situations clearly fail that test?
 
 </Details>
 
-<Details summary="Antwoord">
+<Details summary="Answer">
 
-Twee situaties uit de module:
+Two situations from this module:
 
-- **Eenmalige tweak** — typo's, één rij toevoegen aan een vertaalbestand, een dependency bumpen. De spec-overhead is groter dan de tweak zelf.
-- **Exploratief prototype** — als je nog niet weet of het idee überhaupt werkt. Toets je aannames eerst met een wegwerp-prototype; schrijf pas daarna de spec voor de versie die wél in productie gaat.
+- **One-off tweak** — typos, adding a single row to a translation file, bumping a dependency. The spec overhead outweighs the tweak itself.
+- **Exploratory prototype** — when you don't even know whether the idea works yet. Test your assumptions with a throwaway prototype first; only write the spec for the version that's actually going into production.
 
-Voor alles daartussen — een nieuwe feature, een breaking change, een refactor met gevolgen voor consumers — loont OpenSpec zich wel.
+For everything in between — a new feature, a breaking change, a refactor that affects consumers — OpenSpec does earn its keep.
 
 </Details>
 
 </div>
 
-<NextSteps title="Volgende stap" lede="Nu je de begrippen kent, schrijven we in deel 2 een echte change van begin tot eind.">
+<NextSteps title="Next step" lede="Now that you know the concepts, in Part 2 we write a real change from beginning to end.">
   <NextStep
-    title="Deel 2 — Je eerste OpenSpec change"
+    title="Part 2 — Your first OpenSpec change"
     href="/academy/openspec-tutorial-2-eerste-change"
-    description="Maak een change met /opsx-new, schrijf een spec-delta met requirements en scenarios, genereer een takenlijst, en valideer het geheel."
+    description="Create a change with /opsx-new, write a spec-delta with requirements and scenarios, generate a task list, and validate the whole thing."
   />
   <NextStep
-    title="De Hydra-leerlijn"
+    title="The Hydra tutorial series"
     href="/academy/hydra-tutorial-1-wat-is-hydra"
-    description="Wil je zien hoe onze AI-pipeline van een OpenSpec change naar code komt? Lees hoe Hydra die overdracht automatiseert."
+    description="Want to see how our AI pipeline turns an OpenSpec change into code? Read how Hydra automates the handover."
   />
   <NextStep
-    title="OpenSpec officieel"
+    title="OpenSpec official"
     href="https://openspec.dev"
-    description="De officiële OpenSpec-website met de bron-conventie waar wij op voortbouwen."
+    description="The official OpenSpec site with the source convention we build on top of."
   />
 </NextSteps>
 
 <ContactCta
-  title="Vragen over OpenSpec?"
-  body="Spreek je teamlead of buddy aan, of stel je vraag in #openspec op Slack. Issues op deze tutorial graag op het bijbehorende GitHub-issue."
-  cta={{ label: "Mail ons", href: "mailto:info@conduction.nl?subject=OpenSpec%20leerlijn%20deel%201" }}
+  title="Questions about OpenSpec?"
+  body="Talk to your team lead or buddy, or ask in #openspec on Slack. Issues with this tutorial go on its GitHub issue."
+  cta={{ label: "Email us", href: "mailto:info@conduction.nl?subject=OpenSpec%20learning%20track%20part%201" }}
 />

--- a/academy/2026-05-12-openspec-tutorial-2-eerste-change/index.mdx
+++ b/academy/2026-05-12-openspec-tutorial-2-eerste-change/index.mdx
@@ -1,10 +1,10 @@
 ---
 slug: openspec-tutorial-2-eerste-change
-title: "OpenSpec leerlijn — Deel 2: Je eerste OpenSpec change"
+title: "OpenSpec tutorial series — Part 2: Your first OpenSpec change"
 contentType: tutorial
 authors: [conduction]
 date: 2026-05-12
-summary: Van leeg mapje naar gevalideerde OpenSpec change. We starten met /opsx-new, schrijven een spec-delta met een requirement plus scenario, laten /opsx-ff de rest genereren, en valideren het geheel. Tweede van twee korte modules.
+summary: From empty folder to validated OpenSpec change. We start with /opsx-new, write a spec-delta with a requirement plus scenario, let /opsx-ff generate the rest, and validate the whole thing. Second of two short modules.
 tags: [OpenSpec, Spec-first, Tutorial series, Workflow, Claude Code]
 apps: []
 durationMinutes: 22
@@ -15,184 +15,184 @@ partNumber: 2
 import {Outcomes, Outcome, Prerequisites, PrerequisiteItem, Troubleshooting, TroubleshootingItem, NextSteps, NextStep, ContactCta} from '@conduction/docusaurus-preset/components';
 import Details from '@theme/Details';
 
-Tijd om OpenSpec aan het werk te zien. In dit deel maak je in een Conduction-project je **eerste echte change** — van leeg mapje, via een spec-delta met requirement en scenario, naar een gevalideerd voorstel klaar voor implementatie. We doen dat met de Claude Code-skills [`/opsx-new`](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md) en [`/opsx-ff`](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md).
+Time to see OpenSpec in action. In this part you'll create your **first real change** inside a Conduction project — from empty folder, through a spec-delta with a requirement and scenario, to a validated proposal ready for implementation. We do that with the Claude Code skills [`/opsx-new`](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md) and [`/opsx-ff`](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md).
 
 {/* truncate */}
 
-<Outcomes title="Wat je gaat opleveren">
-  <Outcome>Begrip van waar <code>/opsx-explore</code> in de pipeline zit en wanneer je hem inzet (optionele voorverkenning).</Outcome>
-  <Outcome>Een werkende change in <code>openspec/changes/&lt;naam&gt;/</code>, op een eigen feature-branch.</Outcome>
-  <Outcome>Alle vier de artefacten — proposal, spec-delta, design, tasks — in de juiste afhankelijkheidsvolgorde, handmatig én via <code>/opsx-ff</code>.</Outcome>
-  <Outcome>Een gevalideerde spec-delta die door <code>openspec validate --strict</code> heen komt en klaar is om als PR open te zetten.</Outcome>
-  <Outcome>Een overzicht van wat er na de spec gebeurt: <code>/opsx-plan-to-issues</code>, <code>/opsx-apply</code> (implementeren), <code>/opsx-verify</code> (review) en <code>/opsx-archive</code>.</Outcome>
+<Outcomes title="What you'll deliver">
+  <Outcome>An understanding of where <code>/opsx-explore</code> sits in the pipeline and when you reach for it (optional pre-spec exploration).</Outcome>
+  <Outcome>A working change in <code>openspec/changes/&lt;name&gt;/</code>, on its own feature branch.</Outcome>
+  <Outcome>All four artefacts — proposal, spec-delta, design, tasks — in the right dependency order, both by hand and via <code>/opsx-ff</code>.</Outcome>
+  <Outcome>A validated spec-delta that passes <code>openspec validate --strict</code> and is ready to open as a PR.</Outcome>
+  <Outcome>An overview of what happens after the spec: <code>/opsx-plan-to-issues</code>, <code>/opsx-apply</code> (implementation), <code>/opsx-verify</code> (review) and <code>/opsx-archive</code>.</Outcome>
 </Outcomes>
 
-<Prerequisites title="Wat je nodig hebt">
-  <PrerequisiteItem>Deel 1 doorgelezen — <a href="/academy/openspec-tutorial-1-wat-is-openspec">Wat is OpenSpec?</a> — zodat je weet wat een spec, requirement, scenario en change zijn.</PrerequisiteItem>
-  <PrerequisiteItem>Claude Code geïnstalleerd en werkend in je projectmap. Heb je dat nog niet, volg dan eerst <a href="/academy/build-an-app">Build an App</a>.</PrerequisiteItem>
-  <PrerequisiteItem>Een ge-checkoute Conduction-repo waarin je rondkijken kan — bijvoorbeeld <a href="https://github.com/ConductionNL/openregister">openregister</a>. We werken in een nieuwe branch, dus je raakt niets bestaands kwijt.</PrerequisiteItem>
-  <PrerequisiteItem>Basiskennis Git: branch aanmaken, committen, pushen.</PrerequisiteItem>
+<Prerequisites title="What you'll need">
+  <PrerequisiteItem>Part 1 read through — <a href="/academy/openspec-tutorial-1-wat-is-openspec">What is OpenSpec?</a> — so that you know what a spec, requirement, scenario and change are.</PrerequisiteItem>
+  <PrerequisiteItem>Claude Code installed and working in your project folder. If you don't have that yet, start with <a href="/academy/build-an-app">Build an App</a>.</PrerequisiteItem>
+  <PrerequisiteItem>A checked-out Conduction repo you can poke around in — for example <a href="https://github.com/ConductionNL/openregister">openregister</a>. We work in a new branch, so you won't lose anything.</PrerequisiteItem>
+  <PrerequisiteItem>Basic Git: create a branch, commit, push.</PrerequisiteItem>
 </Prerequisites>
 
-## Het voorbeeld waar we mee werken
+## The example we'll work with
 
-Om het concreet te houden voegen we één feature toe aan een denkbeeldig publicatie-register: **een full-text zoekfunctie over publicatie-titels en -inhoud**. Klein genoeg om in één tutorial te doen, groot genoeg om alle artefacten te raken.
+To keep things concrete, we'll add one feature to an imaginary publication register: **a full-text search across publication titles and content**. Small enough to do in one tutorial, big enough to touch every artefact.
 
-Werk je in een eigen repo? Vervang dan in elke stap "publication-search" door je eigen change-naam. De stappen veranderen niet.
+Working in your own repo? Just replace "publication-search" with your own change name in every step. The steps themselves don't change.
 
-## Stap 0: verkennen met `/opsx-explore` (optioneel)
+## Step 0: explore with `/opsx-explore` (optional)
 
-Weet je al precies wat je wil bouwen? Sla deze stap over en ga direct naar Stap 1. Twijfel je over scope, aanpak of of de feature überhaupt thuishoort in deze app? Dan begin je met:
+Already know exactly what you want to build? Skip this step and jump to Step 1. Unsure about scope, approach, or whether the feature even belongs in this app? Then start with:
 
 ```
 /opsx-explore
 ```
 
-`/opsx-explore` is de **Pre-spec-fase** uit de [commando-referentie](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md#opsx-explore): het maakt **geen artefacten aan**, het denkt met je mee. Claude verkent de codebase, stelt vragen over je intentie, weegt alternatieve aanpakken tegen elkaar af, en geeft aan welke onbekenden er nog liggen. Het is een gesprek — geen bestand op schijf.
+`/opsx-explore` is the **Pre-spec phase** from the [command reference](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md#opsx-explore): it produces **no artefacts**, it thinks alongside you. Claude explores the codebase, asks about your intent, weighs alternative approaches, and points out the unknowns that are still floating around. It's a conversation — not a file on disk.
 
-Goede momenten om `/opsx-explore` te gebruiken:
+Good moments to reach for `/opsx-explore`:
 
-- *"Past dit in deze app, of is het een aparte capability?"*
-- *"Welke bestaande spec raakt dit?"*
-- *"Wat is de eenvoudigste manier om dit te bouwen?"*
+- *"Does this fit in this app, or is it a separate capability?"*
+- *"Which existing spec does this touch?"*
+- *"What's the simplest way to build this?"*
 
-Niet voor `/opsx-explore`: een feature die je al twee keer eerder hebt gebouwd in een andere app. Dan kun je direct door naar `/opsx-new`.
+Not for `/opsx-explore`: a feature you've already built twice before in a different app. Then go straight to `/opsx-new`.
 
-> **Voor de tutorial.** Het voorbeeld `add-publication-search` is bewust simpel — we slaan `/opsx-explore` over. Onthoud hem voor je eigen, complexere changes.
+> **For the tutorial.** The `add-publication-search` example is deliberately simple — we skip `/opsx-explore`. Remember it for your own, more complex changes.
 
-## Stap 1: een eigen branch
+## Step 1: a dedicated branch
 
-Een change zit altijd op zijn eigen feature-branch. Niet werken op `development` direct:
+A change always sits on its own feature branch. Don't work on `development` directly:
 
 ```bash
-cd /pad/naar/openregister
+cd /path/to/openregister
 git checkout development
 git pull
 git checkout -b feature/add-publication-search
 ```
 
-De branch-naam volgt het patroon `feature/<change-name>` — handig voor reviewers om te zien waar de spec bij hoort. In de volledig geautomatiseerde [Hydra-flow](https://github.com/ConductionNL/.github/blob/main/docs/hydra/README.md) wordt dat `feature/<issue-number>/<change-name>` zodra `/opsx-plan-to-issues` (Stap 10) een tracking-issue heeft aangemaakt. Voor deze tutorial pakken we het korte patroon.
+The branch name follows the `feature/<change-name>` pattern — handy for reviewers to see which spec it belongs to. In the fully automated [Hydra flow](https://github.com/ConductionNL/.github/blob/main/docs/hydra/README.md) that becomes `feature/<issue-number>/<change-name>` once `/opsx-plan-to-issues` (Step 10) has created a tracking issue. For this tutorial we'll stick with the short pattern.
 
-## Stap 2: een lege change met `/opsx-new`
+## Step 2: an empty change with `/opsx-new`
 
-Open Claude Code in de repo-map en draai:
+Open Claude Code inside the repo folder and run:
 
 ```
 /opsx-new add-publication-search
 ```
 
-Dat maakt het skelet aan:
+That creates the skeleton:
 
 ```
 openspec/changes/add-publication-search/
 └── .openspec.yaml
 ```
 
-`.openspec.yaml` bevat de metadata (schema-versie, aanmaakdatum). Verder is het mapje leeg — dat vullen we hierna.
+`.openspec.yaml` holds the metadata (schema version, creation date). The folder is otherwise empty — that's what we'll fill in next.
 
-> **Naamgevingsregel.** Gebruik kebab-case (`add-publication-search`, niet `AddPublicationSearch` of `add_publication_search`). De change-naam wordt een GitHub-issue label, dus houd hem leesbaar en kort.
+> **Naming rule.** Use kebab-case (`add-publication-search`, not `AddPublicationSearch` or `add_publication_search`). The change name becomes a GitHub issue label, so keep it readable and short.
 
-## Stap 3: de twee routes — `/opsx-ff` versus handmatig
+## Step 3: the two routes — `/opsx-ff` versus by hand
 
-Vanaf hier zijn er twee manieren om de change te vullen:
+From here there are two ways to fill in the change:
 
-| Route | Wanneer | Wat doet het |
+| Route | When | What it does |
 | --- | --- | --- |
-| **Geautomatiseerd** — `/opsx-ff` | Je weet wat je wil bouwen en wil snel een complete eerste versie. | Genereert in één run proposal, specs, design en tasks — in deze afhankelijkheidsvolgorde. Daarna lees je terug en stuur je bij. |
-| **Stapsgewijs** — handmatig of `/opsx-continue` | Je wil per artefact even nadenken voor je verder gaat. | Je schrijft (of laat genereren) eerst de proposal, dan de spec-delta, dan design, en pas dan de tasks. |
+| **Automated** — `/opsx-ff` | You know what you want to build and want a complete first draft fast. | Generates proposal, specs, design and tasks in one run — in this dependency order. Then you read back and adjust. |
+| **Step by step** — by hand or `/opsx-continue` | You want to pause and think between artefacts. | You write (or generate) the proposal first, then the spec-delta, then design, and only then the tasks. |
 
-In productie pak je vaak `/opsx-ff` voor een ruwe schets en stuur je daarna bij — dat is **het canonical pad** uit de Conduction-docs (`/opsx-ff` → `/opsx-apply` → `/opsx-verify`). In deze tutorial doen we het stap-voor-stap handmatig — dat geeft het meeste begrip van wat elk artefact eigenlijk is. Bij stap 7 laten we zien wat `/opsx-ff` in één keer voor je zou doen.
+In production you'll often grab `/opsx-ff` for a rough draft and adjust from there — that's the **canonical path** from the Conduction docs (`/opsx-ff` → `/opsx-apply` → `/opsx-verify`). In this tutorial we do it step by step by hand — that gives the best feel for what each artefact actually is. At Step 7 we show what `/opsx-ff` would do for you in one go.
 
-> **Afhankelijkheidsvolgorde uit de [commando-referentie](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md#opsx-continue):** `proposal` (root) → `specs` + `design` (beide hangen af van proposal) → `tasks` (hangt af van specs én design). We volgen die volgorde hieronder.
+> **Dependency order from the [command reference](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md#opsx-continue):** `proposal` (root) → `specs` + `design` (both depend on proposal) → `tasks` (depends on both specs and design). We follow that order below.
 
-## Stap 4: `proposal.md` — het waarom en wat
+## Step 4: `proposal.md` — the why and the what
 
-Het eerste artefact is het **proposal**: waarom doe je deze change, en wat verandert er op hoog niveau? In mensentaal, voor reviewers die de feature nog niet kennen.
+The first artefact is the **proposal**: why are you making this change, and what changes at a high level? In human language, for reviewers who don't know the feature yet.
 
-Maak `openspec/changes/add-publication-search/proposal.md`:
+Create `openspec/changes/add-publication-search/proposal.md`:
 
 ```markdown
 # Proposal: add-publication-search
 
 ## Why
-Gebruikers van het publicatie-register kunnen vandaag alleen op exacte
-publicatie-ID zoeken. Een zoekfunctie over titels en inhoud is de
-meest gevraagde feature in support-tickets van de afgelopen maand.
+Users of the publication register can currently only search by exact
+publication ID. A search across titles and content is the most
+requested feature in last month's support tickets.
 
 ## What
-- Full-text zoekfunctie via PostgreSQL `tsvector`
-- Eén nieuw API-endpoint: `GET /api/publications/search?q=...`
-- Resultaten gesorteerd op relevantiescore
+- Full-text search via PostgreSQL `tsvector`
+- One new API endpoint: `GET /api/publications/search?q=...`
+- Results sorted by relevance score
 
 ## Out of scope
-- Filters (per organisatie, periode, status)
-- Suggesties / autocomplete
-- Geavanceerde queries (AND/OR, wildcards)
+- Filters (by organisation, period, status)
+- Suggestions / autocomplete
+- Advanced queries (AND/OR, wildcards)
 ```
 
-Het proposal staat aan de top van de afhankelijkheidsketen — alle andere artefacten verwijzen er impliciet naar terug. Houd hem daarom kort en helder; details horen in `design.md` (stap 6), niet hier.
+The proposal sits at the top of the dependency chain — every other artefact refers back to it implicitly. So keep it short and clear; details belong in `design.md` (Step 6), not here.
 
-## Stap 5: de spec-delta — het hart van de change
+## Step 5: the spec-delta — the heart of the change
 
-De **spec-delta** is het centrale artefact. Het is geen volledige spec; het is alleen wat er verandert ten opzichte van de hoofd-spec. Drie soorten wijzigingen:
+The **spec-delta** is the central artefact. It is not a full spec; it is only what changes relative to the main spec. Three kinds of changes:
 
-- **ADDED** — nieuwe requirements
-- **MODIFIED** — bestaande requirements die anders worden
-- **REMOVED** — requirements die vervallen
+- **ADDED** — new requirements
+- **MODIFIED** — existing requirements that change
+- **REMOVED** — requirements that go away
 
-We voegen een requirement toe aan de hypothetische `publications`-capability. Maak het bestand aan:
+We add a requirement to the hypothetical `publications` capability. Create the file:
 
 ```
 openspec/changes/add-publication-search/specs/publications/spec.md
 ```
 
-En vul met:
+And fill it with:
 
 ```markdown
 # publications — Delta
 
 ## ADDED Requirements
 
-### REQ-001: Volledige tekstzoekfunctie
-Het systeem MOET full-text zoeken ondersteunen over publicatie-titels en
-publicatie-inhoud met behulp van PostgreSQL's `tsvector`.
+### REQ-001: Full-text search
+The system MUST support full-text search across publication titles and
+publication content using PostgreSQL's `tsvector`.
 
-#### Scenario: Zoekopdracht levert overeenkomende publicaties op
-- GIVEN publicaties met titels "Klimaatrapport 2026" en "Begrotingsoverzicht 2026"
-- WHEN een gebruiker zoekt op "klimaat"
-- THEN MOETEN de resultaten "Klimaatrapport 2026" bevatten
-- AND MOGEN de resultaten "Begrotingsoverzicht 2026" NIET bevatten
-- AND MOETEN de resultaten op relevantiescore gesorteerd zijn
+#### Scenario: Search query returns matching publications
+- GIVEN publications with titles "Climate Report 2026" and "Budget Overview 2026"
+- WHEN a user searches for "climate"
+- THEN the results MUST contain "Climate Report 2026"
+- AND the results MUST NOT contain "Budget Overview 2026"
+- AND the results MUST be sorted by relevance score
 
-#### Scenario: Lege zoekopdracht geeft een nette fout
-- GIVEN een gebruiker op de zoekpagina
-- WHEN de zoekopdracht leeg is
-- THEN MOET het systeem HTTP 400 retourneren
-- AND MOET het antwoord de fout `query parameter required` bevatten
+#### Scenario: Empty query returns a clean error
+- GIVEN a user on the search page
+- WHEN the search query is empty
+- THEN the system MUST return HTTP 400
+- AND the response MUST contain the error `query parameter required`
 ```
 
-Drie dingen die hier mis kunnen gaan:
+Three things that can go wrong here:
 
-- **Vier hashtags voor een scenario.** `#### Scenario:` (vier), niet `###` (drie). De parser herkent `###` niet als scenario — geen foutmelding, gewoon stilzwijgend overgeslagen.
-- **MOET / MAG / KAN.** Gebruik [RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119)-woorden bewust. Een reviewer leest "MAG" en weet dat het optioneel is.
-- **Geen implementatie noemen.** Geen klassen, controllers of tabel-namen. Die horen in `design.md` (stap 6). De spec beschrijft *gedrag*.
+- **Four hashes for a scenario.** `#### Scenario:` (four), not `###` (three). The parser doesn't recognise `###` as a scenario — no error, just silently skipped.
+- **MUST / MAY / SHOULD.** Use [RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119) words deliberately. A reviewer reads "MAY" and knows it's optional.
+- **No implementation talk.** No classes, controllers or table names. Those go in `design.md` (Step 6). The spec describes *behaviour*.
 
-## Stap 6: `design.md` en `tasks.md`
+## Step 6: `design.md` and `tasks.md`
 
-Met proposal en spec-delta op orde zijn de laatste twee artefacten kort werk.
+With proposal and spec-delta in place, the last two artefacts are quick work.
 
-**`design.md`** — het *hoe*, technisch. Hier wél klassen, tabellen en controllers — alles wat in de spec niet thuishoort:
+**`design.md`** — the *how*, technical. Here you *do* mention classes, tables and controllers — everything that doesn't belong in the spec:
 
 ````markdown
 # Design: add-publication-search
 
 ## Approach
-We gebruiken PostgreSQL's native `tsvector` en `tsquery`, geen
-externe zoekmachine. Volstaat voor de huidige hoeveelheid publicaties
-(< 100k rijen) en houdt de stack simpel.
+We use PostgreSQL's native `tsvector` and `tsquery`, no
+external search engine. Sufficient for the current publication
+volume (< 100k rows) and keeps the stack simple.
 
-## Schema-wijziging
-Een gegenereerde kolom `search_vector` op tabel `publications`:
+## Schema change
+A generated column `search_vector` on the `publications` table:
 
 ```sql
 ALTER TABLE publications
@@ -206,60 +206,60 @@ CREATE INDEX idx_publications_search ON publications USING GIN (search_vector);
 ```
 
 ## Endpoint
-Nieuw: `GET /api/publications/search`
-- Query parameter: `q` (verplicht, niet leeg)
-- Antwoord: gepagineerde lijst, gesorteerd op `ts_rank`
+New: `GET /api/publications/search`
+- Query parameter: `q` (required, non-empty)
+- Response: paginated list, sorted by `ts_rank`
 ````
 
-**`tasks.md`** — de implementatie-checklist. Komt als laatste want hangt af van zowel de spec als het design:
+**`tasks.md`** — the implementation checklist. Comes last because it depends on both the spec and the design:
 
 ```markdown
 # Tasks: add-publication-search
 
-- [ ] Task 1 — Migratie: `search_vector` kolom + GIN-index op `publications`
-- [ ] Task 2 — Backend: nieuwe `SearchController::search()` met `tsquery`-vertaling
-- [ ] Task 3 — Backend: 400 bij lege of ontbrekende `q`
-- [ ] Task 4 — Tests: PHPUnit voor beide scenario's uit REQ-001
-- [ ] Task 5 — API-documentatie: endpoint opgenomen in OpenAPI-spec
-- [ ] Task 6 — README-update: vermelden in feature-lijst
+- [ ] Task 1 — Migration: `search_vector` column + GIN index on `publications`
+- [ ] Task 2 — Backend: new `SearchController::search()` with `tsquery` translation
+- [ ] Task 3 — Backend: 400 on empty or missing `q`
+- [ ] Task 4 — Tests: PHPUnit for both scenarios from REQ-001
+- [ ] Task 5 — API documentation: endpoint included in OpenAPI spec
+- [ ] Task 6 — README update: mention in the feature list
 ```
 
-Tasks zijn klein en concreet — 15-30 minuten werk per task. Te grote tasks zijn een teken dat je ze nog moet opsplitsen. Goede taskbreakdown bepaalt direct hoe soepel `/opsx-apply` (stap 10) straks door je change loopt.
+Tasks are small and concrete — 15-30 minutes of work each. Tasks that feel too big are a sign you still need to split them. Good task breakdown directly drives how smoothly `/opsx-apply` (Step 10) will move through your change later.
 
-> **Optionele extra artefacten.** Naast de vier vaste artefacten heeft OpenSpec een paar optionele: `discovery.md` (open vragen die je tijdens onderzoek aantrof), `contract.md` (cross-project API-contracten), `migration.md` (data-migratie tussen schema-versies), en `test-plan.md` (test-classificatie voor `/opsx-apply-loop`). Voor een eerste change heb je ze meestal niet nodig — zie de [commando-referentie](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md#opsx-continue) voor de volledige dependency-chain.
+> **Optional extra artefacts.** Beyond the four standard artefacts, OpenSpec has a few optional ones: `discovery.md` (open questions you hit during research), `contract.md` (cross-project API contracts), `migration.md` (data migration between schema versions), and `test-plan.md` (test classification for `/opsx-apply-loop`). For a first change you usually don't need them — see the [command reference](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md#opsx-continue) for the full dependency chain.
 
-## Stap 7: of in één klap met `/opsx-ff`
+## Step 7: or all at once with `/opsx-ff`
 
-Voor wie liever met één commando begint: nadat je `/opsx-new add-publication-search` hebt gedraaid, kun je ook gewoon zeggen:
+For anyone who'd rather start with a single command: after running `/opsx-new add-publication-search`, you can just say:
 
 ```
 /opsx-ff
 ```
 
-Claude Code stelt eerst een paar vragen ("wat moet de change doen?", "welk model wil je gebruiken?") en genereert dan in één run de proposal, de specs/, de design en de tasks — in **diezelfde afhankelijkheidsvolgorde** die we hierboven handmatig hebben afgelopen. Snel, en in onze ervaring goed genoeg om vanaf daar bij te sturen.
+Claude Code asks a few questions first ("what should the change do?", "which model do you want to use?") and then generates the proposal, the specs/, the design and the tasks in one run — in **the same dependency order** we walked through by hand above. Fast, and in our experience good enough as a starting point to adjust from.
 
-Wanneer wel `/opsx-ff`: voor changes waarvan je het beeld al helder hebt en je vooral typewerk wil uitsparen. Per [`spec-driven-development.md`](https://github.com/ConductionNL/.github/blob/main/docs/WayOfWork/spec-driven-development.md) is **`/opsx-ff` → `/opsx-apply` → `/opsx-verify`** het canonical pad voor de meeste changes.
+When to reach for `/opsx-ff`: for changes where you already have a clear picture and mostly want to save typing. Per [`spec-driven-development.md`](https://github.com/ConductionNL/.github/blob/main/docs/WayOfWork/spec-driven-development.md), **`/opsx-ff` → `/opsx-apply` → `/opsx-verify`** is the canonical path for most changes.
 
-Wanneer juist niet: bij architecturale keuzes waar je per stap wil mee-denken — dan loont [`/opsx-continue`](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md#opsx-continue) zich (genereert telkens het volgende artefact na review en eventuele aanpassing). Of, voor de brainstorm vooraf, [`/opsx-explore`](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md#opsx-explore) (zie Stap 0) — die maakt nog niets aan, maar denkt mee.
+When not to: when there are architectural choices you want to think through step by step — then [`/opsx-continue`](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md#opsx-continue) earns its keep (it generates the next artefact after review and any adjustment). Or, for the brainstorm upfront, [`/opsx-explore`](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md#opsx-explore) (see Step 0) — that creates nothing yet, but thinks with you.
 
-## Stap 8: valideren
+## Step 8: validate
 
-Op spec-niveau draai je de OpenSpec-CLI:
+At the spec level you run the OpenSpec CLI:
 
 ```bash
 openspec validate --strict
 ```
 
-Dat is een **terminal-commando**, geen slash-command (zie de [commando-referentie](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md#openspec-cli-commands)). Met `--strict` worden waarschuwingen als fouten gezien. De validator checkt onder andere:
+That's a **terminal command**, not a slash-command (see the [command reference](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md#openspec-cli-commands)). With `--strict` warnings are treated as errors. The validator checks, among other things:
 
-- Scenario's gebruiken **vier** hashtags (`####`), niet drie — de meest voorkomende OpenSpec-fout, en wordt anders stilzwijgend door de parser overgeslagen.
-- Requirements gebruiken RFC 2119-keywords (MOET / MAG / KAN).
-- ADDED / MODIFIED / REMOVED-secties zijn correct gevormd.
-- Geen lege of incomplete artefacten.
+- Scenarios use **four** hashes (`####`), not three — the most common OpenSpec mistake, otherwise silently skipped by the parser.
+- Requirements use RFC 2119 keywords (MUST / MAY / SHOULD).
+- ADDED / MODIFIED / REMOVED sections are well-formed.
+- No empty or incomplete artefacts.
 
-Komt validate groen door, dan is je spec-delta klaar voor commit + PR. Komt-ie rood, dan staan de bevindingen klip en klaar — bijna altijd een vergeten hashtag of een typo in een keyword.
+If validate comes back green, your spec-delta is ready to commit + PR. If it comes back red, the findings are spelled out — almost always a forgotten hash or a typo in a keyword.
 
-## Stap 9: commit en PR
+## Step 9: commit and PR
 
 ```bash
 git add openspec/changes/add-publication-search/
@@ -268,122 +268,122 @@ git push -u origin feature/add-publication-search
 
 gh pr create --base development \
   --title "spec: add-publication-search" \
-  --body "Eerste OpenSpec change — alleen specs, geen implementatie."
+  --body "First OpenSpec change — specs only, no implementation."
 ```
 
-In een spec-eerste workflow merge je deze spec-PR apart vóór implementatie; de review focust dan op of de spec klopt — niet of de code werkt, want er is nog geen code. Daarna komen de volgende fases — zie Stap 10 (implementeren) en Stap 11 (verifiëren en archiveren).
+In a spec-first workflow you merge this spec-PR separately before implementation; the review then focuses on whether the spec is correct — not whether the code works, because there's no code yet. After that come the next phases — see Step 10 (implementation) and Step 11 (verify and archive).
 
-> **Spec + implementatie in één PR?** Ook prima — vooral voor kleine, duidelijke changes. Het spec-only-eerst patroon hierboven loont vooral wanneer reviewers de spec willen tekenen voordat er code is.
+> **Spec + implementation in one PR?** Also fine — especially for small, obvious changes. The spec-only-first pattern above mainly pays off when reviewers want to sign off the spec before code exists.
 
-## Stap 10: implementeren
+## Step 10: implementation
 
-Met de spec gemerged is de spec klaar — nu de code. Twee skills nemen je daarbij bij de hand, in volgorde:
+With the spec merged, the spec is done — now the code. Two skills walk you through it, in order:
 
-### `/opsx-plan-to-issues` — tasks worden GitHub-issues
+### `/opsx-plan-to-issues` — tasks become GitHub issues
 
 ```
 /opsx-plan-to-issues
 ```
 
-Dit leest `tasks.md` en maakt:
+This reads `tasks.md` and creates:
 
-- Een **tracking-issue** (de "epic") met een complete checkboxlijst.
-- **Eén GitHub-issue per task**, met acceptance-criteria, een `spec_ref` naar de relevante spec-sectie, en bestanden-die-waarschijnlijk-aangeraakt-worden.
-- Een `plan.json` in de change-map met alle issue-nummers gekoppeld.
+- A **tracking issue** (the "epic") with a complete checkbox list.
+- **One GitHub issue per task**, with acceptance criteria, a `spec_ref` pointing at the relevant spec section, and the files that will likely be touched.
+- A `plan.json` in the change folder linking all issue numbers together.
 
-Vanaf nu staat de change op het projectbord — zichtbaar voor het team. Optioneel `--trigger-label <label>` (bv. `--trigger-label wilco-ready-to-build`) zet meteen het Hydra-bouwlabel op elk issue.
+From now on the change is on the project board — visible to the team. Optional `--trigger-label <label>` (e.g. `--trigger-label wilco-ready-to-build`) immediately sets the Hydra build label on every issue.
 
-### `/opsx-apply` — bouwen tegen de spec
+### `/opsx-apply` — build against the spec
 
 ```
 /opsx-apply
 ```
 
-`/opsx-apply` draait de **Build-fase**: pakt de volgende open task uit `plan.json`, leest **alleen** de bijbehorende spec-sectie (via `spec_ref` — minimale context, geen "AI-amnesie"), implementeert backend + UI + tests, draait die tests, vinkt de task af in `tasks.md` én op het GitHub-issue, en herhaalt tot alles staat.
+`/opsx-apply` runs the **Build phase**: picks the next open task from `plan.json`, reads **only** the relevant spec section (via `spec_ref` — minimal context, no "AI amnesia"), implements backend + UI + tests, runs those tests, ticks the task off in `tasks.md` and on the GitHub issue, and repeats until everything is in place.
 
-De skill laadt automatisch alle bedrijfsbrede ADR's uit [`hydra/openspec/architecture/`](https://github.com/ConductionNL/hydra/tree/main/openspec/architecture) mee — harde constraints op de implementatie (data-laag, API-patronen, frontend-conventies, security, i18n).
+The skill automatically loads every company-wide ADR from [`hydra/openspec/architecture/`](https://github.com/ConductionNL/hydra/tree/main/openspec/architecture) along the way — hard constraints on the implementation (data layer, API patterns, frontend conventions, security, i18n).
 
-Per [`spec-driven-development.md`](https://github.com/ConductionNL/.github/blob/main/docs/WayOfWork/spec-driven-development.md) is dit het canonical pad: **de meeste changes hebben alleen `/opsx-ff` → `/opsx-apply` → `/opsx-verify` nodig**.
+Per [`spec-driven-development.md`](https://github.com/ConductionNL/.github/blob/main/docs/WayOfWork/spec-driven-development.md), this is the canonical path: **most changes only need `/opsx-ff` → `/opsx-apply` → `/opsx-verify`**.
 
-**Hands-off alternatief.** [`/opsx-apply-loop`](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md#opsx-apply-loop) draait `apply` → `verify` in een isolated Docker-container (max 5 iteraties), optioneel met tests, en archiveert daarna. Of gebruik Hydra zelf: label het tracking-issue met `ready-to-build`, dan pikt [Hydra](https://github.com/ConductionNL/.github/blob/main/docs/hydra/README.md) hem op via de container-pipeline en levert een draft-PR.
+**Hands-off alternative.** [`/opsx-apply-loop`](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md#opsx-apply-loop) runs `apply` → `verify` inside an isolated Docker container (max 5 iterations), optionally with tests, and archives after. Or use Hydra itself: label the tracking issue `ready-to-build`, and [Hydra](https://github.com/ConductionNL/.github/blob/main/docs/hydra/README.md) picks it up via the container pipeline and produces a draft PR.
 
-## Stap 11: verifiëren en archiveren
+## Step 11: verify and archive
 
-Nadat de implementatie staat — alle taken in `tasks.md` afgevinkt en de code in `development` — draai je `/opsx-verify`:
+Once the implementation is in place — every task in `tasks.md` ticked off and the code in `development` — you run `/opsx-verify`:
 
 ```
 /opsx-verify
 ```
 
-Dit is de **Review-fase**. Waar `openspec validate` (Stap 8) checkte of de **spec** syntactisch klopt, checkt `/opsx-verify` of de **code** ook levert wat de spec belooft. Vijf controles:
+This is the **Review phase**. Where `openspec validate` (Step 8) checked whether the **spec** is syntactically right, `/opsx-verify` checks whether the **code** actually delivers what the spec promises. Five checks:
 
-- **Completeness** — alle tasks afgevinkt en elke requirement geïmplementeerd.
-- **Correctness** — de implementatie matcht de spec-intentie.
-- **Coherence** — design-beslissingen zijn terug te zien in de code.
-- **Test-dekking** — nieuwe PHP-services/controllers hebben een testbestand; nieuwe Vue-components idem.
-- **Documentatie** — nieuwe features en endpoints staan in README of `docs/`.
+- **Completeness** — every task ticked off and every requirement implemented.
+- **Correctness** — the implementation matches the spec's intent.
+- **Coherence** — design decisions are visible in the code.
+- **Test coverage** — new PHP services/controllers have a test file; new Vue components likewise.
+- **Documentation** — new features and endpoints are written up in README or `docs/`.
 
-Bevindingen komen in drie smaken: **CRITICAL** (moet vóór archive opgelost), **WARNING** (zou opgelost moeten worden) en **SUGGESTION** (mooi-om-te-doen). Verify biedt ook aan om gevonden issues meteen te fixen en daarna opnieuw te draaien.
+Findings come in three flavours: **CRITICAL** (must be fixed before archive), **WARNING** (should be fixed) and **SUGGESTION** (nice to have). Verify also offers to fix the issues it found immediately and re-run itself.
 
-Pas als verify groen is, draai je:
+Only once verify is green do you run:
 
 ```
 /opsx-archive
 ```
 
-`/opsx-archive` doet vijf dingen:
+`/opsx-archive` does five things:
 
-1. Controleert opnieuw artefact- en task-completeness.
-2. Syncht de delta naar de hoofd-spec via [`/opsx-sync`](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md#opsx-sync) (als dat nog niet is gebeurd).
-3. Verhuist het mapje naar `openspec/changes/archive/YYYY-MM-DD-<naam>/`.
-4. Werkt `CHANGELOG.md` bij (completed tasks worden versie-entries).
-5. Maakt of update `docs/features/<change-name>.md` en het feature-overzicht in `docs/features/README.md`.
+1. Re-checks artefact and task completeness.
+2. Syncs the delta into the main spec via [`/opsx-sync`](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md#opsx-sync) (if that hasn't happened yet).
+3. Moves the folder to `openspec/changes/archive/YYYY-MM-DD-<name>/`.
+4. Updates `CHANGELOG.md` (completed tasks become version entries).
+5. Creates or updates `docs/features/<change-name>.md` and the feature overview in `docs/features/README.md`.
 
-Daarna is je change geschiedenis.
+After that, your change is history.
 
-> **`/opsx-sync` apart draaien? Meestal niet nodig.** `/opsx-archive` regelt de sync zelf — dat is stap 2 hierboven. De toegevoegde waarde van `/opsx-sync` standalone zit in **timing**: je wilt de hoofd-spec al bijwerken vóórdat je archiveert. Bijvoorbeeld om de gewijzigde regels alvast met een ander team te delen, een tussentijdse spec-review te doen, of de spec bij te werken terwijl de implementatie nog loopt. De skill mergt de ADDED / MODIFIED / REMOVED / RENAMED-secties slim in de hoofd-spec (alleen wat in de delta staat verandert — bestaande scenarios blijven staan). Daarna kun je later alsnog `/opsx-archive` draaien; die slaat stap 2 dan over.
+> **Run `/opsx-sync` separately? Usually not needed.** `/opsx-archive` handles the sync itself — that's step 2 above. The added value of `/opsx-sync` standalone is **timing**: you want the main spec updated *before* you archive. For example, to share the changed rules with another team early, hold an interim spec review, or update the spec while implementation is still going. The skill cleanly merges the ADDED / MODIFIED / REMOVED / RENAMED sections into the main spec (only what's in the delta changes — existing scenarios stay put). You can still run `/opsx-archive` later; it then skips step 2.
 
-<Troubleshooting title="Probleemoplossing">
-  <TroubleshootingItem symptom="openspec validate meldt 'geen scenarios gevonden' voor een requirement">
-    Tellen tot vier: <code>#### Scenario:</code> — geen <code>###</code>, geen vetdruk. De parser slaat scenarios met drie hashtags stilzwijgend over, dus <code>openspec validate</code> ziet alleen het symptoom (een requirement zonder scenarios). Meest voorkomende OpenSpec-fout.
+<Troubleshooting title="Troubleshooting">
+  <TroubleshootingItem symptom="openspec validate reports 'no scenarios found' for a requirement">
+    Count to four: <code>#### Scenario:</code> — not <code>###</code>, no bold. The parser silently skips scenarios with three hashes, so <code>openspec validate</code> only sees the symptom (a requirement without scenarios). The most common OpenSpec mistake.
   </TroubleshootingItem>
-  <TroubleshootingItem symptom="Mijn change-mapje heeft geen .openspec.yaml">
-    Je hebt vermoedelijk handmatig een map gemaakt in plaats van <code>/opsx-new</code> te gebruiken. Verwijder de map en draai <code>/opsx-new &lt;naam&gt;</code> opnieuw — de tooling maakt het skelet aan inclusief de metadata.
+  <TroubleshootingItem symptom="My change folder has no .openspec.yaml">
+    You probably created the folder by hand instead of using <code>/opsx-new</code>. Delete the folder and run <code>/opsx-new &lt;name&gt;</code> again — the tooling creates the skeleton including the metadata.
   </TroubleshootingItem>
-  <TroubleshootingItem symptom="Reviewer zegt: deze requirement is te implementatie-specifiek">
-    Lees terug: noem je controllers, klassen of tabelnamen in <code>specs/</code>? Verplaats die naar <code>design.md</code>. De spec beschrijft alleen <em>extern waarneembaar gedrag</em>.
+  <TroubleshootingItem symptom="Reviewer says: this requirement is too implementation-specific">
+    Read it back: are you naming controllers, classes or table names in <code>specs/</code>? Move those into <code>design.md</code>. The spec only describes <em>externally observable behaviour</em>.
   </TroubleshootingItem>
-  <TroubleshootingItem symptom="Ik wil iets wijzigen aan een bestaande spec, maar weet niet hoe">
-    Gebruik een <strong>MODIFIED Requirements</strong>-sectie in je spec-delta. Vermeld erbij wat het vorige gedrag was — bijvoorbeeld <em>(Voorheen: sessies verliepen na 30 minuten.)</em>. Zo kunnen reviewers de wijziging volgen.
+  <TroubleshootingItem symptom="I want to change something in an existing spec but don't know how">
+    Use a <strong>MODIFIED Requirements</strong> section in your spec-delta. Mention what the previous behaviour was — for example <em>(Previously: sessions expired after 30 minutes.)</em>. That lets reviewers follow the change.
   </TroubleshootingItem>
 </Troubleshooting>
 
-## Test jezelf
+## Test yourself
 
-Vijf korte vragen om te checken of je dit deel begrepen hebt. Vastgelopen? Klik **Hint**. Curieus naar het antwoord? Klik **Antwoord**.
+Five short questions to check that this part landed. Stuck? Click **Hint**. Curious about the answer? Click **Answer**.
 
 <div className="tutorial-quiz">
 
-**1. Welk commando gebruik je om een nieuwe lege change te starten, en wat staat er direct in het mapje na die stap?**
+**1. Which command do you use to start a new empty change, and what's in the folder right after that step?**
 
 <Details summary="Hint">
 
-Eén commando, één naam in kebab-case. Direct daarna is het mapje vrijwel leeg op één metadata-bestandje na.
+One command, one name in kebab-case. Right after, the folder is virtually empty except for a single metadata file.
 
 </Details>
 
-<Details summary="Antwoord">
+<Details summary="Answer">
 
-**`/opsx-new <naam>`** met de change-naam in kebab-case (bijv. `add-publication-search` — niet `AddPublicationSearch` of `add_publication_search`). De change-naam wordt ook een GitHub-issue-label, dus kort en leesbaar.
+**`/opsx-new <name>`** with the change name in kebab-case (e.g. `add-publication-search` — not `AddPublicationSearch` or `add_publication_search`). The change name also becomes a GitHub issue label, so keep it short and readable.
 
-Direct na de stap staat in het mapje:
+Right after the step, the folder contains:
 
 ```
-openspec/changes/<naam>/
+openspec/changes/<name>/
 └── .openspec.yaml
 ```
 
-Eén bestand — `.openspec.yaml` met metadata (schema-versie, aanmaakdatum). Verder leeg; proposal, delta, design en tasks komen pas daarna.
+One file — `.openspec.yaml` with metadata (schema version, creation date). Otherwise empty; proposal, delta, design and tasks come later.
 
 </Details>
 
@@ -391,20 +391,20 @@ Eén bestand — `.openspec.yaml` met metadata (schema-versie, aanmaakdatum). Ve
 
 <div className="tutorial-quiz">
 
-**2. Wat is het verschil tussen `/opsx-ff` en handmatig artefacten schrijven, en wanneer kies je welke?**
+**2. What's the difference between `/opsx-ff` and writing artefacts by hand, and when do you pick which?**
 
 <Details summary="Hint">
 
-Snelheid vs. controle. De ene levert in één run alles op, de andere laat je per artefact terugkijken en bijsturen.
+Speed vs. control. One delivers everything in one run; the other lets you review and adjust per artefact.
 
 </Details>
 
-<Details summary="Antwoord">
+<Details summary="Answer">
 
-- **`/opsx-ff`** ("fast-forward") — genereert proposal, specs, design en tasks in één run na een paar setup-vragen. Kies hem als je het beeld al helder hebt en typewerk wil besparen.
-- **Handmatig of `/opsx-continue`** — je schrijft (of genereert) per artefact, leest terug, scherpt aan, en gaat dan pas verder. Kies dit bij architecturale keuzes waar je per stap wil meedenken. `/opsx-explore` zit nog een stap eerder: die maakt nog niets aan, maar denkt mee bij de brainstorm.
+- **`/opsx-ff`** ("fast-forward") — generates proposal, specs, design and tasks in one run after a few setup questions. Pick it when you already have a clear picture and want to save typing.
+- **By hand or `/opsx-continue`** — you write (or generate) per artefact, read back, sharpen, and only then move on. Pick this when there are architectural choices you want to think through at each step. `/opsx-explore` sits one step earlier still: it creates nothing yet, but thinks with you in the brainstorm.
 
-In de praktijk: vaak `/opsx-ff` voor een ruwe schets en daarna handmatig bijsturen.
+In practice: often `/opsx-ff` for a rough draft and then adjust by hand.
 
 </Details>
 
@@ -412,21 +412,21 @@ In de praktijk: vaak `/opsx-ff` voor een ruwe schets en daarna handmatig bijstur
 
 <div className="tutorial-quiz">
 
-**3. Welke drie soorten delta-secties kun je in een spec-delta schrijven, en wat doe je in elke?**
+**3. What are the three kinds of delta sections you can write in a spec-delta, and what does each do?**
 
 <Details summary="Hint">
 
-Drie hoofdletter-woorden, alledrie een werkwoord voor wat ze met requirements doen.
+Three uppercase words, each a verb for what they do to requirements.
 
 </Details>
 
-<Details summary="Antwoord">
+<Details summary="Answer">
 
-- **ADDED Requirements** — nieuwe requirements die nog niet in de hoofd-spec staan.
-- **MODIFIED Requirements** — bestaande requirements die anders worden. Vermeld erbij wat het vorige gedrag was — bijvoorbeeld *(Voorheen: sessies verliepen na 30 minuten.)* — zodat reviewers de wijziging kunnen volgen.
-- **REMOVED Requirements** — requirements die vervallen.
+- **ADDED Requirements** — new requirements that aren't in the main spec yet.
+- **MODIFIED Requirements** — existing requirements that change. Note what the previous behaviour was — for example *(Previously: sessions expired after 30 minutes.)* — so reviewers can follow the change.
+- **REMOVED Requirements** — requirements that go away.
 
-Bij archivering gaan ADDED-regels naar de hoofd-spec, MODIFIED overschrijven hun voorganger, en REMOVED-regels verdwijnen.
+On archive, ADDED rules move into the main spec, MODIFIED ones overwrite their predecessors, and REMOVED ones disappear.
 
 </Details>
 
@@ -434,20 +434,20 @@ Bij archivering gaan ADDED-regels naar de hoofd-spec, MODIFIED overschrijven hun
 
 <div className="tutorial-quiz">
 
-**4. Met welk commando check je je spec voordat je commit, en met welk commando check je later of de implementatie de spec ook echt levert?**
+**4. Which command checks your spec before commit, and which command later checks whether the implementation actually delivers the spec?**
 
 <Details summary="Hint">
 
-Twee verschillende rollen — één is een OpenSpec-CLI die naar **spec-syntax** kijkt, één is een Claude Code-skill die naar **code-vs-spec** kijkt.
+Two different roles — one is an OpenSpec CLI that looks at **spec syntax**, one is a Claude Code skill that looks at **code-vs-spec**.
 
 </Details>
 
-<Details summary="Antwoord">
+<Details summary="Answer">
 
-- **Vóór commit**: `openspec validate --strict`. De OpenSpec-CLI (terminal-commando, geen slash). Checkt of de delta syntactisch klopt — vier hashtags voor scenarios, RFC 2119-keywords, ADDED/MODIFIED/REMOVED-vorm, geen lege artefacten. Met `--strict` worden waarschuwingen ook als fouten gezien.
-- **Na implementatie**: `/opsx-verify`. Een Claude Code-skill die de **Review**-fase draait — alle taken afgevinkt, code in `development` — en checkt of de code ook levert wat de spec belooft. Vijf controles: **completeness**, **correctness**, **coherence**, **test-dekking** en **documentatie**. Bevindingen komen in **CRITICAL** / **WARNING** / **SUGGESTION**.
+- **Before commit**: `openspec validate --strict`. The OpenSpec CLI (terminal command, no slash). Checks that the delta is syntactically correct — four hashes for scenarios, RFC 2119 keywords, ADDED/MODIFIED/REMOVED shape, no empty artefacts. With `--strict`, warnings are also treated as errors.
+- **After implementation**: `/opsx-verify`. A Claude Code skill that runs the **Review** phase — every task ticked off, code in `development` — and checks whether the code actually delivers what the spec promises. Five checks: **completeness**, **correctness**, **coherence**, **test coverage** and **documentation**. Findings come in **CRITICAL** / **WARNING** / **SUGGESTION**.
 
-Het ene checkt of de spec **correct opgeschreven** is, het andere of de code de spec **echt levert**. De meest voorkomende spec-syntaxfout — drie i.p.v. vier hashtags bij een scenario — wordt door de parser stilzwijgend overgeslagen, dus `openspec validate` ziet alleen het symptoom (requirement zonder scenarios). "Tellen tot vier" blijft de eerste reflex.
+One checks whether the spec is **correctly written**, the other whether the code **actually delivers** the spec. The most common spec-syntax mistake — three hashes instead of four for a scenario — is silently skipped by the parser, so `openspec validate` only sees the symptom (a requirement without scenarios). "Count to four" stays the first reflex.
 
 </Details>
 
@@ -455,54 +455,54 @@ Het ene checkt of de spec **correct opgeschreven** is, het andere of de code de 
 
 <div className="tutorial-quiz">
 
-**5. Wanneer is een change klaar om gearchiveerd te worden, en welk commando draai je dan?**
+**5. When is a change ready to be archived, and which command do you run?**
 
 <Details summary="Hint">
 
-Vier voorwaarden: tasks, code in development, delta in hoofd-spec, en mapje verhuisd. Het laatste hoef je niet zelf te doen.
+Four conditions: tasks, code in development, delta in main spec, and folder moved. The last one you don't do by hand.
 
 </Details>
 
-<Details summary="Antwoord">
+<Details summary="Answer">
 
-Een change is klaar om gearchiveerd te worden als:
+A change is ready to be archived when:
 
-1. Alle taken in `tasks.md` afgevinkt zijn.
-2. De implementatie in `development` zit (PR gemerged).
-3. De spec-delta is gesynct naar de hoofd-spec in `openspec/specs/`.
-4. Het mapje is verplaatst naar `openspec/changes/archive/YYYY-MM-DD-<naam>/`.
+1. Every task in `tasks.md` is ticked off.
+2. The implementation is in `development` (PR merged).
+3. The spec-delta has been synced into the main spec at `openspec/specs/`.
+4. The folder has been moved to `openspec/changes/archive/YYYY-MM-DD-<name>/`.
 
-Stap 3 en 4 doe je niet handmatig — draai **`/opsx-archive`**. Die controleert of alle taken klaar zijn, syncht de delta via `/opsx-sync`, en verhuist het mapje met datum vooraan. Daarna is je change geschiedenis.
+Steps 3 and 4 you don't do by hand — run **`/opsx-archive`**. It re-checks that every task is done, syncs the delta via `/opsx-sync`, and moves the folder with the date in front. After that your change is history.
 
 </Details>
 
 </div>
 
-<NextSteps title="Volgende stap" lede="Je eerste change staat. Een paar logische vervolgstappen:">
+<NextSteps title="Next step" lede="Your first change is in. A few logical follow-ups:">
   <NextStep
-    title="Deel 1 — Wat is OpenSpec?"
+    title="Part 1 — What is OpenSpec?"
     href="/academy/openspec-tutorial-1-wat-is-openspec"
-    description="Even teruglezen wat een spec versus een change is — handig als je een collega meeneemt in deze workflow."
+    description="Re-read the spec-vs-change distinction — useful when you're bringing a colleague along into this workflow."
   />
   <NextStep
-    title="Hydra-leerlijn — van spec naar code"
+    title="Hydra tutorial series — from spec to code"
     href="/academy/hydra-tutorial-1-wat-is-hydra"
-    description="Hoe gaat een OpenSpec change vanzelf door naar een PR met code? Onze AI-pipeline doet dat werk."
+    description="How does an OpenSpec change move on to a PR with code automatically? Our AI pipeline does that work."
   />
   <NextStep
-    title="De officiële OpenSpec-conventie"
+    title="The official OpenSpec convention"
     href="https://openspec.dev"
-    description="De bron-conventie waar wij op voortbouwen, met de volledige naamgeving en regels."
+    description="The source convention we build on top of, with all the naming and the rules."
   />
   <NextStep
-    title="OpenSpec-commando's compleet"
+    title="The full OpenSpec command list"
     href="https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md"
-    description="Alle /opsx-*-commando's op één rij: new, ff, continue, explore, apply, verify, sync, archive."
+    description="Every /opsx-* command in one place: new, ff, continue, explore, apply, verify, sync, archive."
   />
 </NextSteps>
 
 <ContactCta
-  title="Vragen of feedback?"
-  body="Spreek je teamlead of buddy aan, of stel je vraag in #openspec op Slack. Issues op deze tutorial graag op het bijbehorende GitHub-issue."
-  cta={{ label: "Mail ons", href: "mailto:info@conduction.nl?subject=OpenSpec%20leerlijn%20deel%202" }}
+  title="Questions or feedback?"
+  body="Talk to your team lead or buddy, or ask in #openspec on Slack. Issues with this tutorial go on its GitHub issue."
+  cta={{ label: "Email us", href: "mailto:info@conduction.nl?subject=OpenSpec%20learning%20track%20part%202" }}
 />

--- a/academy/2026-05-15-claude-skills-tutorial-1-wat-zijn-claude-skills/index.mdx
+++ b/academy/2026-05-15-claude-skills-tutorial-1-wat-zijn-claude-skills/index.mdx
@@ -1,10 +1,10 @@
 ---
 slug: claude-skills-tutorial-1-wat-zijn-claude-skills
-title: "Claude Skills leerlijn — Deel 1: Wat zijn Claude Skills?"
+title: "Claude Skills tutorial series — Part 1: What are Claude Skills?"
 contentType: tutorial
 authors: [conduction]
 date: 2026-05-15
-summary: Wat is een Claude Skill, wanneer schrijf je er een (en wanneer juist een prompt of command), welke velden staan in de frontmatter en hoe weet Claude wanneer hij hem moet triggeren. Eerste van vier korte modules.
+summary: What a Claude Skill is, when you should write one (and when a prompt or command is the better tool), what fields belong in the frontmatter, and how Claude decides when to trigger it. First of four short modules.
 tags: [Claude, Claude Code, Skills, AI, Tutorial series]
 apps: []
 durationMinutes: 12
@@ -15,57 +15,57 @@ partNumber: 1
 import {Outcomes, Outcome, Prerequisites, PrerequisiteItem, NextSteps, NextStep, HexCard, ContactCta} from '@conduction/docusaurus-preset/components';
 import Details from '@theme/Details';
 
-Claude Skills zijn het mechanisme waarmee je Claude Code uitbreidt met herbruikbare, gespecialiseerde gedragingen. Denk aan Conductions eigen `/review-pr`, `/opsx-new` of de hele `hydra-gate-*` familie: stuk voor stuk skills. Dit eerste deel legt in tien minuten uit wát een skill is, hoe hij geactiveerd wordt, en wanneer je beter géén skill maakt. Het is deel 1 van een leerlijn van vier; aan het eind sta je klaar om er in deel 2 zelf een te schrijven — en in deel 3 introduceren we het **7-level maturity-framework** waarmee je een skill van "voelt goed" naar "gemeten goed" brengt (deel 4 gaat door op L6 en L7).
+Claude Skills are the mechanism for extending Claude Code with reusable, specialised behaviours. Think of Conduction's own `/review-pr`, `/opsx-new`, or the whole `hydra-gate-*` family: each one is a skill. This first part explains in ten minutes *what* a skill is, how it gets activated, and when you should not write one. It's part 1 of a four-part track; by the end you'll be ready to write your own in part 2 — and in part 3 we introduce the **7-level maturity framework** that takes a skill from "feels good" to "measured good" (part 4 continues with L6 and L7).
 
 {/* truncate */}
 
-<Outcomes title="Wat je leert in dit deel">
-  <Outcome>Wat een Claude Skill is — een mapje met een <code>SKILL.md</code> dat Claude on-demand laadt.</Outcome>
-  <Outcome>De twee manieren waarop een skill geactiveerd kan worden: handmatig via <code>/</code> en automatisch door Claude zelf.</Outcome>
-  <Outcome>Welke velden de frontmatter heeft, en waarom de <code>description</code> verreweg het belangrijkste veld is.</Outcome>
-  <Outcome>Wanneer een skill de juiste keuze is — en wanneer een gewone prompt, een command of een agent beter past.</Outcome>
+<Outcomes title="What you'll learn in this part">
+  <Outcome>What a Claude Skill is — a folder with a <code>SKILL.md</code> that Claude loads on demand.</Outcome>
+  <Outcome>The two ways a skill can be activated: manually via <code>/</code> and automatically by Claude itself.</Outcome>
+  <Outcome>Which fields live in the frontmatter, and why the <code>description</code> is by far the most important one.</Outcome>
+  <Outcome>When a skill is the right choice — and when a plain prompt, a command, or an agent is a better fit.</Outcome>
 </Outcomes>
 
-<Prerequisites title="Wat je nodig hebt">
-  <PrerequisiteItem>Een werkende installatie van <a href="https://docs.claude.com/en/docs/claude-code/overview">Claude Code</a> op je laptop. Zo niet, doe eerst de <a href="https://github.com/ConductionNL/.github/blob/main/docs/claude/workstation-setup.md">Workstation Setup</a>.</PrerequisiteItem>
-  <PrerequisiteItem>Basiskennis Git en GitHub — een skill is uiteindelijk gewoon een bestand dat je commit.</PrerequisiteItem>
-  <PrerequisiteItem>Een paar uur ervaring met Claude Code in de praktijk. Je hoeft geen power-user te zijn, maar je moet wel weten wat <code>/help</code> doet en hoe je een prompt naar Claude stuurt.</PrerequisiteItem>
+<Prerequisites title="What you need">
+  <PrerequisiteItem>A working installation of <a href="https://docs.claude.com/en/docs/claude-code/overview">Claude Code</a> on your laptop. If not, do the <a href="https://github.com/ConductionNL/.github/blob/main/docs/claude/workstation-setup.md">Workstation Setup</a> first.</PrerequisiteItem>
+  <PrerequisiteItem>Basic Git and GitHub knowledge — a skill is, after all, just a file you commit.</PrerequisiteItem>
+  <PrerequisiteItem>A few hours of hands-on Claude Code experience. You don't need to be a power user, but you should know what <code>/help</code> does and how to send a prompt to Claude.</PrerequisiteItem>
 </Prerequisites>
 
-## In één zin
+## In one sentence
 
-Een **Claude Skill** is een mapje onder `.claude/skills/<naam>/` met daarin een `SKILL.md` (en optioneel scripts, voorbeelden, referentiebestanden). De frontmatter van die `SKILL.md` vertelt Claude wanneer de skill relevant is; de inhoud is de instructie die Claude volgt zodra de skill geladen wordt.
+A **Claude Skill** is a folder under `.claude/skills/<name>/` containing a `SKILL.md` (and optionally scripts, examples, reference files). The frontmatter of that `SKILL.md` tells Claude when the skill is relevant; the body is the instruction Claude follows once the skill is loaded.
 
-Praktisch: een skill is een **bundel-eenheid van gedrag**. In plaats van duizend regels prompt-tekst in `CLAUDE.md` te plakken, of telkens dezelfde instructies opnieuw te typen, schrijf je het één keer als skill. Hergebruikbaar, testbaar, en deelbaar met je team.
+In practical terms: a skill is a **unit of bundled behaviour**. Instead of pasting a thousand lines of prompt text into `CLAUDE.md`, or retyping the same instructions every time, you write it once as a skill. Reusable, testable, and shareable with your team.
 
 ```
 .claude/skills/
 └── review-pr/
-    ├── SKILL.md          ← verplicht: de skill-logica
-    ├── templates/        ← optioneel: bestanden met placeholders
-    ├── references/       ← optioneel: standaarden en achtergrond
-    ├── examples/         ← optioneel: voorbeelden van gewenste output
-    └── scripts/          ← optioneel: shell- of Python-scripts
+    ├── SKILL.md          ← required: the skill logic
+    ├── templates/        ← optional: files with placeholders
+    ├── references/       ← optional: standards and background
+    ├── examples/         ← optional: examples of desired output
+    └── scripts/          ← optional: shell or Python scripts
 ```
 
-## Hoe een skill wordt aangeroepen
+## How a skill gets invoked
 
-Eén skill kan op **twee manieren** in actie komen:
+A single skill can be triggered in **two ways**:
 
-1. **Handmatig** — je typt `/review-pr` in een Claude-sessie. Direct, voorspelbaar, en de skill draait precies wanneer jij dat wilt.
-2. **Automatisch** — Claude leest de `description` van alle beschikbare skills mee en kiest er zelf eentje wanneer de huidige situatie matcht. Vraag bijvoorbeeld "kun je deze PR reviewen?" en Claude triggert vanzelf `review-pr` als die voorhanden is.
+1. **Manually** — you type `/review-pr` in a Claude session. Direct, predictable, and the skill runs exactly when you want it to.
+2. **Automatically** — Claude reads the `description` of every available skill and picks one itself when the current situation matches. Ask "can you review this PR?" and Claude triggers `review-pr` on its own if it's available.
 
-Welke mode is toegestaan, regel je in de frontmatter van de skill zelf:
+Which mode is allowed is controlled in the skill's own frontmatter:
 
-- `disable-model-invocation: true` — alleen jij kunt 'm aanroepen via `/<naam>`. Gebruik dit voor skills met side-effects (`/opsx-apply` past code aan, `/create-pr` opent een PR). Claude mag dit niet zomaar uit zichzelf doen.
-- `user-invocable: false` — alleen Claude zelf mag 'm laden. Gebruik dit voor achtergrondkennis die niet als actie zinvol is (bijvoorbeeld een `legacy-system-context` die alleen informeert).
-- Geen van beide gezet → beide mogen. Default voor de meeste skills.
+- `disable-model-invocation: true` — only you can invoke it via `/<name>`. Use this for skills with side effects (`/opsx-apply` modifies code, `/create-pr` opens a PR). Claude shouldn't fire these on its own.
+- `user-invocable: false` — only Claude itself may load it. Use this for background knowledge that doesn't make sense as an action (e.g. a `legacy-system-context` that only informs).
+- Neither set → both are allowed. The default for most skills.
 
-In een Hydra-pipeline draaien skills meestal **automatisch**: containers hebben geen toetsenbord en leunen op auto-activatie. Achter je eigen toetsenbord typ je vaker expliciet `/` voor controle.
+In a Hydra pipeline skills mostly run **automatically**: containers have no keyboard and rely on auto-activation. Behind your own keyboard you'll more often type `/` explicitly for control.
 
-## De frontmatter, veld voor veld
+## The frontmatter, field by field
 
-Een minimale `SKILL.md` ziet er zo uit:
+A minimal `SKILL.md` looks like this:
 
 ```markdown
 ---
@@ -78,136 +78,136 @@ metadata:
 
 # Review PR
 
-Korte uitleg van wat de skill doet.
+Short explanation of what the skill does.
 
-**Input**: hoe je de skill aanroept en welke argumenten hij accepteert.
+**Input**: how you invoke the skill and which arguments it accepts.
 
 **Steps**
 
-1. **Stap-naam**
-   Instructies...
+1. **Step name**
+   Instructions...
 
-2. **Stap-naam**
-   Instructies...
+2. **Step name**
+   Instructions...
 
 **Guardrails**
-- Wat de skill nooit mag doen
-- Wat hij moet checken voor destructieve acties
+- What the skill must never do
+- What it must check before destructive actions
 ```
 
-Drie velden vragen extra aandacht:
+Three fields deserve extra attention:
 
-| Veld | Functie |
+| Field | Function |
 |---|---|
-| `name` | Moet **exact gelijk** zijn aan de mapnaam. Folder heet `review-pr` → `name: review-pr`. Wijkt het af, dan kun je de skill niet via `/<naam>` triggeren. |
-| `description` | Het belangrijkste veld van de hele skill. Hierop beslist Claude of de skill relevant is. Action-oriented, derde persoon, met concrete trigger-woorden. |
-| `metadata.tags` / `metadata.category` | Vrij in te vullen, handig voor filteren en groeperen — geen invloed op triggering. |
+| `name` | Must be **exactly equal** to the folder name. Folder `review-pr` → `name: review-pr`. If they differ, you can't trigger the skill via `/<name>`. |
+| `description` | The most important field of the entire skill. Claude decides relevance based on this. Action-oriented, third person, with concrete trigger words. |
+| `metadata.tags` / `metadata.category` | Free-form, useful for filtering and grouping — no impact on triggering. |
 
-### Waarom de description zoveel belangrijker is dan je denkt
+### Why the description matters more than you think
 
-Claude laadt skills in drie lagen:
+Claude loads skills in three layers:
 
-| Laag | Wat | Wanneer geladen |
+| Layer | What | Loaded when |
 |---|---|---|
-| **Metadata** | `name` + `description` | **Altijd** — zit standaard in de system prompt |
-| **SKILL.md body** | Steps, guardrails, instructies | Pas wanneer de skill triggert |
-| **Reference files** | `references/`, `templates/`, `examples/` | On-demand tijdens uitvoering |
+| **Metadata** | `name` + `description` | **Always** — sits in the system prompt by default |
+| **SKILL.md body** | Steps, guardrails, instructions | Only when the skill triggers |
+| **Reference files** | `references/`, `templates/`, `examples/` | On demand during execution |
 
-Dat betekent: alleen je `description` staat altijd "aan". Is hij vaag, dan vuurt je skill nooit automatisch. Schrijf 'm in derde persoon, start met een werkwoord, en plak de meest specifieke trigger-woorden vooraan (alleen de eerste ~250 tekens zijn zichtbaar in skill-listings).
+That means: only your `description` is always "on". If it's vague, your skill never fires automatically. Write it in third person, start with a verb, and front-load the most specific trigger words (only the first ~250 characters are visible in skill listings).
 
 ```
-# Slecht — vaag, passief, geen trigger-woorden
+# Bad — vague, passive, no trigger words
 description: A skill that helps with various document-related tasks
 
-# Goed — specifiek, derde persoon, action-werkwoord vooraan
+# Good — specific, third person, action verb up front
 description: Create a Pull Request from the current branch — runs local checks, picks target branch, and opens the PR on GitHub
 ```
 
-### Verdiepende frontmatter-velden
+### Deeper frontmatter fields
 
-Naast `name`, `description` en `metadata` zijn er een paar optionele velden die het gedrag van een skill subtiel sturen. Je hebt ze niet altijd nodig, maar weten dát ze bestaan helpt later:
+Besides `name`, `description` and `metadata` there are a few optional fields that subtly steer a skill's behaviour. You won't always need them, but knowing they exist helps later:
 
-| Veld | Functie | Wanneer gebruiken |
+| Field | Function | When to use |
 |---|---|---|
-| `allowed-tools` | Beperkt welke tools de skill mag aanroepen | Read-only audit-skills die nooit mogen schrijven |
-| `context: fork` | Runt de skill in een geïsoleerde sub-context | Zware skills die je hoofdgesprek niet willen vervuilen |
-| `paths` | Auto-trigger alleen bij werk in deze paden | Skills die alleen relevant zijn in bv. `openspec/**` |
-| `disable-model-invocation` | Schakelt auto-trigger volledig uit | Skills met side-effects die strikt slash-only moeten zijn |
-| `user-invocable: false` | Schakelt handmatige `/`-invocatie uit | Pure achtergrondkennis voor Claude zelf |
+| `allowed-tools` | Restricts which tools the skill may call | Read-only audit skills that must never write |
+| `context: fork` | Runs the skill in an isolated sub-context | Heavy skills that shouldn't pollute your main conversation |
+| `paths` | Auto-trigger only for work in these paths | Skills only relevant in e.g. `openspec/**` |
+| `disable-model-invocation` | Turns auto-trigger off entirely | Side-effect skills that must be strictly slash-only |
+| `user-invocable: false` | Disables manual `/` invocation | Pure background knowledge for Claude itself |
 
-Begin met de drie verplichte/basis-velden. Voeg de bovenstaande pas toe als je een concrete reden hebt — anders maak je je skill stiller of strikter dan nodig.
+Start with the three required/basic fields. Add the above only when you have a concrete reason — otherwise you'll make your skill quieter or stricter than necessary.
 
 ### Naming convention: `namespace-action`
 
-Skills heten standaard `<namespace>-<action>` met alleen kleine letters, cijfers en koppeltekens. Conduction gebruikt onder meer:
+Skills are conventionally named `<namespace>-<action>` using only lowercase letters, digits and hyphens. Conduction uses, among others:
 
-| Namespace | Dekt |
+| Namespace | Covers |
 |---|---|
-| `opsx-` | OpenSpec-workflow (`opsx-new`, `opsx-apply`, `opsx-archive`) |
-| `app-` | Nextcloud app-lifecycle (`app-design`, `app-create`) |
-| `test-` | Testen (`test-counsel`, `test-persona-henk`) |
-| `team-` | Scrum team-rollen (`team-backend`, `team-qa`) |
-| `hydra-gate-` | Quality- en security-gates binnen Hydra |
+| `opsx-` | OpenSpec workflow (`opsx-new`, `opsx-apply`, `opsx-archive`) |
+| `app-` | Nextcloud app lifecycle (`app-design`, `app-create`) |
+| `test-` | Testing (`test-counsel`, `test-persona-henk`) |
+| `team-` | Scrum team roles (`team-backend`, `team-qa`) |
+| `hydra-gate-` | Quality and security gates inside Hydra |
 
-De mapnaam, het `name`-veld én de manier waarop je 'm typt (`/<naam>`) moeten allemaal exact gelijk zijn.
+The folder name, the `name` field, and the way you type it (`/<name>`) all need to be exactly identical.
 
 ## Skill vs. prompt vs. agent
 
-Een veelgehoorde vraag: wanneer is een skill de juiste keuze, en wanneer iets anders? Drie categorieën, kort:
+A common question: when is a skill the right choice, and when is something else? Three categories, briefly:
 
-<HexCard title="Gewone prompt">
-  Eenmalig, of iets wat je sneller schrijft dan op te zoeken. Geen herhaalbaar patroon. Voorbeeld: <em>"refactor deze functie naar early-return-stijl"</em>.
+<HexCard title="Plain prompt">
+  One-off, or something you can write faster than you can look it up. No repeatable pattern. Example: <em>"refactor this function to early-return style"</em>.
 </HexCard>
 
 <HexCard title="Skill">
-  Herhaalbaar gedrag, mechanisch te beschrijven, met side-effects of een vast stappenplan. Voorbeelden: <code>/review-pr</code>, <code>/opsx-new</code>, <code>/create-pr</code>.
+  Repeatable behaviour, mechanically describable, with side effects or a fixed sequence of steps. Examples: <code>/review-pr</code>, <code>/opsx-new</code>, <code>/create-pr</code>.
 </HexCard>
 
 <HexCard title="Subagent">
-  Een aparte uitvoeringscontext met eigen tools en eigen tokenbudget. Gebruik je wanneer je werk wilt isoleren (zware exploratie, parallelle reviews). Een skill kan een subagent oproepen, maar is er niet hetzelfde als.
+  A separate execution context with its own tools and its own token budget. Use one when you want to isolate work (heavy exploration, parallel reviews). A skill can invoke a subagent, but isn't the same thing.
 </HexCard>
 
-De pragmatische test: schrijf een skill als…
+The pragmatic test: write a skill when…
 
-1. **Het gedrag is herhaalbaar** — meer dan eens nodig, op meer dan één plek.
-2. **Het is mechanisch beschrijfbaar** — je kunt het in 1-3 alinea's instrueren, zonder dat het ontaardt in "het hangt van de context af".
-3. **Je teamgenoot zou hetzelfde willen doen** — anders is het een persoonlijke macro, geen team-skill.
+1. **The behaviour is repeatable** — needed more than once, in more than one place.
+2. **It's mechanically describable** — you can instruct it in 1-3 paragraphs without devolving into "it depends on the context".
+3. **A teammate would want to do the same** — otherwise it's a personal macro, not a team skill.
 
-Voor één-keer-werk: gewoon prompten. Voor herhaalbaar werk: skill. Voor zware isolatie van een sub-werkstroom: subagent.
+For one-off work: just prompt. For repeatable work: skill. For heavy isolation of a sub-workflow: subagent.
 
-## Waar skills "wonen"
+## Where skills "live"
 
-Skills kunnen op drie niveaus liggen:
+Skills can sit at three levels:
 
-| Niveau | Pad | Wie zie ze |
+| Level | Path | Who sees them |
 |---|---|---|
-| **Globaal** | `~/.claude/skills/<naam>/` | Jij, in elke Claude-sessie op deze laptop |
-| **Per project** | `<repo>/.claude/skills/<naam>/` | Iedereen die in deze repo werkt — gecommit in Git |
-| **Vendored** | `<repo>/vendor/skills/<naam>/` | Idem, maar afkomstig van een externe partij (bv. Anthropic of Trail of Bits) |
+| **Global** | `~/.claude/skills/<name>/` | You, in every Claude session on this laptop |
+| **Per project** | `<repo>/.claude/skills/<name>/` | Everyone working in this repo — committed to Git |
+| **Vendored** | `<repo>/vendor/skills/<name>/` | Same, but sourced from a third party (e.g. Anthropic or Trail of Bits) |
 
-In Conduction-repo's leeft het overgrote deel als **project-skills** in `<repo>/.claude/skills/`. Dat zorgt dat het hele team — en Hydra's Docker-personas — exact dezelfde skills hebben.
+In Conduction repos the vast majority live as **project skills** in `<repo>/.claude/skills/`. That ensures the whole team — and Hydra's Docker personas — have exactly the same skills.
 
-## Test jezelf
+## Test yourself
 
-Vier korte vragen om te checken of je dit deel begrepen hebt. Vastgelopen? Klik **Hint**. Curieus naar het antwoord? Klik **Antwoord**.
+Four short questions to check you understood this part. Stuck? Click **Hint**. Curious about the answer? Click **Answer**.
 
 <div className="tutorial-quiz">
 
-**1. Wanneer kies je voor een skill, en wanneer voor een gewone prompt of een subagent?**
+**1. When do you pick a skill, and when a plain prompt or a subagent?**
 
 <Details summary="Hint">
 
-Denk aan herhaalbaarheid, mechanische beschrijfbaarheid, en isolatie. Bij welke combinaties valt de keuze welke kant op?
+Think about repeatability, mechanical describability, and isolation. Which combinations push you which way?
 
 </Details>
 
-<Details summary="Antwoord">
+<Details summary="Answer">
 
-- **Gewone prompt** — eenmalig, of iets wat je sneller schrijft dan op te zoeken. Geen herhaalbaar patroon. Bijvoorbeeld: *"refactor deze functie naar early-return-stijl"*.
-- **Skill** — herhaalbaar gedrag, mechanisch te beschrijven, met side-effects of een vast stappenplan. Voorbeelden: `/review-pr`, `/opsx-new`, `/create-pr`. Je teamgenoot zou ook willen dat dit consistent gebeurt.
-- **Subagent** — een aparte uitvoeringscontext met eigen tools en tokenbudget. Voor isolatie: zware exploratie, parallelle reviews. Een skill kan een subagent oproepen, maar is niet hetzelfde.
+- **Plain prompt** — one-off, or something you can write faster than you can look it up. No repeatable pattern. For example: *"refactor this function to early-return style"*.
+- **Skill** — repeatable behaviour, mechanically describable, with side effects or a fixed step sequence. Examples: `/review-pr`, `/opsx-new`, `/create-pr`. Your teammate would also want this to happen consistently.
+- **Subagent** — a separate execution context with its own tools and token budget. For isolation: heavy exploration, parallel reviews. A skill can call a subagent, but isn't one.
 
-Vuistregel: één-keer-werk → prompt. Herhaalbaar werk → skill. Zware isolatie van een sub-werkstroom → subagent.
+Rule of thumb: one-off work → prompt. Repeatable work → skill. Heavy isolation of a sub-workflow → subagent.
 
 </Details>
 
@@ -215,29 +215,29 @@ Vuistregel: één-keer-werk → prompt. Herhaalbaar werk → skill. Zware isolat
 
 <div className="tutorial-quiz">
 
-**2. Welke velden zijn verplicht in de frontmatter van een skill, en wat doen ze?**
+**2. Which fields are required in a skill's frontmatter, and what do they do?**
 
 <Details summary="Hint">
 
-Twee velden zijn écht verplicht. Eén ervan beslist over de mapnaam, de ander beslist of Claude de skill ooit oppikt.
+Two fields are truly required. One determines the folder name, the other determines whether Claude ever picks the skill up.
 
 </Details>
 
-<Details summary="Antwoord">
+<Details summary="Answer">
 
-Verplicht zijn:
+Required:
 
-- **`name`** — moet exact gelijk zijn aan de mapnaam (folder `review-pr` → `name: review-pr`). Wijkt het af, dan kun je de skill niet via `/<naam>` triggeren.
-- **`description`** — wat Claude leest om te beslissen of de skill relevant is. Action-oriented, derde persoon, concrete trigger-woorden vooraan.
+- **`name`** — must equal the folder name exactly (folder `review-pr` → `name: review-pr`). If it differs, you can't trigger the skill via `/<name>`.
+- **`description`** — what Claude reads to decide whether the skill is relevant. Action-oriented, third person, concrete trigger words up front.
 
-Optioneel, maar veel gebruikt:
+Optional, but commonly used:
 
-- **`metadata.category`** / **`metadata.tags`** — voor filteren/groeperen.
-- **`disable-model-invocation: true`** — alleen handmatig oproepbaar.
-- **`user-invocable: false`** — alleen automatisch laadbaar door Claude.
-- **`allowed-tools`** — beperkt welke tools de skill mag gebruiken.
+- **`metadata.category`** / **`metadata.tags`** — for filtering/grouping.
+- **`disable-model-invocation: true`** — only manually invocable.
+- **`user-invocable: false`** — only auto-loadable by Claude.
+- **`allowed-tools`** — restricts which tools the skill may use.
 
-Verreweg het belangrijkste veld is de `description`: alleen díe staat altijd in de system prompt geladen. De rest van de `SKILL.md` wordt pas gelezen wanneer de skill triggert.
+By far the most important field is the `description`: only that one is permanently loaded in the system prompt. The rest of the `SKILL.md` is only read once the skill triggers.
 
 </Details>
 
@@ -245,26 +245,26 @@ Verreweg het belangrijkste veld is de `description`: alleen díe staat altijd in
 
 <div className="tutorial-quiz">
 
-**3. Hoe weet Claude wanneer hij een skill moet triggeren — wat staat er in de `description`?**
+**3. How does Claude know when to trigger a skill — what goes in the `description`?**
 
 <Details summary="Hint">
 
-Claude leest een korte tekst en moet vervolgens op basis daarvan beslissen. Wat zou jij willen lezen om die beslissing snel en zeker te kunnen nemen?
+Claude reads a short piece of text and has to decide based on it. What would you want to read to make that decision fast and confident?
 
 </Details>
 
-<Details summary="Antwoord">
+<Details summary="Answer">
 
-Claude vergelijkt de huidige conversatie tegen de `description` van elke beschikbare skill. Een goede description:
+Claude matches the current conversation against the `description` of every available skill. A good description:
 
-1. **Begint met een action-werkwoord** (`Create`, `Review`, `Archive`, `Test`, …) — geen passieve constructies.
-2. **Front-loadt de kern in de eerste ~250 tekens** — daarna kapt het skill-listing af.
-3. **Bevat concrete trigger-woorden** — zelfstandige naamwoorden en werkwoorden die een gebruiker zou typen. ("Pull Request", "review", "GitHub branch" voor `review-pr`).
-4. **Is geschreven in derde persoon** — hij wordt letterlijk in de system prompt geïnjecteerd.
+1. **Starts with an action verb** (`Create`, `Review`, `Archive`, `Test`, …) — no passive constructions.
+2. **Front-loads the essence in the first ~250 characters** — skill listings cut off after that.
+3. **Contains concrete trigger words** — nouns and verbs a user would actually type. ("Pull Request", "review", "GitHub branch" for `review-pr`).
+4. **Is written in third person** — it gets injected verbatim into the system prompt.
 
-Vermijd vage formuleringen ("helpt met allerlei dingen"), de eerste persoon ("ik help je…"), en marketing-taal ("een handige tool voor…"). Concreet en specifiek wint altijd.
+Avoid vague phrasing ("helps with various things"), first person ("I'll help you…"), and marketing language ("a handy tool for…"). Concrete and specific always wins.
 
-Praktische realiteit: meerdere bronnen rapporteren ~50% auto-activatie zelfs voor goede skills, doordat Claude een vast contextbudget heeft voor skill-descriptions. Bij grote skill-libraries is expliciet `/skill-naam` typen altijd betrouwbaarder dan vertrouwen op auto-trigger.
+Practical reality: multiple sources report ~50% auto-activation even for good skills, because Claude has a fixed context budget for skill descriptions. With large skill libraries, typing `/skill-name` explicitly is always more reliable than relying on auto-trigger.
 
 </Details>
 
@@ -272,54 +272,54 @@ Praktische realiteit: meerdere bronnen rapporteren ~50% auto-activatie zelfs voo
 
 <div className="tutorial-quiz">
 
-**4. Wanneer is het beter om een gewone prompt te schrijven dan een skill?**
+**4. When is a plain prompt the better choice than a skill?**
 
 <Details summary="Hint">
 
-Vraag jezelf: ga ik dit nog een keer doen? En zou een collega dit ook willen?
+Ask yourself: am I going to do this again? And would a colleague want this too?
 
 </Details>
 
-<Details summary="Antwoord">
+<Details summary="Answer">
 
-Schrijf een gewone prompt als…
+Write a plain prompt when…
 
-- Het werk is **eenmalig**: een specifieke refactor, een onderzoeksvraag, een ad-hoc analyse.
-- Het is **persoonlijk**: alleen jij hebt het ooit nodig, niemand anders in het team — dan blijft het een eigen macro/snippet, geen team-skill.
-- Het is **moeilijk mechanisch beschrijfbaar**: "het hangt sterk van de context af", veel uitzonderingen, veel oordeel. Skills zijn voor herhaalbare patronen, niet voor situatie-specifieke beslissingen.
-- Je hebt **nog geen 3 keer hetzelfde gedaan**. Schrijf een skill pas wanneer je het patroon écht ziet — anders bouw je een abstractie op één voorbeeld.
+- The work is **one-off**: a specific refactor, a research question, an ad-hoc analysis.
+- It's **personal**: only you will ever need it, nobody else on the team — then it stays a personal macro/snippet, not a team skill.
+- It's **hard to describe mechanically**: "it heavily depends on the context", lots of exceptions, lots of judgement. Skills are for repeatable patterns, not situation-specific decisions.
+- You haven't **done the same thing three times yet**. Only write a skill once you really see the pattern — otherwise you're building an abstraction on a single example.
 
-Vuistregel ("rule of three"): één keer is toeval, twee keer ook nog, drie keer is een patroon dat een skill verdient.
+Rule of thumb ("rule of three"): once is coincidence, twice is still coincidence, three times is a pattern that deserves a skill.
 
 </Details>
 
 </div>
 
-<NextSteps title="Volgende stap" lede="Nu je weet wat een skill is, gaan we er in deel 2 zelf eentje schrijven — met /skill-creator als startpunt.">
+<NextSteps title="Next step" lede="Now that you know what a skill is, in part 2 we'll write one ourselves — starting from /skill-creator.">
   <NextStep
-    title="Deel 2 — Je eerste skill schrijven"
+    title="Part 2 — Writing your first skill"
     href="/academy/claude-skills-tutorial-2-je-eerste-skill"
-    description="Van mapje naar werkende skill: scaffolden met /skill-creator, een goede description schrijven, lokaal testen, en opnemen in de skill-registry."
+    description="From folder to working skill: scaffolding with /skill-creator, writing a good description, testing locally, and adding it to the skill registry."
   />
   <NextStep
-    title="Hydra-leerlijn — Deel 4: Skills in de praktijk"
+    title="Hydra track — Part 4: Skills in practice"
     href="/academy/hydra-tutorial-4-skills"
-    description="Wil je vooraf al een gevoel krijgen waar skills in een echte agentic loop landen? Hydra's deel 4 laat de skill-families zien die de fabriek draaiende houden (opsx-*, hydra-gate-*, team-*, test-*)."
+    description="Want a feel up front for where skills land in a real agentic loop? Hydra's part 4 shows the skill families that keep the factory running (opsx-*, hydra-gate-*, team-*, test-*)."
   />
   <NextStep
     title="Anthropic — Skill authoring best practices"
     href="https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices"
-    description="De officiële Anthropic-documentatie over skill-structuur, descriptions en progressive disclosure. Goed als achtergrondlectuur."
+    description="The official Anthropic docs on skill structure, descriptions and progressive disclosure. Good background reading."
   />
   <NextStep
     title="Agent Skills Open Standard"
     href="https://agentskills.io/specification"
-    description="De open standaard voor het SKILL.md-formaat, geadopteerd door 20+ tools (OpenAI Codex, Gemini CLI, Cursor, GitHub Copilot)."
+    description="The open standard for the SKILL.md format, adopted by 20+ tools (OpenAI Codex, Gemini CLI, Cursor, GitHub Copilot)."
   />
 </NextSteps>
 
 <ContactCta
-  title="Vragen over Claude Skills?"
-  body="Stuur ons gerust een mail of stel je vraag via GitHub Discussions op de .github-repo. We helpen je graag op weg."
-  cta={{ label: "Mail Conduction", href: "mailto:info@conduction.nl?subject=Claude%20Skills%20leerlijn%20deel%201" }}
+  title="Questions about Claude Skills?"
+  body="Drop us an email or ask your question via GitHub Discussions on the .github repo. We're happy to help you get going."
+  cta={{ label: "Email Conduction", href: "mailto:info@conduction.nl?subject=Claude%20Skills%20track%20part%201" }}
 />

--- a/academy/2026-05-15-claude-skills-tutorial-2-je-eerste-skill/index.mdx
+++ b/academy/2026-05-15-claude-skills-tutorial-2-je-eerste-skill/index.mdx
@@ -1,10 +1,10 @@
 ---
 slug: claude-skills-tutorial-2-je-eerste-skill
-title: "Claude Skills leerlijn — Deel 2: Je eerste skill schrijven"
+title: "Claude Skills tutorial series — Part 2: Writing your first skill"
 contentType: tutorial
 authors: [conduction]
 date: 2026-05-15
-summary: Schrijf van scratch een werkende Claude Skill — een mini-skill die git-statussen samenvat. Met /skill-creator als startpunt, een goede description, lokaal testen, en opnemen in je registry. Tweede van vier korte modules.
+summary: Write a working Claude Skill from scratch — a mini-skill that summarises git statuses. Using /skill-creator as a starting point, a solid description, local testing, and adding it to your registry. Second of four short modules.
 tags: [Claude, Claude Code, Skills, AI, Tutorial series]
 apps: []
 durationMinutes: 18
@@ -15,28 +15,28 @@ partNumber: 2
 import {Outcomes, Outcome, Prerequisites, PrerequisiteItem, NextSteps, NextStep, HexCard, ContactCta} from '@conduction/docusaurus-preset/components';
 import Details from '@theme/Details';
 
-In deel 1 zag je wát een skill is. In dit deel ga je er zélf eentje schrijven: een werkende `git-status-summary` skill die een leesbare samenvatting maakt van de huidige working tree. Aan het eind staat hij in je `~/.claude/skills/`-folder, kun je hem aanroepen via `/git-status-summary`, en weet je hoe je hem deelt met je team.
+In part 1 you saw *what* a skill is. In this part you'll write one yourself: a working `git-status-summary` skill that produces a readable summary of the current working tree. At the end it sits in your `~/.claude/skills/` folder, you can invoke it via `/git-status-summary`, and you'll know how to share it with your team.
 
 {/* truncate */}
 
-<Outcomes title="Wat je leert in dit deel">
-  <Outcome>Een complete skill scaffolden met <code>/skill-creator</code> in plaats van zelf folders aanleggen.</Outcome>
-  <Outcome>Een goede <code>description</code> schrijven die zowel handmatig (<code>/</code>) als automatisch betrouwbaar triggert.</Outcome>
-  <Outcome>De skill lokaal testen vóór je hem deelt — met een should-trigger / should-not-trigger checklist.</Outcome>
-  <Outcome>Wanneer een skill globaal hoort (<code>~/.claude/skills/</code>) en wanneer in een project (<code>repo/.claude/skills/</code>).</Outcome>
+<Outcomes title="What you'll learn in this part">
+  <Outcome>Scaffold a complete skill with <code>/skill-creator</code> instead of laying out folders by hand.</Outcome>
+  <Outcome>Write a good <code>description</code> that triggers reliably both manually (<code>/</code>) and automatically.</Outcome>
+  <Outcome>Test the skill locally before you share it — using a should-trigger / should-not-trigger checklist.</Outcome>
+  <Outcome>When a skill belongs in global scope (<code>~/.claude/skills/</code>) and when in a project (<code>repo/.claude/skills/</code>).</Outcome>
 </Outcomes>
 
-<Prerequisites title="Wat je nodig hebt">
-  <PrerequisiteItem>Deel 1 doorgenomen: <a href="/academy/claude-skills-tutorial-1-wat-zijn-claude-skills">Wat zijn Claude Skills?</a></PrerequisiteItem>
-  <PrerequisiteItem>Claude Code geïnstalleerd, en een werkende sessie in een willekeurige Git-repo. Zelfs een leeg <code>git init</code> mapje is voldoende.</PrerequisiteItem>
-  <PrerequisiteItem>De <code>skill-creator</code> skill geïnstalleerd. Hij komt standaard mee als plugin met Claude Code; als je hem niet hebt: <code>git clone https://github.com/anthropics/skills</code> en kopieer <code>skills/skill-creator/</code> naar je <code>~/.claude/skills/</code>.</PrerequisiteItem>
+<Prerequisites title="What you need">
+  <PrerequisiteItem>Part 1 read: <a href="/academy/claude-skills-tutorial-1-wat-zijn-claude-skills">What are Claude Skills?</a></PrerequisiteItem>
+  <PrerequisiteItem>Claude Code installed, and a working session in any Git repo. Even an empty <code>git init</code> folder is enough.</PrerequisiteItem>
+  <PrerequisiteItem>The <code>skill-creator</code> skill installed. It ships as a plugin with Claude Code by default; if you don't have it: <code>git clone https://github.com/anthropics/skills</code> and copy <code>skills/skill-creator/</code> into your <code>~/.claude/skills/</code>.</PrerequisiteItem>
 </Prerequisites>
 
-## Wat we gaan bouwen
+## What we're building
 
-Een mini-skill die je `git status` leesbaar samenvat — met categorieën (staged / unstaged / untracked), bestandsaantallen, en een lijst van wijzigingen per categorie. Eenvoudig genoeg om in dit deel volledig te schrijven, maar concreet genoeg om alle stappen mee te illustreren.
+A mini-skill that summarises your `git status` in a readable way — with categories (staged / unstaged / untracked), file counts, and a list of changes per category. Simple enough to write out completely in this part, but concrete enough to illustrate every step.
 
-Eindresultaat: typ `/git-status-summary` in je sessie en je krijgt iets zoals:
+End result: type `/git-status-summary` in your session and you get something like:
 
 ```
 Working tree status
@@ -54,52 +54,52 @@ Untracked (1 file):
   • notes.txt
 ```
 
-## Stap 1 — Scaffold met `/skill-creator`
+## Step 1 — Scaffold with `/skill-creator`
 
-De makkelijkste manier om een nieuwe skill te starten is **niet** zelf folders aanleggen, maar `/skill-creator` laten begeleiden. Open een Claude-sessie en typ:
+The easiest way to start a new skill is **not** to lay out folders yourself, but to let `/skill-creator` guide you. Open a Claude session and type:
 
 ```
 /skill-creator
 ```
 
-Claude vraagt je vervolgens wat je wilt maken. Antwoord ongeveer zo:
+Claude then asks what you want to create. Answer roughly like this:
 
-> Ik wil een skill `git-status-summary` die `git status --porcelain` draait, de output parset, en in drie groepen (staged / unstaged / untracked) presenteert met bestandsnamen en wijzigings-type. Hij hoort op alle Git-repo's te werken.
+> I want a skill `git-status-summary` that runs `git status --porcelain`, parses the output, and presents it in three groups (staged / unstaged / untracked) with filenames and change type. It should work on any Git repo.
 
-`/skill-creator` zal vervolgens:
+`/skill-creator` will then:
 
-1. Vragen om een korte description — geef hier de zorgvuldig geformuleerde versie van hieronder.
-2. Vragen of de skill side-effects heeft (nee — alleen lezen).
-3. Een mapje aanmaken: `~/.claude/skills/git-status-summary/` met een eerste `SKILL.md`.
+1. Ask for a short description — paste the carefully crafted version from below here.
+2. Ask whether the skill has side effects (no — read-only).
+3. Create a folder: `~/.claude/skills/git-status-summary/` with a starter `SKILL.md`.
 
-:::tip Niet bang zijn om met de hand te starten
-Als `/skill-creator` om wat voor reden dan ook niet werkt, kun je het mapje ook gewoon aanmaken: `mkdir -p ~/.claude/skills/git-status-summary && touch ~/.claude/skills/git-status-summary/SKILL.md`. De skill is een doodgewoon tekstbestand.
+:::tip Don't be afraid to start by hand
+If `/skill-creator` doesn't work for any reason, you can also just create the folder directly: `mkdir -p ~/.claude/skills/git-status-summary && touch ~/.claude/skills/git-status-summary/SKILL.md`. The skill is a plain text file.
 :::
 
-## Stap 2 — De `description` zorgvuldig formuleren
+## Step 2 — Craft the `description` carefully
 
-Herinner je uit deel 1: alleen de `description` staat altijd in de system prompt geladen. Hier valt of staat je auto-triggering.
+Recall from part 1: only the `description` is permanently loaded in the system prompt. This is where your auto-triggering stands or falls.
 
-Een goede description voor onze skill:
+A good description for our skill:
 
 ```
 description: Summarise the current Git working tree — groups changes by staged, unstaged, and untracked, and lists files per group with their change type
 ```
 
-Wat zit daarin?
+What's in there?
 
-| Stuk | Waarom |
+| Piece | Why |
 |---|---|
-| `Summarise` | Action-werkwoord vooraan. Geen "this skill is" of "helps with". |
-| `current Git working tree` | Concrete trigger-woorden: iemand die "git status overview" of "what's changed" typt, raakt hier. |
-| `groups changes by staged, unstaged, and untracked` | Vertelt Claude precies wat hij krijgt — handig bij keuzes tussen meerdere skills. |
-| `lists files per group with their change type` | Sluit af met het waarneembare resultaat, zodat een gebruiker meteen herkent of dit is wat hij zoekt. |
+| `Summarise` | Action verb up front. No "this skill is" or "helps with". |
+| `current Git working tree` | Concrete trigger words: someone who types "git status overview" or "what's changed" lands here. |
+| `groups changes by staged, unstaged, and untracked` | Tells Claude exactly what he gets — useful when choosing between several skills. |
+| `lists files per group with their change type` | Closes with the observable result so a user immediately recognises whether this is what they want. |
 
-Schrijf 'm in **derde persoon** (de description wordt letterlijk geïnjecteerd in de system prompt) en blijf onder ~250 tekens — daarna kapt skill-listings af.
+Write it in **third person** (the description is injected verbatim into the system prompt) and stay under ~250 characters — skill listings cut off after that.
 
-## Stap 3 — Schrijf de `SKILL.md`
+## Step 3 — Write the `SKILL.md`
 
-Open `~/.claude/skills/git-status-summary/SKILL.md` en vul hem zo:
+Open `~/.claude/skills/git-status-summary/SKILL.md` and fill it in like this:
 
 ````markdown
 ---
@@ -172,42 +172,42 @@ working directory.
 - Do not invent files. Only list what `git status --porcelain` actually returns.
 ````
 
-Drie dingen om op te merken:
+Three things to note:
 
-1. **Genummerde stappen** — geen prozaïsche paragrafen. Eén handeling per stap, met een duidelijke kop.
-2. **Een "Guardrails" sectie** — wat de skill expliciet niet mag. Voor read-only skills is de regel "geen schrijfacties" cruciaal.
-3. **Concreet output-formaat in een code-block** — Claude volgt zichtbare voorbeelden veel betrouwbaarder dan vage instructies.
+1. **Numbered steps** — no prose paragraphs. One action per step, with a clear heading.
+2. **A "Guardrails" section** — what the skill explicitly may not do. For read-only skills, the "no write actions" rule is crucial.
+3. **Concrete output format in a code block** — Claude follows visible examples far more reliably than vague instructions.
 
-### Hoe specifiek moet je SKILL.md zijn? — degrees of freedom
+### How specific should your SKILL.md be? — degrees of freedom
 
-Een veelgemaakte fout: alle skills hetzelfde detail-niveau geven. In de praktijk past je specificiteit zich aan de fragiliteit van de taak aan:
+A common mistake: giving every skill the same level of detail. In practice, your specificity should match the fragility of the task:
 
-| Soort taak | Vrijheid | Skill-stijl |
+| Kind of task | Freedom | Skill style |
 |---|:---:|---|
-| Exploratie, brainstorm, code review | **Hoog** | Geef doelen en kaders, laat Claude de aanpak kiezen |
-| Feature-werk, refactor | **Middel** | Geef stappen met beslispunten, laat Claude adapteren |
-| DB-migraties, production-deploys, CI-config | **Laag** | Voorgeschreven commando's, expliciete confirmation-gates |
+| Exploration, brainstorming, code review | **High** | Give goals and guardrails, let Claude pick the approach |
+| Feature work, refactor | **Medium** | Give steps with decision points, let Claude adapt |
+| DB migrations, production deploys, CI config | **Low** | Prescribed commands, explicit confirmation gates |
 
-Onze `git-status-summary` is read-only en mechanisch — middel-tot-laag, met expliciete formattering en harde guardrails. Een hypothetische `/explore-architecture` zou juist hoge vrijheid willen ("denk hardop, vergelijk opties, geen vaste vorm").
+Our `git-status-summary` is read-only and mechanical — medium-to-low, with explicit formatting and hard guardrails. A hypothetical `/explore-architecture` would want high freedom instead ("think out loud, compare options, no fixed shape").
 
-### Dynamic content: argumenten en shell-output injecteren
+### Dynamic content: injecting arguments and shell output
 
-Een laatste stuk syntax dat je verderop tegen gaat komen, maar nog niet nodig hebt voor `git-status-summary`:
+A last bit of syntax you'll run into later, but don't need yet for `git-status-summary`:
 
-| Syntax | Betekenis | Voorbeeld |
+| Syntax | Meaning | Example |
 |---|---|---|
-| `$ARGUMENTS` | Alles wat na `/skill-naam` getypt is | `/app-create my-app` → `$ARGUMENTS` = `"my-app"` |
-| `$ARGUMENTS[0]` | Eerste positionele argument | Eerste woord na de skill-naam |
-| `${CLAUDE_SKILL_DIR}` | Absoluut pad naar de skill-folder | Voor verwijzingen naar bundled scripts |
-| `` !`command` `` | Shell-output geïnjecteerd vóór de skill laadt | `` !`git branch --show-current` `` injecteert de huidige branch |
+| `$ARGUMENTS` | Everything typed after `/skill-name` | `/app-create my-app` → `$ARGUMENTS` = `"my-app"` |
+| `$ARGUMENTS[0]` | First positional argument | First word after the skill name |
+| `${CLAUDE_SKILL_DIR}` | Absolute path to the skill folder | For references to bundled scripts |
+| `` !`command` `` | Shell output injected *before* the skill loads | `` !`git branch --show-current` `` injects the current branch |
 
-Vooral de `` !`command` ``-syntax is krachtig: hij draait *voordat* de skill in context komt, dus je kunt runtime-informatie (current branch, git-user, datum) als context meegeven aan Claude. Niet nodig voor onze mini-skill, maar goed om te kennen voor wanneer je meer dynamische skills schrijft.
+The `` !`command` `` syntax in particular is powerful: it runs *before* the skill enters context, so you can pass runtime information (current branch, git user, date) to Claude as context. Not needed for our mini-skill, but worth knowing about for when you write more dynamic skills.
 
-### De gebruiker iets vragen: `AskUserQuestion`
+### Asking the user something: `AskUserQuestion`
 
-Sommige skills hebben input nodig die je niet uit shell-commando's kunt afleiden — bijvoorbeeld een keuze tussen twee aanpakken, of confirmatie vóór een destructieve actie. Daarvoor is er de **`AskUserQuestion`** tool: een ingebouwde Claude Code-tool waarmee een skill midden in z'n uitvoering een korte multiple-choice vraag aan de gebruiker stelt en op het antwoord wacht.
+Some skills need input you can't derive from shell commands — for example a choice between two approaches, or confirmation before a destructive action. For that there is the **`AskUserQuestion`** tool: a built-in Claude Code tool that lets a skill, mid-execution, ask the user a short multiple-choice question and wait for the answer.
 
-In je `SKILL.md` instrueer je 'm gewoon in tekst:
+In your `SKILL.md` you simply instruct it in text:
 
 ```markdown
 3. **Confirm before applying**
@@ -217,104 +217,104 @@ In je `SKILL.md` instrueer je 'm gewoon in tekst:
    Only continue to step 4 if the user picks the first option.
 ```
 
-Wanneer gebruiken: bij beslismomenten waar Claude niet zelfstandig mag kiezen (production-deploys, branch-strategie, gevoelige refactors). Wanneer níet: voor info die je uit `git`, `gh` of het bestand zelf kunt halen — dan is `` !`command` `` of een Read-call sneller en minder storend. Voor `git-status-summary` is er geen keuzemoment, dus we gebruiken hem niet — maar onthou hem voor je volgende, zwaardere skill.
+When to use it: at decision moments where Claude shouldn't choose autonomously (production deploys, branch strategy, sensitive refactors). When *not*: for info you can pull from `git`, `gh` or the file itself — then `` !`command` `` or a Read call is faster and less intrusive. There's no decision moment in `git-status-summary`, so we don't use it — but keep it in mind for your next, heavier skill.
 
-## Stap 4 — Lokaal testen
+## Step 4 — Test locally
 
-Vóór je de skill deelt: test hem zelf. Drie soorten tests:
+Before you share the skill: test it yourself. Three kinds of tests:
 
-### A. Handmatige trigger
+### A. Manual trigger
 
-Open een Claude-sessie in een Git-repo met wat unstaged wijzigingen en typ:
+Open a Claude session in a Git repo with some unstaged changes and type:
 
 ```
 /git-status-summary
 ```
 
-Wat je verwacht: een nette samenvatting in het beloofde formaat. Wat je controleert: klopt de telling? Mist er een bestand? Worden staged + unstaged dubbel getoond bij gemengde wijzigingen?
+What you expect: a clean summary in the promised format. What you check: do the counts match? Is a file missing? Are staged + unstaged shown twice for mixed changes?
 
 ### B. Auto-trigger checklist
 
-De moeilijkere test: triggert hij automatisch wanneer hij zou moeten, en blijft hij stil wanneer dat niet zou moeten?
+The harder test: does it trigger automatically when it should, and stay quiet when it shouldn't?
 
-| Prompt | Verwacht gedrag |
+| Prompt | Expected behaviour |
 |---|---|
-| "Wat is er veranderd in mijn working tree?" | **Should trigger** |
-| "Geef me een overzicht van staged en unstaged" | **Should trigger** |
-| "Show me the diff for src/App.vue" | **Should not trigger** (dat is `git diff`, niet status) |
-| "Commit my changes" | **Should not trigger** (write-actie, niet status) |
-| "Wat doet git rebase?" | **Should not trigger** (informatieve vraag) |
+| "What's changed in my working tree?" | **Should trigger** |
+| "Give me an overview of staged and unstaged" | **Should trigger** |
+| "Show me the diff for src/App.vue" | **Should not trigger** (that's `git diff`, not status) |
+| "Commit my changes" | **Should not trigger** (write action, not status) |
+| "What does git rebase do?" | **Should not trigger** (informational question) |
 
-Loopt een prompt mis? Pas de `description` aan en probeer opnieuw. Triggert hij over-eager? Voeg specifiekere woorden toe ("working tree", "staged/unstaged/untracked"). Triggert hij niet vaak genoeg? Haal jargon weg en voeg natuurlijke termen toe ("git status overview", "what's changed").
+A prompt going wrong? Tweak the `description` and try again. Triggers over-eagerly? Add more specific words ("working tree", "staged/unstaged/untracked"). Triggers too rarely? Strip jargon and add natural terms ("git status overview", "what's changed").
 
 ### C. Edge cases
 
-- **Lege repo** — geen commits, geen wijzigingen. Krijg je de "Working tree clean" boodschap?
-- **Alleen untracked** — `echo "test" > new.txt` zonder add. Wordt alleen de Untracked-groep getoond?
-- **Bestand met spaties** — `touch "my file.txt" && git add "my file.txt"`. Wordt de naam correct gerenderd?
+- **Empty repo** — no commits, no changes. Do you get the "Working tree clean" message?
+- **Untracked only** — `echo "test" > new.txt` without add. Is only the Untracked group shown?
+- **File with spaces** — `touch "my file.txt" && git add "my file.txt"`. Is the name rendered correctly?
 
-## Stap 5 — Globaal of per project?
+## Step 5 — Global or per project?
 
-Nu de skill werkt, is de vraag: waar laat je hem staan?
+Now that the skill works, the question is: where do you keep it?
 
-<HexCard title="~/.claude/skills/ — globaal">
-  Voor skills die je in <strong>elke repo</strong> bruikbaar vindt. Onze <code>git-status-summary</code> is hier een goede kandidaat — het is een algemeen Git-hulpmiddel. Nadeel: je teamgenoten hebben hem niet automatisch.
+<HexCard title="~/.claude/skills/ — global">
+  For skills you find useful in <strong>every repo</strong>. Our <code>git-status-summary</code> is a good candidate here — it's a general Git helper. Downside: your teammates don't get it automatically.
 </HexCard>
 
 <HexCard title="repo/.claude/skills/ — per project">
-  Voor skills die <strong>specifiek voor deze repo</strong> zijn (eigen quality-gates, eigen workflow, eigen domein-kennis). Voordeel: je commit hem, je team heeft hem, en CI/Hydra-containers gebruiken dezelfde versie. Bijna alle skills in Conduction-repo's leven hier.
+  For skills <strong>specific to this repo</strong> (custom quality gates, custom workflow, custom domain knowledge). Upside: you commit it, your team gets it, and CI/Hydra containers use the same version. Almost all skills in Conduction repos live here.
 </HexCard>
 
-<HexCard title="vendor/skills/ — extern">
-  Voor skills die je <strong>van buiten</strong> importeert (Anthropic-community, Trail of Bits, OWASP). Apart houden helpt bij audit-spoor en onderhoud — externe skills muteer je niet, je volgt de bron.
+<HexCard title="vendor/skills/ — external">
+  For skills you <strong>import from outside</strong> (Anthropic community, Trail of Bits, OWASP). Keeping them separate helps with audit trail and maintenance — you don't mutate external skills, you follow upstream.
 </HexCard>
 
-Voor `git-status-summary` is globaal prima. Voor een fictieve `conduction-quality-check`-skill die de Conduction-specifieke PHPCS/Psalm/ESLint-config draait, hoort het in `.claude/skills/` van de project-repo zelf.
+For `git-status-summary` global is fine. For a fictional `conduction-quality-check` skill that runs the Conduction-specific PHPCS/Psalm/ESLint config, it belongs in `.claude/skills/` of the project repo itself.
 
-## Stap 6 — Opnemen in de skill-registry
+## Step 6 — Add it to the skill registry
 
-Binnen Conduction houden we een lijst bij van alle interne skills (zowel persoonlijk relevant als project-niveau). Als je een nieuwe skill schrijft die voor het team waardevol is:
+Within Conduction we keep a list of all internal skills (both personally useful and project-level). If you write a new skill that's valuable to the team:
 
-1. **Voeg 'm toe aan de relevante repo** — meestal `<repo>/.claude/skills/<naam>/` met een gewone commit.
-2. **Update de `README.md` van die `.claude/skills/`-folder** als die bestaat — voeg een regel toe met naam, één-zin-omschrijving, en wanneer je hem aanroept.
-3. **Update de Hydra skill-docs in [`ConductionNL/.github`](https://github.com/ConductionNL/.github)** als de skill in een Hydra-pipeline meedraait — de centrale documentatie over welke skills Hydra kent, in welke familie ze horen en wat ze doen, leeft daar. Zonder die update weet de rest van het team (en latere Hydra-runs) niet dat je skill bestaat.
-4. **Open een PR** en laat één teamgenoot de skill triggeren in zijn eigen sessie. Niet de description theoretisch beoordelen — letterlijk een prompt typen die zou moeten triggeren.
+1. **Add it to the relevant repo** — usually `<repo>/.claude/skills/<name>/` with a regular commit.
+2. **Update the `README.md` of that `.claude/skills/` folder** if it exists — add a line with the name, a one-sentence description, and when you invoke it.
+3. **Update the Hydra skill docs in [`ConductionNL/.github`](https://github.com/ConductionNL/.github)** if the skill runs in a Hydra pipeline — the central documentation about which skills Hydra knows, what family they belong to, and what they do lives there. Without that update, the rest of the team (and later Hydra runs) won't know your skill exists.
+4. **Open a PR** and let one teammate trigger the skill in their own session. Don't review the description theoretically — literally type a prompt that ought to trigger it.
 
-Voor globaal-persoonlijke skills (`~/.claude/skills/`) hoeft niets gecommit te worden — het is je eigen workshop.
+For global-personal skills (`~/.claude/skills/`) nothing needs to be committed — it's your own workshop.
 
-## Veelgemaakte beginnersfouten
+## Common beginner mistakes
 
-| Symptoom | Oorzaak | Fix |
+| Symptom | Cause | Fix |
 |---|---|---|
-| Skill triggert nooit automatisch | `description` is te vaag of mist trigger-woorden | Herschrijf in derde persoon, action-werkwoord vooraan, concrete zelfstandige naamwoorden uit de gebruiker-vraag |
-| Skill triggert te vaak op onverwante prompts | `description` is te breed of overlapt met andere skills | Voeg specifieke afbakening toe ("only for X, not Y") |
-| `/skill-naam` werkt niet | `name`-veld in frontmatter wijkt af van mapnaam | Maak ze identiek (folder `git-status-summary` → `name: git-status-summary`) |
-| Skill doet iets onverwachts destructiefs | Geen guardrails | Voeg een **Guardrails** sectie toe met expliciete "never do X"-regels |
-| Skill werkt op één laptop, niet op een andere | Hardcoded paden of OS-specifieke commando's | Gebruik relatieve paden; check OS-afhankelijke commando's (`grep` vs `ggrep`, etc.) |
+| Skill never triggers automatically | `description` is too vague or lacks trigger words | Rewrite in third person, action verb up front, concrete nouns from the user's question |
+| Skill triggers too often on unrelated prompts | `description` is too broad or overlaps with other skills | Add specific scoping ("only for X, not Y") |
+| `/skill-name` doesn't work | `name` field in frontmatter differs from folder name | Make them identical (folder `git-status-summary` → `name: git-status-summary`) |
+| Skill does something unexpectedly destructive | No guardrails | Add a **Guardrails** section with explicit "never do X" rules |
+| Skill works on one laptop, not another | Hardcoded paths or OS-specific commands | Use relative paths; check OS-dependent commands (`grep` vs `ggrep`, etc.) |
 
-## Test jezelf
+## Test yourself
 
-Vier korte vragen om te checken of je dit deel begrepen hebt. Vastgelopen? Klik **Hint**. Curieus naar het antwoord? Klik **Antwoord**.
+Four short questions to check you understood this part. Stuck? Click **Hint**. Curious about the answer? Click **Answer**.
 
 <div className="tutorial-quiz">
 
-**1. Hoe test je een skill voordat je hem deelt met het team?**
+**1. How do you test a skill before sharing it with the team?**
 
 <Details summary="Hint">
 
-Drie soorten tests: een handmatige, een over auto-triggering, en eentje voor randgevallen. Wat doet elk daarvan?
+Three kinds of tests: a manual one, one for auto-triggering, and one for edge cases. What does each of them do?
 
 </Details>
 
-<Details summary="Antwoord">
+<Details summary="Answer">
 
-Drie niveaus:
+Three levels:
 
-1. **Handmatige trigger** — typ `/skill-naam` in een sessie waar de skill van toepassing is. Controleer of de output klopt en het formaat strak is.
-2. **Auto-trigger checklist** — verzin 5+ prompts die wél moeten triggeren en 5+ die níet mogen triggeren. Loop ze één voor één door. Triggert hij te weinig? `description` te vaag. Te vaak? `description` te breed.
-3. **Edge cases** — test situaties die voorzienbaar mis kunnen gaan (lege input, speciale tekens, ontbrekende dependencies). Een skill die de happy path doet maar de leeg-geval mist, is niet af.
+1. **Manual trigger** — type `/skill-name` in a session where the skill applies. Check that the output is correct and the format is tight.
+2. **Auto-trigger checklist** — come up with 5+ prompts that *should* trigger and 5+ that *should not* trigger. Walk through them one by one. Triggers too rarely? `description` too vague. Too often? `description` too broad.
+3. **Edge cases** — test situations that can predictably go wrong (empty input, special characters, missing dependencies). A skill that handles the happy path but misses the empty case isn't finished.
 
-Pas na alle drie deel je hem — anders ontdek je problemen in een teamgenoot z'n sessie in plaats van je eigen.
+Only after all three do you share it — otherwise you discover problems in a teammate's session instead of your own.
 
 </Details>
 
@@ -322,19 +322,19 @@ Pas na alle drie deel je hem — anders ontdek je problemen in een teamgenoot z'
 
 <div className="tutorial-quiz">
 
-**2. Waar zou je een skill voor "Conduction-specifieke PR-template invullen" plaatsen — globaal of per project?**
+**2. Where would you put a skill for "fill in the Conduction-specific PR template" — global or per project?**
 
 <Details summary="Hint">
 
-De vraag is: voor wie is dit nuttig? Alleen jij, of het hele team?
+The question is: who is this useful for? Just you, or the whole team?
 
 </Details>
 
-<Details summary="Antwoord">
+<Details summary="Answer">
 
-**Per project**, in `<repo>/.claude/skills/`. Reden: het is Conduction-specifiek (een algemene Claude-gebruiker zou er niets aan hebben) en je wilt dat het hele team — én Hydra's containers — dezelfde versie heeft. Commit hem in Git, zodat hij meekomt met elke fresh checkout.
+**Per project**, in `<repo>/.claude/skills/`. Reason: it's Conduction-specific (a general Claude user wouldn't benefit) and you want the whole team — and Hydra's containers — to have the same version. Commit it to Git so it comes along with every fresh checkout.
 
-Globaal (`~/.claude/skills/`) is voor skills die jij over álle repo's heen handig vindt en die niets met de specifieke codebase te maken hebben. Bijvoorbeeld: een persoonlijke `summarise-clipboard` skill.
+Global (`~/.claude/skills/`) is for skills you find useful across *all* repos and that have nothing to do with the specific codebase. For example: a personal `summarise-clipboard` skill.
 
 </Details>
 
@@ -342,22 +342,22 @@ Globaal (`~/.claude/skills/`) is voor skills die jij over álle repo's heen hand
 
 <div className="tutorial-quiz">
 
-**3. Waarom moet de `name` in de frontmatter exact gelijk zijn aan de mapnaam?**
+**3. Why must the `name` in the frontmatter exactly match the folder name?**
 
 <Details summary="Hint">
 
-De naam die je achter `/` typt moet ergens vandaan komen. Wat ziet Claude eerst — de map of het frontmatter-veld?
+The name you type after `/` has to come from somewhere. What does Claude see first — the folder or the frontmatter field?
 
 </Details>
 
-<Details summary="Antwoord">
+<Details summary="Answer">
 
-Claude vindt skills door je `~/.claude/skills/` en `.claude/skills/` te scannen op mappen met een `SKILL.md`. Voor de slash-trigger kijkt hij naar het `name`-veld in de frontmatter. Komen die niet overeen, dan zijn er twee mogelijke symptomen:
+Claude finds skills by scanning your `~/.claude/skills/` and `.claude/skills/` for folders containing a `SKILL.md`. For the slash trigger it looks at the `name` field in the frontmatter. If they don't match, there are two possible symptoms:
 
-- **`/foldername` werkt niet** maar `/nameveld` wel — verwarrend, want je teamgenoot kent alleen de mapnaam uit Git.
-- **Auto-trigger werkt onverwacht** — Claude koppelt de description aan het frontmatter-name, niet aan de mapnaam.
+- **`/foldername` doesn't work** but `/namefield` does — confusing, because your teammate only knows the folder name from Git.
+- **Auto-trigger behaves unexpectedly** — Claude links the description to the frontmatter name, not the folder name.
 
-Vuistregel: kies één naam, gebruik 'm overal hetzelfde. `skill-creator` zorgt dat dit klopt; bij handmatig scaffolden moet je er zelf op letten.
+Rule of thumb: pick one name, use it everywhere identically. `skill-creator` keeps them in sync; with manual scaffolding you have to watch it yourself.
 
 </Details>
 
@@ -365,48 +365,48 @@ Vuistregel: kies één naam, gebruik 'm overal hetzelfde. `skill-creator` zorgt 
 
 <div className="tutorial-quiz">
 
-**4. Je hebt een skill die soms over-eager triggert op onverwante prompts. Wat is je eerste actie?**
+**4. You have a skill that sometimes over-eagerly triggers on unrelated prompts. What's your first action?**
 
 <Details summary="Hint">
 
-Welk veld bepaalt wanneer Claude een skill oppikt? En welk gereedschap heb je om dat veld te valideren?
+Which field decides when Claude picks up a skill? And what tool do you have to validate that field?
 
 </Details>
 
-<Details summary="Antwoord">
+<Details summary="Answer">
 
-Pas de **`description`** aan. Concreet:
+Tweak the **`description`**. Concretely:
 
-1. **Maak hem specifieker** — voeg trigger-woorden toe die alleen bij de bedoelde situatie passen ("for the current Git working tree", niet alleen "for changes").
-2. **Voeg afbakening toe** — een korte zin als "Only for X, not Y" werkt verrassend goed.
-3. **Test opnieuw** met je should-trigger / should-not-trigger checklist (zie vraag 1).
+1. **Make it more specific** — add trigger words that only fit the intended situation ("for the current Git working tree", not just "for changes").
+2. **Add scoping** — a short sentence like "Only for X, not Y" works surprisingly well.
+3. **Re-test** with your should-trigger / should-not-trigger checklist (see question 1).
 
-Pas als de description al ijzersterk is en hij nóg over-eager is, overweeg `disable-model-invocation: true` om auto-triggering helemaal uit te zetten en alleen `/<naam>` toe te staan. Dat is een laatste redmiddel — meestal lost een betere description het op.
+Only once the description is rock-solid and it's *still* over-eager should you consider `disable-model-invocation: true` to turn auto-triggering off entirely and only allow `/<name>`. That's a last resort — usually a better description solves it.
 
 </Details>
 
 </div>
 
-<NextSteps title="Volgende stap" lede="Je skill werkt nu. In deel 3 leer je hoe je systematisch meet of hij blijft werken — met skill-evals.">
+<NextSteps title="Next step" lede="Your skill works now. In part 3 you'll learn how to systematically measure whether it keeps working — with skill evals.">
   <NextStep
-    title="Deel 3 — Skill-evals: meten of je skill werkt"
+    title="Part 3 — Skill evals: measuring whether your skill works"
     href="/academy/claude-skills-tutorial-3-skill-evals"
-    description="Test-scenario's schrijven, baseline-meting, trigger-tests. Hoe je van een 'voelt goed' skill naar een gemeten skill gaat (Maturity Level 5)."
+    description="Writing test scenarios, baseline measurement, trigger tests. How to move from a 'feels good' skill to a measured skill (Maturity Level 5)."
   />
   <NextStep
-    title="Vorige stap — Wat zijn Claude Skills?"
+    title="Previous step — What are Claude Skills?"
     href="/academy/claude-skills-tutorial-1-wat-zijn-claude-skills"
-    description="De concept-introductie als je nog wilt teruglezen."
+    description="The concept introduction if you want to re-read it."
   />
   <NextStep
-    title="Anthropic skill-creator op GitHub"
+    title="Anthropic skill-creator on GitHub"
     href="https://github.com/anthropics/skills/blob/main/skills/skill-creator/SKILL.md"
-    description="De officiële skill-creator skill, met scripts voor scaffolden, eval-runner, en description-optimizer."
+    description="The official skill-creator skill, with scripts for scaffolding, eval runner, and description optimiser."
   />
 </NextSteps>
 
 <ContactCta
-  title="Vastgelopen bij je eerste skill?"
-  body="Stuur ons je SKILL.md en de prompts waarmee je test — we kijken even mee en helpen je 'm sneller goed te krijgen."
-  cta={{ label: "Mail Conduction", href: "mailto:info@conduction.nl?subject=Claude%20Skills%20leerlijn%20deel%202" }}
+  title="Stuck on your first skill?"
+  body="Send us your SKILL.md and the prompts you're testing with — we'll take a look and help you get it right faster."
+  cta={{ label: "Email Conduction", href: "mailto:info@conduction.nl?subject=Claude%20Skills%20track%20part%202" }}
 />

--- a/academy/2026-05-15-claude-skills-tutorial-3-skill-evals/index.mdx
+++ b/academy/2026-05-15-claude-skills-tutorial-3-skill-evals/index.mdx
@@ -1,10 +1,10 @@
 ---
 slug: claude-skills-tutorial-3-skill-evals
-title: "Claude Skills leerlijn — Deel 3: Skill-evals — meten of je skill werkt"
+title: "Claude Skills tutorial series — Part 3: Skill evals — measuring whether your skill actually works"
 contentType: tutorial
 authors: [conduction]
 date: 2026-05-15
-summary: Van een skill die "goed voelt" naar een skill die gemeten goed werkt. Test-scenario's schrijven, baseline-meting, trigger-tests, en de eval-runner van /skill-creator. Derde van vier korte modules.
+summary: From a skill that "feels right" to a skill that measurably works. Writing test scenarios, baseline measurement, trigger tests, and the eval runner inside /skill-creator. Third of four short modules.
 tags: [Claude, Claude Code, Skills, AI, Evals, Tutorial series]
 apps: []
 durationMinutes: 15
@@ -15,62 +15,62 @@ partNumber: 3
 import {Outcomes, Outcome, Prerequisites, PrerequisiteItem, NextSteps, NextStep, HexCard, ContactCta} from '@conduction/docusaurus-preset/components';
 import Details from '@theme/Details';
 
-Je hebt nu een werkende skill — maar werkt hij ook écht goed? En blijft hij goed werken als Claude zelf een upgrade krijgt of als je de skill aanpast? Dit derde, optionele deel laat zien hoe je een skill systematisch evalueert: test-scenario's, trigger-tests, een baseline-meting, en de eval-runner die `/skill-creator` voor je inricht. Dit is de stap van Maturity Level 4 ("voelt goed") naar Level 5 ("gemeten goed").
+You now have a working skill — but does it actually work *well*? And does it keep working when Claude itself gets upgraded or when you tweak the skill? This third, optional part shows how to evaluate a skill systematically: test scenarios, trigger tests, a baseline measurement, and the eval runner that `/skill-creator` sets up for you. This is the step from Maturity Level 4 ("feels right") to Level 5 ("measurably right").
 
 {/* truncate */}
 
-<Outcomes title="Wat je leert in dit deel">
-  <Outcome>Waarom skills die alleen "goed voelen" blinde vlekken hebben, en wat een baseline-meting daaraan toevoegt.</Outcome>
-  <Outcome>Het <code>evals/evals.json</code>-formaat schrijven: prompts, expectations, trigger-tests.</Outcome>
-  <Outcome>De eval-runner van <code>/skill-creator</code> draaien en de uitkomst lezen (<code>timing.json</code>, <code>grading.json</code>).</Outcome>
-  <Outcome>Wanneer een skill genoeg evals heeft om Maturity Level 5 te claimen — en wanneer je verder moet naar Level 6.</Outcome>
+<Outcomes title="What you'll learn in this part">
+  <Outcome>Why skills that only "feel right" have blind spots, and what a baseline measurement adds.</Outcome>
+  <Outcome>Writing the <code>evals/evals.json</code> format: prompts, expectations, trigger tests.</Outcome>
+  <Outcome>Running the eval runner inside <code>/skill-creator</code> and reading the output (<code>timing.json</code>, <code>grading.json</code>).</Outcome>
+  <Outcome>When a skill has enough evals to claim Maturity Level 5 — and when you need to push on to Level 6.</Outcome>
 </Outcomes>
 
-<Prerequisites title="Wat je nodig hebt">
-  <PrerequisiteItem>Deel 1 en 2 doorgenomen, en idealiter een eigen werkende skill om te evalueren (de <code>git-status-summary</code> uit deel 2 werkt prima als oefenobject).</PrerequisiteItem>
-  <PrerequisiteItem>De <code>skill-creator</code> skill geïnstalleerd — de eval-runner zit daarin verstopt.</PrerequisiteItem>
-  <PrerequisiteItem>Een paar concrete scenario's waarin jouw skill is gebruikt of zou worden gebruikt — anders kun je geen realistische evals schrijven.</PrerequisiteItem>
+<Prerequisites title="What you need">
+  <PrerequisiteItem>Parts 1 and 2 read, and ideally a working skill of your own to evaluate (the <code>git-status-summary</code> from part 2 works fine as a practice target).</PrerequisiteItem>
+  <PrerequisiteItem>The <code>skill-creator</code> skill installed — the eval runner is hidden inside it.</PrerequisiteItem>
+  <PrerequisiteItem>A few concrete scenarios in which your skill has been or would be used — otherwise you can't write realistic evals.</PrerequisiteItem>
 </Prerequisites>
 
-## Waarom meten? De 7 maturity-niveaus, kort
+## Why measure? The 7 maturity levels, in brief
 
-Skills doorlopen zeven volwassenheidsniveaus, elk bovenop het vorige. Je hoeft niet alles te bouwen — een eenvoudig hulpmiddel hoeft niet voorbij L3 te komen. Maar voor skills die kritisch zijn (hele pipelines, gates, dagelijkse workflows) wil je verder dan "voelt goed":
+Skills move through seven maturity levels, each one stacked on the previous. You don't have to build everything — a simple helper doesn't need to go past L3. But for skills that are critical (full pipelines, gates, daily workflows) you want to go beyond "feels right":
 
-| Level | Wat erbij komt | Voor wie |
+| Level | What it adds | For whom |
 |---|---|---|
-| **L1** Anatomy | `SKILL.md` met frontmatter, genummerde stappen, guardrails | Iedereen |
-| **L2** Golden Rule | Optimale `description`, progressive disclosure, &lt;500 regels | Iedereen die wil dat de skill goed triggert |
-| **L3** Foundations | Gebouwd op proven patterns, met `examples/` of `references/` | Skills die meer dan een quick utility zijn |
-| **L4** Personalisation | Bevat business-specifieke kennis (jouw ADRs, standaarden, domein) | Conduction-specifieke skills |
-| **L5** Measurement | Heeft 3+ evals, trigger-tests, en `last_validated` is gezet | **Hier zit dit deel** |
-| **L6** Self-improvement | Houdt `learnings.md` bij, consolideert periodiek | Skills die je intensief gebruikt |
-| **L7** Workforce | Orkestreert sub-agents of zit in een workflow-keten | Hydra-achtige pipelines |
+| **L1** Anatomy | `SKILL.md` with frontmatter, numbered steps, guardrails | Everyone |
+| **L2** Golden Rule | Optimal `description`, progressive disclosure, &lt;500 lines | Anyone who wants the skill to trigger well |
+| **L3** Foundations | Built on proven patterns, with `examples/` or `references/` | Skills that are more than a quick utility |
+| **L4** Personalisation | Contains business-specific knowledge (your ADRs, standards, domain) | Conduction-specific skills |
+| **L5** Measurement | Has 3+ evals, trigger tests, and `last_validated` is set | **This part lives here** |
+| **L6** Self-improvement | Maintains `learnings.md`, consolidates periodically | Skills you use intensively |
+| **L7** Workforce | Orchestrates sub-agents or sits in a workflow chain | Hydra-style pipelines |
 
-Dit deel brengt je van L4 naar L5. Onderzoek toont aan dat ~80% van community-skills de output *slechter* maakt; de 20% die werkt is gebouwd door domein-experts mét iteratieve evaluatie. Meten is wat het verschil maakt.
+This part takes you from L4 to L5. Research shows that ~80% of community skills make the output *worse*; the 20% that work were built by domain experts *with* iterative evaluation. Measurement is what makes the difference.
 
-## Het probleem: wat je niet meet, weet je niet
+## The problem: what you don't measure, you don't know
 
-Een skill die "goed voelt" maar nooit gemeten is, kan drie verborgen problemen hebben:
+A skill that "feels right" but has never been measured can have three hidden problems:
 
-1. **Geen baseline** — je weet niet of de skill beter is dan Claude zonder skill. Misschien voegt hij niets toe.
-2. **Onbekende auto-triggering** — je hebt 'm twee keer met succes met `/` aangeroepen, maar Claude pikt 'm in normale gesprekken nooit op. Of juist veel te vaak.
-3. **Regressie na een edit** — je tweakt de `description` om scenario A te fixen en breekt onbedoeld scenario B.
+1. **No baseline** — you don't know whether the skill is better than Claude without the skill. Maybe it adds nothing.
+2. **Unknown auto-triggering** — you've invoked it successfully twice with `/`, but Claude never picks it up in normal conversation. Or picks it up way too often.
+3. **Regression after an edit** — you tweak the `description` to fix scenario A and accidentally break scenario B.
 
-Evals lossen alle drie op.
+Evals solve all three.
 
-## De drie soorten meting
+## The three kinds of measurement
 
-| Meting | Antwoordt op de vraag | Output |
+| Measurement | Answers the question | Output |
 |---|---|---|
-| **Eval scenarios** | Doet de skill wat hij moet doen op realistische prompts? | `grading.json` — pass/fail per scenario |
-| **Trigger tests** | Triggert hij wel/niet automatisch zoals bedoeld? | `should_trigger` / `should_not_trigger` slagings-percentage |
-| **Baseline** | Is de skill beter dan Claude zonder skill? | Een vergelijking naast elkaar |
+| **Eval scenarios** | Does the skill do what it's supposed to do on realistic prompts? | `grading.json` — pass/fail per scenario |
+| **Trigger tests** | Does it auto-trigger when it should, and stay quiet when it shouldn't? | `should_trigger` / `should_not_trigger` pass percentage |
+| **Baseline** | Is the skill better than Claude without the skill? | A side-by-side comparison |
 
-Je hebt alle drie nodig voor een schone L5-claim.
+You need all three for a clean L5 claim.
 
-## Het `evals.json`-formaat
+## The `evals.json` format
 
-Maak in je skill-folder een subfolder `evals/` aan met daarin `evals.json`:
+In your skill folder, create a subfolder `evals/` and put `evals.json` inside it:
 
 ```json
 {
@@ -142,112 +142,112 @@ Maak in je skill-folder een subfolder `evals/` aan met daarin `evals.json`:
 }
 ```
 
-Drie stukken om op te merken:
+Three things to notice:
 
-1. **3+ evals zijn het minimum** voor L5. Schrijf ze vanuit realistisch gebruik — wat zou een teamgenoot écht intypen?
-2. **10+ should-trigger en 10+ should-not-trigger** prompts. Saaier om te schrijven dan je denkt, maar onmisbaar — dit is waar over-eagerness en blinde vlekken zichtbaar worden.
-3. **`last_validated: null`** — dit veld zet de runner zelf wanneer hij draait. Zolang het `null` is, telt je skill nog niet als gemeten.
+1. **3+ evals is the minimum** for L5. Write them from realistic use — what would a teammate *actually* type?
+2. **10+ should-trigger and 10+ should-not-trigger** prompts. Duller to write than you'd expect, but indispensable — this is where over-eagerness and blind spots become visible.
+3. **`last_validated: null`** — the runner fills this field in itself when it runs. As long as it's `null`, your skill doesn't yet count as measured.
 
-## De eval-runner draaien
+## Running the eval runner
 
-`/skill-creator` heeft een ingebouwde eval-runner. Open een Claude-sessie in een repo met je skill en typ:
+`/skill-creator` has a built-in eval runner. Open a Claude session in a repo containing your skill and type:
 
 ```
 /skill-creator
 ```
 
-Zeg in je eerste prompt iets als: *"Ik wil de evals draaien voor mijn `git-status-summary` skill."* `/skill-creator` herkent dat je in de evaluatie-fase zit en doet vier dingen:
+In your first prompt, say something like: *"I want to run the evals for my `git-status-summary` skill."* `/skill-creator` recognises that you're in the evaluation phase and does four things:
 
-1. **Spawnt parallel twee subagents** — eentje met toegang tot je skill, eentje zonder (baseline).
-2. **Draait elke eval-prompt** in beide contexten, registreert tokens en duur in `timing.json`.
-3. **Toetst de output tegen je `expectations`** en schrijft pass/fail naar `grading.json`.
-4. **Opent een lokale benchmark-viewer** waar je beide kanten visueel kunt vergelijken.
+1. **Spawns two subagents in parallel** — one with access to your skill, one without (baseline).
+2. **Runs every eval prompt** in both contexts, recording tokens and duration in `timing.json`.
+3. **Checks the output against your `expectations`** and writes pass/fail to `grading.json`.
+4. **Opens a local benchmark viewer** where you can compare both sides visually.
 
-Na de run vind je in `evals/`:
+After the run, you'll find inside `evals/`:
 
 ```
 evals/
-├── evals.json        ← jouw scenario's
-├── timing.json       ← per scenario: tokens + duur, met- en zonder-skill
-├── grading.json      ← per scenario: assertion pass/fail + bewijs
-└── (eventueel) trigger-results.json
+├── evals.json        ← your scenarios
+├── timing.json       ← per scenario: tokens + duration, with and without skill
+├── grading.json      ← per scenario: assertion pass/fail + evidence
+└── (optionally) trigger-results.json
 ```
 
-Voor de L5-claim heb je álledrie nodig: `evals.json` (geschreven door jou), `timing.json` (de runner heeft daadwerkelijk gedraaid, geen statische read-only simulatie), én `grading.json` (assertions zijn gescoord). Vergeet ook niet `last_validated` bij te werken in `evals.json` zelf.
+For the L5 claim you need all three: `evals.json` (written by you), `timing.json` (the runner actually executed, not a static read-only simulation), and `grading.json` (assertions were scored). Don't forget to update `last_validated` inside `evals.json` itself either.
 
-## De resultaten lezen
+## Reading the results
 
-Drie vragen om jezelf te stellen bij elk eval-rapport:
+Three questions to ask yourself for every eval report:
 
-### 1. Slaagt de skill alle expectations?
+### 1. Does the skill pass all expectations?
 
-Open `grading.json` en kijk welke `expectations` `pass: false` opleveren. Elk failed-item is een concreet verbeterpunt: ofwel mist je `SKILL.md` instructie, ofwel zijn de stappen niet specifiek genoeg, ofwel triggert er een edge case die je niet beschreven hebt.
+Open `grading.json` and look at which `expectations` come back `pass: false`. Every failed item is a concrete improvement opportunity: either your `SKILL.md` is missing an instruction, or the steps aren't specific enough, or an edge case is triggering that you didn't describe.
 
-### 2. Is de skill beter dan baseline?
+### 2. Is the skill better than baseline?
 
-Vergelijk de met-skill output naast de zonder-skill output in de benchmark-viewer. Twee uitkomsten zijn rode vlaggen:
+Compare the with-skill output next to the without-skill output in the benchmark viewer. Two outcomes are red flags:
 
-- **Skill = baseline** — beide produceren ongeveer hetzelfde. Je skill voegt niets toe, behalve misschien wat formattering. Overweeg of het de moeite waard is om hem te hebben.
-- **Skill < baseline** — Claude zonder skill is *beter*. Dit gebeurt vaker dan je denkt; de skill kan over-prescriptief zijn, of in conflict met wat Claude al goed kan. Vereenvoudig de skill of trek 'm in.
+- **Skill = baseline** — both produce roughly the same thing. Your skill adds nothing, except maybe some formatting. Consider whether it's worth having.
+- **Skill < baseline** — Claude without the skill is *better*. This happens more often than you'd think; the skill can be over-prescriptive, or conflict with what Claude is already good at. Simplify the skill or pull it.
 
-### 3. Hoe scoren je trigger-tests?
+### 3. How do your trigger tests score?
 
-De runner draait elke `should_trigger` en `should_not_trigger` prompt in een verse context en checkt of de skill (auto-)laadt. Streef naar 90%+ op beide kanten. Onder de 80%? Iterate op de description.
+The runner runs each `should_trigger` and `should_not_trigger` prompt in a fresh context and checks whether the skill auto-loads. Aim for 90%+ on both sides. Below 80%? Iterate on the description.
 
-> **Realiteitscheck:** meerdere bronnen rapporteren ~50% auto-activatie zelfs voor goede skills, omdat Claude een vast contextbudget heeft voor skill-descriptions. Bij grote skill-libraries is auto-trigger inherent minder betrouwbaar dan expliciet `/<naam>` typen. Een lage score betekent niet altijd "skill is slecht" — soms is "skill is te één van vele". Eval-resultaten lees je in context.
+> **Reality check:** multiple sources report ~50% auto-activation even for good skills, because Claude has a fixed context budget for skill descriptions. With large skill libraries, auto-trigger is inherently less reliable than explicitly typing `/<name>`. A low score doesn't always mean "skill is bad" — sometimes it means "skill is just one of many". Read eval results in context.
 
-## Iteratie-cyclus
+## Iteration cycle
 
-Eén ronde evals draaien is alleen maar het begin. Het patroon:
+Running one round of evals is just the start. The pattern:
 
 ```
-schrijf evals → run → lees resultaten → identificeer 1 zwakte → fix → re-run
+write evals → run → read results → identify 1 weakness → fix → re-run
 ```
 
-Eén verbetering per ronde — niet vier tegelijk. Anders weet je achteraf niet welke fix welk verschil maakte.
+One improvement per round — not four at once. Otherwise you won't know afterwards which fix made which difference.
 
-<HexCard title="Vuistregel: 1 fix per cycle">
-  Identificeer één specifieke zwakte uit de benchmark-viewer (één gefaalde expectation, of één trigger-test die de verkeerde kant op ging). Pas de <code>SKILL.md</code> alleen op dát punt aan. Draai opnieuw. Pas dan ga je door naar de volgende zwakte.
+<HexCard title="Rule of thumb: 1 fix per cycle">
+  Identify one specific weakness from the benchmark viewer (one failed expectation, or one trigger test that went the wrong way). Touch the <code>SKILL.md</code> only on that point. Re-run. Only then move on to the next weakness.
 </HexCard>
 
-## Wanneer is een skill "gemeten genoeg"?
+## When is a skill "measured enough"?
 
-Voor L5-claim heb je minimaal:
+For an L5 claim you need at minimum:
 
 - ✅ 3+ evals in `evals.json`
 - ✅ 10+ should-trigger + 10+ should-not-trigger prompts
-- ✅ `last_validated` is gevuld (niet `null`)
-- ✅ Zowel `timing.json` als `grading.json` aanwezig (bewijs dat de runner gedraaid heeft, niet alleen een read-only beoordeling)
-- ✅ Een baseline-meting (skill vs. zonder skill)
-- ✅ Minstens één iteratie-cycle doorlopen op basis van eval-resultaten
+- ✅ `last_validated` is filled in (not `null`)
+- ✅ Both `timing.json` and `grading.json` present (proof that the runner actually ran, not just a read-only review)
+- ✅ A baseline measurement (skill vs. no skill)
+- ✅ At least one iteration cycle completed based on the eval results
 
-Klopt dat allemaal? Dan kun je de skill als L5-mature labellen. Wil je verder — en voor skills die je dagelijks gebruikt of die andere skills aansturen wil je dat — dan komt L6 (`learnings.md` met capture-loop) en uiteindelijk L7 (multi-agent orchestratie). [Deel 4 van de leerlijn](/academy/claude-skills-tutorial-4-l6-l7-mature-skills) loopt die laatste twee niveaus door, plus het dashboard waarmee je je hele skill-library tegelijk op maturity bewaakt. Voor ~80% van de skills is L5 het natuurlijke eindpunt; deel 4 is voor de skills die dat niet zijn.
+All of that checks out? Then you can label the skill as L5-mature. Want to go further — and for skills you use daily or that steer other skills, you do — then L6 (`learnings.md` with a capture loop) is next, and eventually L7 (multi-agent orchestration). [Part 4 of the track](/academy/claude-skills-tutorial-4-l6-l7-mature-skills) walks through those last two levels, plus the dashboard that lets you monitor your whole skill library for maturity at once. For ~80% of skills, L5 is the natural endpoint; part 4 is for the skills that aren't.
 
-## Test jezelf
+## Test yourself
 
-Vier korte vragen om te checken of je dit deel begrepen hebt. Vastgelopen? Klik **Hint**. Curieus naar het antwoord? Klik **Antwoord**.
+Four short questions to check whether you got this part. Stuck? Click **Hint**. Curious about the answer? Click **Answer**.
 
 <div className="tutorial-quiz">
 
-**1. Waarom is een baseline-meting belangrijk bij skill-evals?**
+**1. Why is a baseline measurement important in skill evals?**
 
 <Details summary="Hint">
 
-Een skill kan slagen op al je expectations en tóch geen waarde toevoegen. Wat zou je daarvoor moeten weten?
+A skill can pass all your expectations and still add no value. What would you need to know to be sure?
 
 </Details>
 
-<Details summary="Antwoord">
+<Details summary="Answer">
 
-Omdat een skill die alle expectations haalt, nog steeds **niets kan toevoegen ten opzichte van Claude zonder skill**. Of erger: Claude zonder skill kan beter zijn (over-prescriptieve skills knellen Claude's eigen oordeel).
+Because a skill that hits every expectation can still **add nothing relative to Claude without the skill**. Or worse: Claude without the skill can be better (over-prescriptive skills squeeze Claude's own judgement).
 
-De baseline draait elke eval-prompt twee keer: eenmaal met toegang tot je skill, eenmaal zonder. Pas dan kun je zeggen "deze skill maakt verschil X". Zonder baseline meet je alleen of de skill consistent is — niet of hij waardevol is.
+The baseline runs every eval prompt twice: once with access to your skill, once without. Only then can you say "this skill makes difference X". Without a baseline, you're only measuring whether the skill is consistent — not whether it's valuable.
 
-Drie mogelijke uitkomsten bij baseline-vergelijk:
+Three possible outcomes from a baseline comparison:
 
-- **Skill > baseline** → de skill verdient zijn plek.
-- **Skill ≈ baseline** → twijfelgeval. Overweeg of de winst (formattering, consistentie) opweegt tegen de context-cost.
-- **Skill < baseline** → skill weghalen of fundamenteel herzien.
+- **Skill > baseline** → the skill earns its place.
+- **Skill ≈ baseline** → borderline case. Consider whether the gain (formatting, consistency) outweighs the context cost.
+- **Skill < baseline** → remove the skill or fundamentally rethink it.
 
 </Details>
 
@@ -255,22 +255,22 @@ Drie mogelijke uitkomsten bij baseline-vergelijk:
 
 <div className="tutorial-quiz">
 
-**2. Wat is het verschil tussen `evals` en `trigger_tests` in `evals.json`?**
+**2. What's the difference between `evals` and `trigger_tests` in `evals.json`?**
 
 <Details summary="Hint">
 
-Eén meet of de skill goed werk levert. De andere meet of hij überhaupt op het juiste moment opduikt.
+One measures whether the skill delivers good work. The other measures whether it shows up at the right moment at all.
 
 </Details>
 
-<Details summary="Antwoord">
+<Details summary="Answer">
 
-- **`evals`** meet **kwaliteit van uitvoering**: gegeven dat de skill is geladen, doet hij wat hij moet doen? Drie expectations per scenario, getoetst tegen de output. Score: hoeveel expectations slagen?
-- **`trigger_tests`** meet **auto-activatie**: pikt Claude de skill automatisch op bij relevante prompts (`should_trigger`), en blijft hij weg bij niet-relevante prompts (`should_not_trigger`)?
+- **`evals`** measure **quality of execution**: given that the skill is loaded, does it do what it should? Three expectations per scenario, checked against the output. Score: how many expectations pass?
+- **`trigger_tests`** measure **auto-activation**: does Claude pick up the skill automatically on relevant prompts (`should_trigger`), and stay away on non-relevant prompts (`should_not_trigger`)?
 
-Een skill kan perfect scoren op `evals` maar slecht op `trigger_tests` — dan werkt hij goed *als* je `/<naam>` typt, maar pikt Claude hem nooit zelf op. Andersom: een skill kan altijd triggeren maar slechte output leveren — dan trekt hij ongevraagd aan tafel zonder waarde toe te voegen.
+A skill can score perfectly on `evals` but poorly on `trigger_tests` — then it works well *when* you type `/<name>`, but Claude never picks it up on its own. The reverse: a skill can always trigger but deliver poor output — then it pulls up a chair uninvited without adding value.
 
-Je hebt beide nodig voor L5.
+You need both for L5.
 
 </Details>
 
@@ -278,22 +278,22 @@ Je hebt beide nodig voor L5.
 
 <div className="tutorial-quiz">
 
-**3. Welke twee bestanden bewijzen dat de eval-runner echt gedraaid heeft, en waarom allebei?**
+**3. Which two files prove that the eval runner actually ran, and why both?**
 
 <Details summary="Hint">
 
-Een statische beoordeling van je `evals.json` is niet voldoende — je hebt bewijs nodig dat er code is uitgevoerd én dat er resultaten zijn gescoord.
+A static review of your `evals.json` isn't enough — you need proof that code was executed *and* that results were scored.
 
 </Details>
 
-<Details summary="Antwoord">
+<Details summary="Answer">
 
-- **`timing.json`** bewijst **uitvoering**: per scenario staat hierin hoeveel tokens er zijn gebruikt en hoe lang de run duurde. Dat kan alleen na werkelijke executie — een read-only simulatie kan dit veld niet vullen.
-- **`grading.json`** bewijst **beoordeling**: pass/fail per expectation, met bewijs. Dit is de daadwerkelijke score van je skill.
+- **`timing.json`** proves **execution**: per scenario it records how many tokens were used and how long the run took. That can only happen after real execution — a read-only simulation can't fill this field.
+- **`grading.json`** proves **scoring**: pass/fail per expectation, with evidence. This is the actual score of your skill.
 
-`grading.json` alleen is niet genoeg — die zou je theoretisch kunnen genereren door een statische read van `SKILL.md` en `evals.json`. Pas met `timing.json` erbij heb je hard bewijs dat de runner ook echt heeft gedraaid.
+`grading.json` alone isn't enough — you could theoretically generate it through a static read of `SKILL.md` and `evals.json`. Only with `timing.json` alongside it do you have hard evidence that the runner actually ran.
 
-In de Conduction-skill-check is dit precies waar het script L5 op valideert: beide bestanden moeten bestaan, plus `last_validated` mag niet `null` zijn.
+In the Conduction skill check, this is exactly what the script validates L5 on: both files must exist, plus `last_validated` may not be `null`.
 
 </Details>
 
@@ -301,46 +301,46 @@ In de Conduction-skill-check is dit precies waar het script L5 op valideert: bei
 
 <div className="tutorial-quiz">
 
-**4. Je hebt evals gedraaid en één expectation faalt consistent. Wat is je volgende stap — en wat juist niet?**
+**4. You've run evals and one expectation fails consistently. What's your next step — and what's exactly not?**
 
 <Details summary="Hint">
 
-Niet hagelschot fixen. Wat is de meest leerzame manier om te iteren?
+Don't shotgun fixes. What's the most informative way to iterate?
 
 </Details>
 
-<Details summary="Antwoord">
+<Details summary="Answer">
 
-**Wel doen:** identificeer die ene gefaalde expectation, lees in de benchmark-viewer wat de skill in plaats daarvan deed, en pas één specifiek stuk van `SKILL.md` aan (een stap, een guardrail, of een output-voorbeeld). Draai daarna opnieuw — pas dan ga je verder met de volgende zwakte.
+**Do:** identify that one failed expectation, read in the benchmark viewer what the skill did instead, and touch one specific piece of `SKILL.md` (a step, a guardrail, or an output example). Then re-run — only then move on to the next weakness.
 
-**Niet doen:** vier tegelijk fixen, of meteen de `description` overhoop halen omdat "er iets niet goed gaat". Bij meerdere wijzigingen tegelijk weet je niet welke iets bijdroeg. Bij een description-herziening verschuif je auto-triggering en je executie-gedrag tegelijkertijd — onmogelijk om uit elkaar te halen.
+**Don't:** fix four at once, or immediately overhaul the `description` because "something's not right". With multiple changes at once you can't tell which one contributed. Overhauling a description shifts auto-triggering and execution behaviour at the same time — impossible to pull apart.
 
-Vuistregel: één eval-cyclus = één hypothese = één fix. Saai? Misschien. Maar je leert er sneller van dan van "alles ineens" pogingen.
+Rule of thumb: one eval cycle = one hypothesis = one fix. Boring? Maybe. But you learn faster from it than from "everything at once" attempts.
 
 </Details>
 
 </div>
 
-<NextSteps title="Volgende stap" lede="Dit was deel 3 — je weet nu hoe je een skill systematisch meet en verbetert. Voor de skills die je écht intensief gebruikt is er nog een vervolg.">
+<NextSteps title="Next step" lede="That was part 3 — you now know how to systematically measure and improve a skill. For the skills you really use intensively, there's one more part.">
   <NextStep
-    title="Deel 4 — Van gemeten naar lerend en orkestrerend (L6 → L7)"
+    title="Part 4 — From measured to learning and orchestrating (L6 → L7)"
     href="/academy/claude-skills-tutorial-4-l6-l7-mature-skills"
-    description="L6 (learnings-loop) en L7 (sub-agent orkestratie), plus het skill-level-overview dashboard waarmee je je hele library tegelijk bewaakt."
+    description="L6 (learnings loop) and L7 (sub-agent orchestration), plus the skill-level-overview dashboard that monitors your whole library at once."
   />
   <NextStep
-    title="Vorige stap — Je eerste skill schrijven"
+    title="Previous step — Writing your first skill"
     href="/academy/claude-skills-tutorial-2-je-eerste-skill"
-    description="De praktische module met /skill-creator, frontmatter en lokaal testen."
+    description="The hands-on module with /skill-creator, frontmatter, and local testing."
   />
   <NextStep
-    title="Conduction-docs over skill-evals"
+    title="Conduction docs on skill evals"
     href="https://github.com/ConductionNL/.github/blob/main/docs/claude/skill-evals.md"
-    description="Verdiepende referentie met het volledige evals.json-schema en de runner-protocol-details."
+    description="In-depth reference with the full evals.json schema and the runner protocol details."
   />
 </NextSteps>
 
 <ContactCta
-  title="Klaar om een skill voor je team te schrijven?"
-  body="Of wil je weten of een use-case skill-waardig is? We sparren graag mee. Stuur ons een mail met je voorgestelde use-case en we geven een eerste reactie."
-  cta={{ label: "Mail Conduction", href: "mailto:info@conduction.nl?subject=Claude%20Skills%20leerlijn%20deel%203" }}
+  title="Ready to write a skill for your team?"
+  body="Or want to know whether a use case is skill-worthy? We're happy to think along. Send us an email with your proposed use case and we'll respond."
+  cta={{ label: "Email Conduction", href: "mailto:info@conduction.nl?subject=Claude%20Skills%20learning%20track%20part%203" }}
 />

--- a/academy/2026-05-15-claude-skills-tutorial-4-l6-l7-mature-skills/index.mdx
+++ b/academy/2026-05-15-claude-skills-tutorial-4-l6-l7-mature-skills/index.mdx
@@ -1,10 +1,10 @@
 ---
 slug: claude-skills-tutorial-4-l6-l7-mature-skills
-title: "Claude Skills leerlijn — Deel 4: Van gemeten naar lerend en orkestrerend (L6 → L7)"
+title: "Claude Skills tutorial series — Part 4: From measured to learning and orchestrating (L6 → L7)"
 contentType: tutorial
 authors: [conduction]
 date: 2026-05-15
-summary: Hoe ga je voorbij L5? L6 zet een learnings-loop op je skill, L7 maakt er een orkestrator van die sub-agents aanstuurt. Plus een blik op het skill-level-overview dashboard waarmee je je hele skill-library in één oogopslag op maturity kunt scannen. Vierde van vier korte modules.
+summary: How do you go beyond L5? L6 puts a learnings loop on your skill, L7 turns it into an orchestrator that steers sub-agents. Plus a look at the skill-level-overview dashboard that lets you scan your whole skill library for maturity at a glance. Fourth of four short modules.
 tags: [Claude, Claude Code, Skills, AI, Maturity, Tutorial series]
 apps: []
 durationMinutes: 18
@@ -15,56 +15,56 @@ partNumber: 4
 import {Outcomes, Outcome, Prerequisites, PrerequisiteItem, NextSteps, NextStep, HexCard, ContactCta} from '@conduction/docusaurus-preset/components';
 import Details from '@theme/Details';
 
-In deel 3 bracht je een skill van "voelt goed" naar "gemeten goed" — Maturity Level 5. Voor de meeste skills is dat genoeg. Maar voor een handvol skills die je dagelijks gebruikt of die andere skills aansturen, wil je verder: een skill die **leert van zijn eigen executies** (L6), en een skill die **andere agents aanstuurt** in een grotere workflow (L7). Dit vierde deel laat zien hoe je daar komt — én hoe je met het Hydra-dashboard je hele skill-library tegelijk op maturity bewaakt.
+In part 3 you took a skill from "feels right" to "measurably right" — Maturity Level 5. For most skills that's enough. But for a handful of skills you use daily, or that steer other skills, you want to go further: a skill that **learns from its own executions** (L6), and a skill that **steers other agents** inside a larger workflow (L7). This fourth part shows how you get there — and how the Hydra dashboard lets you monitor your whole skill library for maturity at once.
 
 {/* truncate */}
 
-<Outcomes title="Wat je leert in dit deel">
-  <Outcome>Wat een learnings-loop is, en hoe een <code>learnings.md</code> + capture-stap je skill iedere executie iets slimmer maakt (L6).</Outcome>
-  <Outcome>De two-stage buffer (<code>learning-candidates.md</code> → <code>learnings.md</code> → <code>SKILL.md</code>) en wanneer je consolideert.</Outcome>
-  <Outcome>Hoe een skill een orkestrator wordt: sub-agents spawnen, workflow-chains, hand-off, fan-out/fan-in patronen (L7).</Outcome>
-  <Outcome>Het verschil tussen <em>structureel</em> L7 en <em>mature</em> L7 — en waarom je beide nodig hebt.</Outcome>
-  <Outcome>Het <code>skill-level-overview.html</code> dashboard en het <code>update-skill-overview.sh</code> script die je hele skill-library live op maturity tonen.</Outcome>
+<Outcomes title="What you'll learn in this part">
+  <Outcome>What a learnings loop is, and how a <code>learnings.md</code> + capture step makes your skill a little smarter on every execution (L6).</Outcome>
+  <Outcome>The two-stage buffer (<code>learning-candidates.md</code> → <code>learnings.md</code> → <code>SKILL.md</code>) and when you consolidate.</Outcome>
+  <Outcome>How a skill becomes an orchestrator: spawning sub-agents, workflow chains, hand-offs, fan-out/fan-in patterns (L7).</Outcome>
+  <Outcome>The difference between <em>structural</em> L7 and <em>mature</em> L7 — and why you need both.</Outcome>
+  <Outcome>The <code>skill-level-overview.html</code> dashboard and the <code>update-skill-overview.sh</code> script that show your whole skill library live by maturity.</Outcome>
 </Outcomes>
 
-<Prerequisites title="Wat je nodig hebt">
-  <PrerequisiteItem>Deel 1, 2 en 3 doorgenomen — vooral deel 3, want L6 en L7 bouwen direct op L5 metingen.</PrerequisiteItem>
-  <PrerequisiteItem>Een skill die je minstens een paar weken intensief hebt gebruikt. L6 zonder echte execution-historie is een lege schil.</PrerequisiteItem>
-  <PrerequisiteItem>Voor L7: een use-case waarin je werk parallel kunt verdelen of die zich in een keten van skills laat ontleden.</PrerequisiteItem>
+<Prerequisites title="What you need">
+  <PrerequisiteItem>Parts 1, 2 and 3 read — especially part 3, because L6 and L7 build directly on L5 measurement.</PrerequisiteItem>
+  <PrerequisiteItem>A skill you've used intensively for at least a few weeks. L6 without real execution history is an empty shell.</PrerequisiteItem>
+  <PrerequisiteItem>For L7: a use case where you can parallelise work, or one that breaks down into a chain of skills.</PrerequisiteItem>
 </Prerequisites>
 
-## Recap: de 7 niveaus, en waar we nu zijn
+## Recap: the 7 levels, and where we are now
 
-| Level | Wat erbij komt |
+| Level | What it adds |
 |---|---|
-| L1–L4 | Anatomy, golden rule, foundations, business-context |
-| **L5** | 3+ evals, trigger-tests, baseline — *deel 3* |
-| **L6** | `learnings.md` + capture-stap, periodieke consolidatie — *dit deel* |
-| **L7** | Orkestreert sub-agents of zit in een workflow-keten — *dit deel* |
+| L1–L4 | Anatomy, golden rule, foundations, business context |
+| **L5** | 3+ evals, trigger tests, baseline — *part 3* |
+| **L6** | `learnings.md` + capture step, periodic consolidation — *this part* |
+| **L7** | Orchestrates sub-agents or sits in a workflow chain — *this part* |
 
-Belangrijk: niveaus zijn **cumulatief in criteria** maar niet altijd in praktijk. Een skill kan een L7-architectuur hebben (spawnt acht parallele agents) zonder L5-evals te hebben — dat heet *structureel L7, maturity L4*. De architectuur is er, de zelfkennis nog niet. Voor échte L7 moet je L1 t/m L6 erbij hebben.
+Important: levels are **cumulative in criteria** but not always in practice. A skill can have an L7 architecture (spawns eight parallel agents) without having L5 evals — that's called *structural L7, maturity L4*. The architecture is there, the self-knowledge isn't. For real L7 you need L1 through L6 alongside it.
 
-## Niveau 6: Self-Improvement — skills die leren van hun executies
+## Level 6: Self-Improvement — skills that learn from their executions
 
-Een L5-skill is gemeten, maar statisch. Elke executie verloopt los van de vorige; wat je vorige week leerde, vergeet de skill morgen. **L6 lost dat op met een learnings-loop**:
+An L5 skill is measured, but static. Each execution runs disconnected from the previous one; what you learned last week, the skill forgets tomorrow. **L6 solves that with a learnings loop**:
 
 ```
-Executie  →  observaties vastleggen  →  learnings.md  →  consolidatie  →  SKILL.md-regels
+Execution  →  capture observations  →  learnings.md  →  consolidation  →  SKILL.md rules
                                           ↑                              │
                                           └──────────────────────────────┘
 ```
 
-### De ingrediënten
+### The ingredients
 
-Drie dingen maken een skill L6-mature:
+Three things make a skill L6-mature:
 
-1. Een **`learnings.md`** in de skill-folder.
-2. Een **"Capture Learnings"-stap** aan het einde van `SKILL.md` — Claude wordt aan het einde van elke executie expliciet gevraagd of er iets in de uitvoering opviel dat een toekomstige run kan helpen.
-3. Een **consolidatie-ritme** — typisch bij 80–100 entries kijk je terug, verwijder je verouderde regels, voeg je duplicaten samen, en promoveer je gevalideerde principes naar guardrails in `SKILL.md` zelf.
+1. A **`learnings.md`** in the skill folder.
+2. A **"Capture Learnings" step** at the end of `SKILL.md` — Claude is explicitly asked at the end of every execution whether anything in the run stood out that could help a future run.
+3. A **consolidation rhythm** — typically at 80–100 entries you look back, remove outdated rules, merge duplicates, and promote validated principles into guardrails inside `SKILL.md` itself.
 
-### Het formaat van `learnings.md`
+### The format of `learnings.md`
 
-Elke entry is **gedateerd en atomair** (één inzicht per bullet). De file kent vijf vaste secties:
+Each entry is **dated and atomic** (one insight per bullet). The file has five fixed sections:
 
 ```markdown
 # Learnings — create-pr
@@ -88,9 +88,9 @@ Elke entry is **gedateerd en atomair** (één inzicht per bullet). De file kent 
 - Draai altijd `composer check:strict` vóór PR-aanmaak — vangt 90% van review-feedback af.
 ```
 
-### De "Capture Learnings"-stap in `SKILL.md`
+### The "Capture Learnings" step in `SKILL.md`
 
-`learnings.md` vult zichzelf niet — Claude doet dat alleen als je hem er expliciet om vraagt. De manier waarop is een vaste stap, helemaal onderaan in `SKILL.md`, na alle uitvoeringsstappen en vóór de guardrails. Hieronder een voorbeeld zoals het in Conductions `create-pr`-skill staat — kort, met de vijf rubrieken vooropgesteld zodat Claude ze niet vergeet:
+`learnings.md` doesn't fill itself — Claude only does that if you ask explicitly. The way to ask is a fixed step, all the way at the bottom of `SKILL.md`, after every execution step and before the guardrails. Below is an example as it sits in Conduction's `create-pr` skill — short, with the five sections stated up front so Claude doesn't forget them:
 
 ```markdown
 ## Capture Learnings
@@ -107,144 +107,144 @@ Each entry must include today's date. One insight per bullet.
 **Skip if nothing new was learned** — do NOT invent learnings to fill the section.
 ```
 
-Drie dingen om op te merken:
+Three things to notice:
 
-1. **Het is een stap, geen suggestie.** Door hem als `## Capture Learnings`-sectie te formatteren staat hij in dezelfde "doe-dit"-modus als de andere genummerde stappen. Een vrijblijvende zin als "denk eraan om eventueel iets op te schrijven" wordt door Claude vaak overgeslagen.
-2. **"Skip if nothing new was learned"** is cruciaal. Zonder die regel produceert Claude *altíjd* iets — pseudo-inzichten zoals "de skill werd succesvol uitgevoerd". Dat is precies het soort ruis dat `learnings.md` snel vervuilt en bij elke run je context-budget opslokt.
-3. **Per sectie expliciet de bedoeling vermelden** — niet alleen de naam. "Patterns That Work" alléén triggert generieke inhoud; "approaches that produced good results" stuurt Claude naar gericht observerend gedrag.
+1. **It's a step, not a suggestion.** By formatting it as a `## Capture Learnings` section, it sits in the same "do this" mode as the other numbered steps. A non-committal sentence like "remember to write something down if you feel like it" gets skipped by Claude often.
+2. **"Skip if nothing new was learned"** is crucial. Without that rule, Claude *always* produces something — pseudo-insights like "the skill executed successfully". That's exactly the kind of noise that quickly pollutes `learnings.md` and eats your context budget on every run.
+3. **Spell out the intent per section** — not just the name. "Patterns That Work" alone triggers generic content; "approaches that produced good results" steers Claude into focused observational behaviour.
 
-Variant voor skills met een container/headless-modus: voeg een tabel toe boven aan `SKILL.md` die expliciet zegt dat de Capture Learnings-stap in headless-mode wordt overgeslagen (een container-filesystem is wegwerp — schrijven naar `learnings.md` is verspilling). De `opsx-apply`-skill doet dat zo:
+Variant for skills with a container/headless mode: add a table at the top of `SKILL.md` that explicitly says the Capture Learnings step is skipped in headless mode (a container filesystem is disposable — writing to `learnings.md` is wasted). The `opsx-apply` skill does it like this:
 
 ```markdown
-| Stap | Interactive mode | Headless mode (CI) |
+| Step | Interactive mode | Headless mode (CI) |
 |---|---|---|
 | Capture Learnings | Append to `learnings.md` | **Skip** — container filesystem is disposable |
 ```
 
-### De two-stage buffer (sterk aanbevolen)
+### The two-stage buffer (strongly recommended)
 
-Het naïeve patroon — élke observatie direct in `learnings.md` schrijven — vult het bestand snel met ruis. Een teamgenoot meldde iets dat "vreemd voelde" maar bij nader inzien een toevallige fluctuatie was; nu staat het er, en bij elke run leest Claude het mee.
+The naive pattern — writing *every* observation directly into `learnings.md` — fills the file with noise fast. A teammate reported something that "felt off" but on reflection was a coincidental fluctuation; now it's there, and Claude reads it on every run.
 
-De fix is een **two-stage buffer**:
+The fix is a **two-stage buffer**:
 
 ```
-learning-candidates.md  →  (promotie-criteria gehaald?)  →  learnings.md  →  SKILL.md-regels
-        ↓ (nee)
-   verwijderd na 30 dagen
+learning-candidates.md  →  (promotion criteria met?)  →  learnings.md  →  SKILL.md rules
+        ↓ (no)
+   removed after 30 days
 ```
 
-Promotie-criteria zijn bewust streng:
-- Observatie minstens **3 keer bevestigd** in losse executies, **óf**
-- Observatie lost een **gemeten eval-failure** op uit deel 3.
+Promotion criteria are deliberately strict:
+- Observation confirmed at least **3 times** in separate executions, **or**
+- Observation fixes a **measured eval failure** from part 3.
 
-Zo blijft `learnings.md` schoon en wordt context-budget niet verspeeld aan eenmalige toevalligheden.
+That keeps `learnings.md` clean and stops context budget being wasted on one-off coincidences.
 
-### Wanneer consolideer je?
+### When do you consolidate?
 
-Bij ~80–100 entries wordt `learnings.md` zelf een context-last. Trigger op dat moment een consolidatie-ronde:
+Around ~80–100 entries `learnings.md` itself becomes a context load. That's when you trigger a consolidation round:
 
-1. **Verouderd?** — verwijderen (de bug is gepatcht, de regel niet meer relevant).
-2. **Duplicaten?** — samenvoegen tot één scherpere bullet.
-3. **Cross-cutting patroon?** — promoveer naar de "Consolidated Principles"-sectie.
-4. **Gevalideerd principe?** — schrijf het als guardrail of stap rechtstreeks in `SKILL.md`, en haal de losse observaties die ernaar leidden uit `learnings.md`.
+1. **Outdated?** — remove (the bug has been patched, the rule no longer applies).
+2. **Duplicates?** — merge into one sharper bullet.
+3. **Cross-cutting pattern?** — promote to the "Consolidated Principles" section.
+4. **Validated principle?** — write it as a guardrail or step directly into `SKILL.md`, and remove the loose observations that led to it from `learnings.md`.
 
-<HexCard title="L6 in één regel">
-  Een L6-skill heeft een <code>learnings.md</code> met gedateerde, atomaire entries; <code>SKILL.md</code> eindigt met een "Capture Learnings"-stap; en je consolideert periodiek zodat principes in regels veranderen.
+<HexCard title="L6 in one line">
+  An L6 skill has a <code>learnings.md</code> with dated, atomic entries; <code>SKILL.md</code> ends with a "Capture Learnings" step; and you consolidate periodically so principles turn into rules.
 </HexCard>
 
-## Niveau 7: AI Workforce — skills die andere agents aansturen
+## Level 7: AI Workforce — skills that steer other agents
 
-L7 is geen "betere skill" — het is een **andere soort skill**. Een L7-skill levert geen output zelf, maar **coördineert** een team van sub-agents of zit zelf in een keten van skills die naar elkaar handoffen.
+L7 isn't a "better skill" — it's a **different kind of skill**. An L7 skill doesn't produce output itself; it **coordinates** a team of sub-agents, or sits inside a chain of skills that hand off to each other.
 
-### Criteria (boven op L6)
+### Criteria (on top of L6)
 
-- **Spawnt sub-agents** (parallelle workers) **óf** wordt zelf aangeroepen door een parent-skill.
-- Zit in een **gedefinieerde workflow-chain** met expliciete hand-off-punten:
+- **Spawns sub-agents** (parallel workers) **or** is itself invoked by a parent skill.
+- Sits in a **defined workflow chain** with explicit hand-off points:
   ```
   opsx-new → opsx-ff → opsx-plan-to-issues → opsx-apply → opsx-verify → opsx-archive
   ```
-- **Geeft context door** aan de volgende skill (toont "Next step: run `/opsx-verify`").
-- Gebruikt **geïsoleerde execution-contexten** waar nodig (git worktrees, Docker, sandbox).
-- Heeft **autonomy** binnen een gedefinieerde scope — niet alles vraagt om bevestiging.
-- Doet **parallel werk** (acht agents tegelijk, fan-out/fan-in).
+- **Passes context forward** to the next skill (shows "Next step: run `/opsx-verify`").
+- Uses **isolated execution contexts** where needed (git worktrees, Docker, sandbox).
+- Has **autonomy** within a defined scope — not everything asks for confirmation.
+- Does **parallel work** (eight agents at once, fan-out/fan-in).
 
-### Orkestratie-patronen in Hydra
+### Orchestration patterns in Hydra
 
-| Patroon | Voorbeeld in Hydra | Beschrijving |
+| Pattern | Example in Hydra | Description |
 |---|---|---|
-| **Pipeline** | `opsx-pipeline` | Volledige lifecycle voor 1+ changes parallel via subagents |
-| **Fan-out/Fan-in** | `test-counsel`, `feature-counsel` | N agents parallel spawnen, daarna één synthese |
-| **Sequential Chain** | `opsx-new → … → opsx-archive` | Elke skill handoft naar de volgende |
-| **Autonomous Loop** | `opsx-apply-loop` | Draait apply→verify-cycle met retry, auto-archive |
-| **Multi-perspective** | `test-app` | Zes gespecialiseerde test-agents simultaan |
+| **Pipeline** | `opsx-pipeline` | Full lifecycle for 1+ changes in parallel via subagents |
+| **Fan-out/Fan-in** | `test-counsel`, `feature-counsel` | Spawn N agents in parallel, then one synthesis |
+| **Sequential Chain** | `opsx-new → … → opsx-archive` | Every skill hands off to the next |
+| **Autonomous Loop** | `opsx-apply-loop` | Runs an apply→verify cycle with retry, auto-archive |
+| **Multi-perspective** | `test-app` | Six specialised test agents simultaneously |
 
-### Structureel L7 ≠ mature L7
+### Structural L7 ≠ mature L7
 
-Het is verleidelijk om een orkestrator op te tuigen en je werk klaar te verklaren. Maar als die orkestrator geen evals heeft (L5) en geen learnings-loop (L6), heb je een **complexe machine zonder zelfkennis**. Hij dóét veel; je weet niet hoe goed.
+It's tempting to stand up an orchestrator and call your work done. But if that orchestrator has no evals (L5) and no learnings loop (L6), you have a **complex machine without self-knowledge**. It *does* a lot; you don't know how well.
 
-Dat heet *structureel L7, maturity L4*. Het probleem: zodra hij faalt, weet niemand wáár in de keten het misging, en de fout herhaalt zich morgen weer. Voor échte L7 moet je de L5- en L6-gaten dichten — meet de keten als geheel én op handoff-punten, en laat de orkestrator zelf observaties capturen.
+That's called *structural L7, maturity L4*. The problem: once it fails, no one knows *where* in the chain things went wrong, and the error repeats tomorrow. For real L7 you need to close the L5 and L6 gaps — measure the chain as a whole and at the hand-off points, and let the orchestrator capture observations itself.
 
-<HexCard title="L7 in één regel">
-  Een L7-skill orkestreert anderen — maar pas als hij óók is gemeten (L5) en leert (L6) is hij ook écht mature; daarvoor is het architectuur zonder zelfreflectie.
+<HexCard title="L7 in one line">
+  An L7 skill orchestrates others — but only when it's also measured (L5) and learning (L6) is it really mature; until then it's architecture without self-reflection.
 </HexCard>
 
-## De hele library bewaken: het skill-level-overview-dashboard
+## Monitoring the whole library: the skill-level-overview dashboard
 
-Eén skill op L6 of L7 brengen is overzichtelijk. Maar zodra je een library van tien, twintig of (zoals in Hydra) ~70 skills hebt, wil je in één oogopslag zien welke skill op welk niveau zit — en welke achteruit kachelen.
+Taking one skill to L6 or L7 is manageable. But once you have a library of ten, twenty, or (as in Hydra) ~70 skills, you want to see at a glance which skill sits at which level — and which ones are sliding back.
 
-Daarvoor zitten er in de Conduction-skill-toolchain twee bestanden onder `.claude/skills/`:
+For that, the Conduction skill toolchain ships two files under `.claude/skills/`:
 
-- **`skill-level-overview.html`** — een lokaal, statisch HTML-dashboard. Eén tabel met per skill: huidige maturity (groene dots), target maturity (badge), regelaantal van `SKILL.md` (gekleurd: groen ≤200, geel rond 450, rood >500), en oranje rings voor "structureel aanwezig maar nog niet mature". Sorteerbaar per kolom. Je opent 'm lokaal — `xdg-open` op Linux, `open` op macOS, of dubbelklik in de file-explorer.
-- **`update-skill-overview.sh`** — een bash-script dat over alle skill-folders heen scant, structurele markers detecteert (frontmatter aanwezig, guardrails, evals met genoeg trigger-tests, dated learnings, agent-spawns), en de HTML up-to-date schrijft. Eén `./update-skill-overview.sh` en je dashboard klopt weer.
+- **`skill-level-overview.html`** — a local, static HTML dashboard. One table per skill: current maturity (green dots), target maturity (badge), `SKILL.md` line count (coloured: green ≤200, yellow around 450, red >500), and orange rings for "structurally present but not yet mature". Sortable by column. You open it locally — `xdg-open` on Linux, `open` on macOS, or double-click in the file explorer.
+- **`update-skill-overview.sh`** — a bash script that scans every skill folder, detects structural markers (frontmatter present, guardrails, evals with enough trigger tests, dated learnings, agent spawns), and writes the HTML back up to date. One `./update-skill-overview.sh` and your dashboard is correct again.
 
-### Wat het script automatisch doet
+### What the script does automatically
 
-Het script detecteert:
+The script detects:
 
-| Niveau | Wat het script meet |
+| Level | What the script measures |
 |---|---|
-| **L1** | Frontmatter aanwezig, genummerde stappen, guardrail-secties of directieven, `name:` matcht foldernaam |
-| **L2** | `SKILL.md` ≤500 regels en `description:` is gevuld |
-| **L3** | Proven patterns + `examples/` of `references/` of `templates/` aanwezig |
-| **L4** | **NOOIT automatisch** — moet je handmatig bevestigen (domein-kennis is mensenwerk) |
-| **L5** | `evals/evals.json` met 3+ scenario's, 10+ should-trigger, 10+ should-not-trigger, `last_validated` gevuld, plus `grading.json` én `timing.json` |
-| **L6** | `learnings.md` met gedateerde entries + "Capture Learnings"-stap in `SKILL.md` |
-| **L7** | Verwijzingen naar `Agent tool`, `subagent` of `Task agents` in `SKILL.md` |
+| **L1** | Frontmatter present, numbered steps, guardrail sections or directives, `name:` matches the folder name |
+| **L2** | `SKILL.md` ≤500 lines and `description:` is filled |
+| **L3** | Proven patterns + `examples/` or `references/` or `templates/` present |
+| **L4** | **NEVER automatic** — you have to confirm manually (domain knowledge is human work) |
+| **L5** | `evals/evals.json` with 3+ scenarios, 10+ should-trigger, 10+ should-not-trigger, `last_validated` filled, plus `grading.json` and `timing.json` |
+| **L6** | `learnings.md` with dated entries + "Capture Learnings" step in `SKILL.md` |
+| **L7** | References to `Agent tool`, `subagent`, or `Task agents` in `SKILL.md` |
 
-Belangrijke ontwerpkeuze: **L4 wordt nooit automatisch gezet**. Domein-kennis is niet detecteerbaar uit bestandsstructuur — alleen jij kunt zeggen of een skill jouw business écht kent. Het script roept luidruchtig om aandacht als L1–L3 staan maar L4 nog niet bevestigd is.
+A key design choice: **L4 is never set automatically**. Domain knowledge isn't detectable from file structure — only you can say whether a skill really knows your business. The script shouts for attention when L1–L3 are in place but L4 isn't confirmed yet.
 
-### Hoe je dit voor je eigen project opzet
+### How to set this up for your own project
 
-De canonieke `skill-level-overview.html` + `update-skill-overview.sh` zitten in Conductions interne skill-toolchain. Twee paden om er zelf mee aan de slag te gaan:
+The canonical `skill-level-overview.html` + `update-skill-overview.sh` live in Conduction's internal skill toolchain. Two paths to get going with it yourself:
 
-- **Vraag de bestanden op** — mail ons via de CTA onderaan deze pagina; we delen de huidige versie graag met klanten en partners als startpunt. Daarna is het `cp` naar `<jouw-repo>/.claude/skills/` en `bash .claude/skills/update-skill-overview.sh` draaien.
-- **Bouw zelf** — de meet-regels uit de tabel hierboven zijn alles wat je nodig hebt. Een paar uur bash + een simpele HTML-tabel-template levert al een werkende v1.
+- **Ask for the files** — email us via the CTA at the bottom of this page; we're happy to share the current version with customers and partners as a starting point. After that it's `cp` to `<your-repo>/.claude/skills/` and run `bash .claude/skills/update-skill-overview.sh`.
+- **Build it yourself** — the measurement rules in the table above are all you need. A few hours of bash and a simple HTML table template will already give you a working v1.
 
-Een natuurlijke plek om het script te draaien: vóór een release-tag, in een pre-commit hook op de skills-folder, of als wekelijkse cron. Zo zie je drift (een skill die naar 520 regels groeit en dus L2 verliest) meteen.
+A natural place to run the script: before a release tag, in a pre-commit hook on the skills folder, or as a weekly cron. That way you see drift (a skill that grows to 520 lines and therefore loses L2) immediately.
 
-<HexCard title="Vuistregel: weekly scan + per-skill consolidatie">
-  Draai <code>update-skill-overview.sh</code> wekelijks; consolideer <code>learnings.md</code> per skill ad-hoc bij ~80 entries. Het dashboard vertelt je welke skill aan de beurt is.
+<HexCard title="Rule of thumb: weekly scan + per-skill consolidation">
+  Run <code>update-skill-overview.sh</code> weekly; consolidate <code>learnings.md</code> per skill ad hoc around ~80 entries. The dashboard tells you which skill is up next.
 </HexCard>
 
-## Test jezelf
+## Test yourself
 
-Vier korte vragen om te checken of je dit deel begrepen hebt. Vastgelopen? Klik **Hint**. Curieus naar het antwoord? Klik **Antwoord**.
+Four short questions to check whether you got this part. Stuck? Click **Hint**. Curious about the answer? Click **Answer**.
 
 <div className="tutorial-quiz">
 
-**1. Waarom een two-stage buffer in plaats van direct in `learnings.md` schrijven?**
+**1. Why a two-stage buffer instead of writing directly into `learnings.md`?**
 
 <Details summary="Hint">
 
-Wat gebeurt er als élke vluchtige observatie meteen permanent wordt opgeslagen?
+What happens if *every* fleeting observation gets stored permanently right away?
 
 </Details>
 
-<Details summary="Antwoord">
+<Details summary="Answer">
 
-Omdat directe schrijfacties `learnings.md` snel verontreinigen met eenmalige toevalligheden, foutdiagnoses die later anders bleken te zijn, of observaties die alleen voor één specifieke context relevant waren. Elk daarvan blijft daarna in elke executie meegelezen worden, en eet van je context-budget.
+Because direct writes pollute `learnings.md` fast with one-off coincidences, error diagnoses that later turned out to be different, or observations that were only relevant to one specific context. Each of those then gets read on every execution and eats your context budget.
 
-De two-stage buffer (`learning-candidates.md` → `learnings.md`) plaatst een filter ertussen: alleen observaties die minstens 3 keer bevestigd zijn, of die een gemeten eval-failure oplossen, promoveren. De rest valt na 30 dagen vanzelf weg. Het resultaat: `learnings.md` blijft hoogwaardige signalen bevatten, en bij consolidatie heb je echte patronen om te promoten naar `SKILL.md`-guardrails.
+The two-stage buffer (`learning-candidates.md` → `learnings.md`) inserts a filter: only observations that have been confirmed at least 3 times, or that fix a measured eval failure, get promoted. The rest drops off after 30 days. The result: `learnings.md` keeps high-signal entries, and at consolidation time you have real patterns to promote into `SKILL.md` guardrails.
 
 </Details>
 
@@ -252,22 +252,22 @@ De two-stage buffer (`learning-candidates.md` → `learnings.md`) plaatst een fi
 
 <div className="tutorial-quiz">
 
-**2. Wat is het verschil tussen "structureel L7" en "mature L7", en waarom is dat verschil belangrijk?**
+**2. What's the difference between "structural L7" and "mature L7", and why does it matter?**
 
 <Details summary="Hint">
 
-Een skill kan architecturaal complex zijn zonder ooit gemeten of geleerd te hebben.
+A skill can be architecturally complex without ever having been measured or having learned anything.
 
 </Details>
 
-<Details summary="Antwoord">
+<Details summary="Answer">
 
-- **Structureel L7** betekent dat de skill *de architectuur* van orkestratie heeft: spawnt subagents, zit in een keten, doet hand-offs, draait parallel.
-- **Mature L7** betekent dat die architectuur óók is gemeten (L5) en zichzelf verbetert (L6).
+- **Structural L7** means the skill has *the architecture* of orchestration: spawns subagents, sits in a chain, does hand-offs, runs in parallel.
+- **Mature L7** means that architecture has *also* been measured (L5) and improves itself (L6).
 
-Een "structureel L7, maturity L4" skill is een complexe machine zonder zelfkennis. Hij dóét veel — je weet niet hoe goed. Zodra hij faalt is onduidelijk wáár in de keten het misging, en de fout herhaalt zich morgen.
+A "structural L7, maturity L4" skill is a complex machine without self-knowledge. It *does* a lot — you don't know how well. Once it fails, it's unclear *where* in the chain things went wrong, and the error repeats tomorrow.
 
-Het verschil is belangrijk omdat orkestrators groot blast-radius hebben: ze starten meerdere agents, doen meerdere acties, raken meerdere bestanden. Als je daarbij geen evals (L5) en geen learnings (L6) hebt, schaal je fouten net zo hard mee als successen.
+The distinction matters because orchestrators have a big blast radius: they start multiple agents, take multiple actions, touch multiple files. If you don't have evals (L5) and learnings (L6) alongside that, you scale failures just as hard as successes.
 
 </Details>
 
@@ -275,21 +275,21 @@ Het verschil is belangrijk omdat orkestrators groot blast-radius hebben: ze star
 
 <div className="tutorial-quiz">
 
-**3. Waarom zet `update-skill-overview.sh` L4 nooit automatisch?**
+**3. Why does `update-skill-overview.sh` never set L4 automatically?**
 
 <Details summary="Hint">
 
-Wat onderscheidt L4 van L1, L2, L3, L5, L6 en L7 in termen van wat detecteerbaar is?
+What sets L4 apart from L1, L2, L3, L5, L6 and L7 in terms of what's detectable?
 
 </Details>
 
-<Details summary="Antwoord">
+<Details summary="Answer">
 
-Omdat L4 — "Personalization / Domain Knowledge" — betekent dat de skill jouw bedrijfsspecifieke kennis bevat (ADRs, naming conventions, business-rules, "wij gebruiken `development` als primaire branch"). Dat is niet detecteerbaar uit bestandsstructuur, regelaantallen of frontmatter-velden.
+Because L4 — "Personalization / Domain Knowledge" — means the skill contains your business-specific knowledge (ADRs, naming conventions, business rules, "we use `development` as our primary branch"). That isn't detectable from file structure, line counts, or frontmatter fields.
 
-L1 t/m L3 zijn structureel (frontmatter, guardrails, voorbeelden — een script kan ze zien). L5 t/m L7 zijn structureel óf gedrags-gerelateerd op manieren die in bestanden zichtbaar zijn (evals-json, learnings.md, agent-calls).
+L1 through L3 are structural (frontmatter, guardrails, examples — a script can see them). L5 through L7 are structural or behaviour-related in ways that show up in files (evals JSON, learnings.md, agent calls).
 
-Maar L4 vereist een mens die zegt: "ja, deze skill kent ónze codebase, niet alleen generieke best-practices." Daarom roept het script luid om jouw input zodra L1–L3 zijn behaald maar L4 nog niet bevestigd. Tot dat moment blijft de skill op M3 hangen, ook al zijn er structureel al hogere niveaus aanwezig.
+But L4 requires a human to say: "yes, this skill knows *our* codebase, not just generic best practices." That's why the script calls loudly for your input as soon as L1–L3 are achieved but L4 isn't confirmed yet. Until that moment the skill stays at M3, even when structurally higher levels are already present.
 
 </Details>
 
@@ -297,50 +297,50 @@ Maar L4 vereist een mens die zegt: "ja, deze skill kent ónze codebase, niet all
 
 <div className="tutorial-quiz">
 
-**4. Een teamgenoot heeft een skill die parallel zes test-agents spawnt, maar geen evals en geen `learnings.md` heeft. Wat zou jij voorstellen — eerst meer orkestratie toevoegen, of eerst iets anders?**
+**4. A teammate has a skill that spawns six test agents in parallel but has no evals and no `learnings.md`. What would you suggest — add more orchestration first, or something else first?**
 
 <Details summary="Hint">
 
-Denk aan het verschil tussen architectuur en zelfkennis.
+Think about the difference between architecture and self-knowledge.
 
 </Details>
 
-<Details summary="Antwoord">
+<Details summary="Answer">
 
-Eerst **niet meer orkestratie**. Deze skill is structureel L7, maturity L4 — de architectuur staat er, maar er is geen meting (L5) en geen lerend gedrag (L6). Meer parallellisme of meer chain-skills toevoegen vergroot alleen de blast-radius.
+First: **not more orchestration**. This skill is structural L7, maturity L4 — the architecture is in place, but there's no measurement (L5) and no learning behaviour (L6). Adding more parallelism or more chain skills only enlarges the blast radius.
 
-De juiste volgorde:
+The right order:
 
-1. **L5 eerst** — schrijf 3+ eval-scenario's voor de hele keten en voor de hand-off-punten. Pas dan weet je of de zes parallele agents elkaar niet tegenwerken of dubbel werk doen.
-2. **L6 daarna** — voeg een `learnings.md` toe waarin de orkestrator vastlegt welke patronen tussen agents wel/niet werken (bv. "wanneer agent A en B beide hetzelfde bestand aanraken, ontstaat conflict X").
-3. **Pas dan L7-uitbreiding** — als de keten gemeten en lerend is, kun je hem veilig uitbreiden (meer agents, langere chain, autonome loop).
+1. **L5 first** — write 3+ eval scenarios for the whole chain and the hand-off points. Only then do you know whether the six parallel agents aren't fighting each other or doubling work.
+2. **L6 next** — add a `learnings.md` where the orchestrator records which patterns between agents work and which don't (e.g. "when agent A and B both touch the same file, conflict X arises").
+3. **Only then L7 expansion** — once the chain is measured and learning, you can expand it safely (more agents, longer chain, autonomous loop).
 
-Vuistregel: orkestratie zonder meting is ongeoorloofd schaalwerk. Eerst weten of de keten werkt, dan groter maken.
+Rule of thumb: orchestration without measurement is unjustified scaling. First know whether the chain works, then grow it.
 
 </Details>
 
 </div>
 
-<NextSteps title="Volgende stap" lede="Je hebt nu het complete spectrum gezien: van anatomy tot orkestratie, plus het dashboard om je hele library te bewaken. Dit zijn goede volgende stappen.">
+<NextSteps title="Next step" lede="You've now seen the full spectrum: from anatomy to orchestration, plus the dashboard to monitor your whole library. These are good next steps.">
   <NextStep
-    title="Hydra leerlijn — Deel 4: Skills in de Hydra-pipeline"
+    title="Hydra tutorial series — Part 4: Skills inside the Hydra pipeline"
     href="/academy/hydra-tutorial-4-skills"
-    description="Zien hoe ~70 skills samen draaien in vier families binnen een echte agentic CI/CD-pipeline. Interne leerlijn voor Conduction-collega's."
+    description="See how ~70 skills run together in four families inside a real agentic CI/CD pipeline. Internal track for Conduction colleagues."
   />
   <NextStep
-    title="Vorige stap — Skill-evals (L5)"
+    title="Previous step — Skill evals (L5)"
     href="/academy/claude-skills-tutorial-3-skill-evals"
-    description="Terug naar de meet-fundering — handig om nog eens door te lezen vóór je L6 op een skill aanzet."
+    description="Back to the measurement foundation — useful to re-read before you switch L6 on for a skill."
   />
   <NextStep
-    title="Conduction-docs — Writing Skills (volledige referentie)"
+    title="Conduction docs — Writing Skills (full reference)"
     href="https://github.com/ConductionNL/.github/blob/main/docs/claude/writing-skills.md"
-    description="De canonieke 7-level maturity framework-doc waar deze leerlijn op gebaseerd is."
+    description="The canonical 7-level maturity framework doc this track is based on."
   />
 </NextSteps>
 
 <ContactCta
-  title="Een orkestrator opzetten voor jouw team?"
-  body="L7-skills zijn waar Hydra zelf op draait. Wil je sparren over of jouw use-case een orkestrator verdient, of hoe je een learnings-loop in je bestaande skill inbouwt? Stuur ons een mail."
-  cta={{ label: "Mail Conduction", href: "mailto:info@conduction.nl?subject=Claude%20Skills%20leerlijn%20deel%204" }}
+  title="Setting up an orchestrator for your team?"
+  body="L7 skills are what Hydra itself runs on. Want to spar about whether your use case deserves an orchestrator, or how to build a learnings loop into your existing skill? Send us an email."
+  cta={{ label: "Email Conduction", href: "mailto:info@conduction.nl?subject=Claude%20Skills%20learning%20track%20part%204" }}
 />

--- a/academy/2026-05-19-openwoo-community-meetings/index.mdx
+++ b/academy/2026-05-19-openwoo-community-meetings/index.mdx
@@ -4,7 +4,7 @@ title: OpenWoo community — two years of monthly meetings
 contentType: webinar
 authors: [conduction]
 date: 2026-05-19
-summary: Recordings of every public OpenWoo community meeting since 2023 — leveranciers, gemeenten, KOOP, en uitvoeringsorganisaties die samen de Wet open overheid uitrollen op Common Ground-leest.
+summary: Recordings of every public OpenWoo community meeting since 2023 — vendors, municipalities, KOOP, and executive agencies rolling out the Dutch Open Government Act (Woo) together on Common Ground foundations.
 tags: [OpenWoo, Woo, Community, Video, Common Ground]
 apps: [openwoo, opencatalogi, openregister, openconnector]
 durationMinutes: 60
@@ -12,19 +12,19 @@ durationMinutes: 60
 
 import {ContactCta} from '@conduction/docusaurus-preset/components';
 
-De OpenWoo-community komt elke tweede dinsdag van de maand samen. Leveranciers (Conduction, Xxllnc, OpenGemeenten, SHIFT2, Acato, Notubiz, iO), gemeenten in productie of acceptatie, en KOOP delen voortgang, blokkeerders, en het volgende stuk van de roadmap. Onder staan alle opgenomen sessies sinds eind 2023.
+The OpenWoo community meets every second Tuesday of the month. Vendors (Conduction, Xxllnc, OpenGemeenten, SHIFT2, Acato, Notubiz, iO), municipalities in production or acceptance, and KOOP share progress, blockers, and the next slice of the roadmap. Below are all recorded sessions since late 2023.
 
 {/* truncate */}
 
-## Hoe de community werkt
+## How the community works
 
-Eén Slack-kanaal in [samenorganiseren.slack.com](https://samenorganiseren.slack.com/archives/C067Q3UE9F0) voor vragen tussen meetings door. Elke meeting heeft een korte demo, een agenda-issue, en wordt opgenomen voor wie het live niet redt. Toetreden tot de community is open — geen contract, geen commitment, mail [info@conduction.nl](mailto:info@conduction.nl) als je wilt aanhaken.
+One Slack channel in [samenorganiseren.slack.com](https://samenorganiseren.slack.com/archives/C067Q3UE9F0) for questions between meetings. Each meeting has a short demo, an agenda issue, and is recorded for anyone who can't make it live. Joining the community is open — no contract, no commitment. Email [info@conduction.nl](mailto:info@conduction.nl) if you want to get involved.
 
-## Opgenomen sessies
+## Recorded sessions
 
 ### 2026 — Common Ground OpenWoo community meetings
 
-| Datum | Sessie | Opname |
+| Date | Session | Recording |
 |---|---|---|
 | 13-05-2026 | Community Meeting | [YouTube](https://www.youtube.com/watch?v=gaOft31cXic) |
 | 08-04-2026 | Community Meeting | [YouTube](https://youtu.be/Czrd3FdhoGU) |
@@ -34,7 +34,7 @@ Eén Slack-kanaal in [samenorganiseren.slack.com](https://samenorganiseren.slack
 
 ### 2025
 
-| Datum | Sessie | Opname |
+| Date | Session | Recording |
 |---|---|---|
 | 10-12-2025 | Community Meeting | [YouTube](https://youtu.be/jjS1DnILE1o?si=FqvAvUTtdxScehPa) |
 | 12-11-2025 | Community Meeting | [YouTube](https://youtu.be/Jh2Ap_Cuya8) |
@@ -45,27 +45,27 @@ Eén Slack-kanaal in [samenorganiseren.slack.com](https://samenorganiseren.slack
 | 12-03-2025 | Community Meeting | [YouTube](https://youtu.be/M9xOWcUOK2s) |
 | 15-01-2025 | Community Meeting | [YouTube](https://youtu.be/uV-hQwdz2Bo) |
 
-### 2024 — externe webinars en demo's
+### 2024 — external webinars and demos
 
-| Datum | Sessie | Spreker | Opname |
+| Date | Session | Speaker | Recording |
 |---|---|---|---|
-| 25-03-2024 | SHIFT2 — Een toekomstbestendige Woo-oplossing | SHIFT2 | [shift2.nl](https://www.shift2.nl/een-toekomstbestendige-woo-oplossing) |
+| 25-03-2024 | SHIFT2 — A future-proof Woo solution | SHIFT2 | [shift2.nl](https://www.shift2.nl/een-toekomstbestendige-woo-oplossing) |
 | 30-01-2024 | OpenGemeenten Woobinar | OpenGemeenten | [Vimeo](https://vimeo.com/909134953) |
 
-### 2023 — eerste demo's en webinars
+### 2023 — first demos and webinars
 
-| Datum | Sessie | Spreker | Opname |
+| Date | Session | Speaker | Recording |
 |---|---|---|---|
 | 19-12-2023 | xxllnc Demo | xxllnc | [YouTube](https://www.youtube.com/watch?v=_FGpUYH1yd0) |
 | 17-11-2023 | xxllnc Woobinar | xxllnc | [YouTube](https://www.youtube.com/watch?v=NCnLDEoPh5A) |
 
-## Verwante content in Academy
+## Related content in Academy
 
-- [Set up a Woo register in OpenRegister](/academy/woo-register-opzetten) — start hier als je net begint, importeert het canonieke Woo-register met alle TOOI-categorieën in tien minuten.
-- [Upload Woo files](/academy/woo-bestanden-uploaden) — vervolgtutorial; voeg PDF-bijlagen toe aan publicaties.
+- [Set up a Woo register in OpenRegister](/academy/woo-register-opzetten) — start here if you're just getting going; imports the canonical Woo register with all TOOI categories in ten minutes.
+- [Upload Woo files](/academy/woo-bestanden-uploaden) — follow-up tutorial; attach PDF documents to publications.
 
-## Volledige technische documentatie
+## Full technical documentation
 
-Voor de architectuur, installatie, configuratie, en integratie-koppelvlakken: [openwoo.conduction.nl](https://openwoo.conduction.nl/). De solutions-page op [conduction.nl/solutions/openwoo](/solutions/openwoo) heeft het commerciële verhaal en de actuele lijst van twaalf gemeenten in productie.
+For architecture, installation, configuration, and integration interfaces: [openwoo.conduction.nl](https://openwoo.conduction.nl/). The solutions page at [conduction.nl/solutions/openwoo](/solutions/openwoo) has the commercial story and the current list of twelve municipalities in production.
 
 <ContactCta />

--- a/data/app-downloads.json
+++ b/data/app-downloads.json
@@ -134,7 +134,7 @@
     },
     {
       "github": {
-        "downloads": 914,
+        "downloads": 924,
         "latest_release": "v0.0.33",
         "latest_release_at": "2026-03-05T10:25:31Z",
         "release_count": 39,
@@ -165,7 +165,7 @@
             "tag": "v0.0.34-beta.20260313155152"
           },
           {
-            "downloads": 161,
+            "downloads": 170,
             "published_at": "2026-03-05T10:25:31Z",
             "tag": "v0.0.33"
           },
@@ -180,7 +180,7 @@
             "tag": "v0.0.32-unstable.2"
           },
           {
-            "downloads": 4,
+            "downloads": 5,
             "published_at": "2026-02-06T12:19:40Z",
             "tag": "v0.0.32-unstable.1"
           },
@@ -344,7 +344,7 @@
     },
     {
       "github": {
-        "downloads": 1866,
+        "downloads": 1870,
         "latest_release": "v0.1.26",
         "latest_release_at": "2025-04-23T06:33:25Z",
         "release_count": 38,
@@ -355,7 +355,7 @@
             "tag": "v0.1.27-beta.20260313153748"
           },
           {
-            "downloads": 592,
+            "downloads": 596,
             "published_at": "2025-04-23T06:33:25Z",
             "tag": "v0.1.26"
           },
@@ -675,7 +675,7 @@
     },
     {
       "github": {
-        "downloads": 401,
+        "downloads": 417,
         "latest_release": "v0.1.2",
         "latest_release_at": "2026-03-05T10:23:21Z",
         "release_count": 14,
@@ -716,7 +716,7 @@
             "tag": "v0.1.3-beta.20260313150323"
           },
           {
-            "downloads": 279,
+            "downloads": 292,
             "published_at": "2026-03-05T10:23:21Z",
             "tag": "v0.1.2"
           },
@@ -731,7 +731,7 @@
             "tag": "v0.1.1-unstable.5"
           },
           {
-            "downloads": 96,
+            "downloads": 99,
             "published_at": "2026-02-06T12:41:22Z",
             "tag": "v0.1.1-unstable.2"
           },
@@ -808,13 +808,18 @@
     },
     {
       "github": {
-        "downloads": 6016,
-        "latest_release": "v1.0.0",
-        "latest_release_at": "2026-05-08T13:47:17Z",
-        "release_count": 336,
+        "downloads": 6059,
+        "latest_release": "v1.0.2",
+        "latest_release_at": "2026-05-21T15:07:27Z",
+        "release_count": 352,
         "releases": [
           {
-            "downloads": 6,
+            "downloads": 17,
+            "published_at": "2026-05-20T08:53:24Z",
+            "tag": "v1.0.1"
+          },
+          {
+            "downloads": 7,
             "published_at": "2026-05-08T13:47:17Z",
             "tag": "v1.0.0"
           },
@@ -824,7 +829,7 @@
             "tag": "v0.7.13-beta.20260507114139"
           },
           {
-            "downloads": 3,
+            "downloads": 4,
             "published_at": "2026-05-05T14:42:02Z",
             "tag": "v0.7.13-beta.20260505143910"
           },
@@ -904,7 +909,7 @@
             "tag": "v0.7.12-beta.1"
           },
           {
-            "downloads": 185,
+            "downloads": 191,
             "published_at": "2026-03-10T12:48:13Z",
             "tag": "v0.7.12"
           },
@@ -984,7 +989,7 @@
             "tag": "v0.7.8-beta.1"
           },
           {
-            "downloads": 185,
+            "downloads": 187,
             "published_at": "2026-01-13T14:37:00Z",
             "tag": "v0.7.7"
           },
@@ -1059,7 +1064,7 @@
             "tag": "v0.7.7-beta.1"
           },
           {
-            "downloads": 281,
+            "downloads": 283,
             "published_at": "2025-10-31T13:14:10Z",
             "tag": "v0.7.6"
           },
@@ -1074,7 +1079,7 @@
             "tag": "v0.7.6-beta.1"
           },
           {
-            "downloads": 77,
+            "downloads": 79,
             "published_at": "2025-10-29T09:54:05Z",
             "tag": "v0.7.5"
           },
@@ -1084,7 +1089,7 @@
             "tag": "v0.7.10-unstable.1"
           },
           {
-            "downloads": 90,
+            "downloads": 92,
             "published_at": "2026-03-05T16:02:21Z",
             "tag": "v0.7.9"
           },
@@ -1169,7 +1174,7 @@
             "tag": "v0.7.9-beta.1"
           },
           {
-            "downloads": 146,
+            "downloads": 148,
             "published_at": "2026-02-11T14:02:41Z",
             "tag": "v0.7.8"
           },
@@ -1469,7 +1474,7 @@
             "tag": "v0.7.5-beta.1"
           },
           {
-            "downloads": 310,
+            "downloads": 312,
             "published_at": "2025-08-06T07:32:56Z",
             "tag": "v0.7.4"
           },
@@ -1484,7 +1489,7 @@
             "tag": "v0.7.4-beta.1"
           },
           {
-            "downloads": 159,
+            "downloads": 161,
             "published_at": "2025-07-17T13:31:18Z",
             "tag": "v0.7.3"
           },
@@ -1709,12 +1714,12 @@
             "tag": "v0.7.3-beta.1"
           },
           {
-            "downloads": 153,
+            "downloads": 155,
             "published_at": "2025-06-20T15:44:19Z",
             "tag": "v0.7.2"
           },
           {
-            "downloads": 65,
+            "downloads": 67,
             "published_at": "2025-06-20T15:04:24Z",
             "tag": "v0.6.75"
           },
@@ -2345,7 +2350,7 @@
         ],
         "in_store": true,
         "last_release_at": null,
-        "latest_version": "0.7.9-beta.8",
+        "latest_version": "1.0.1",
         "rating_count": 0,
         "rating_overall": 0.5,
         "rating_recent": 0.5,
@@ -2354,38 +2359,38 @@
     },
     {
       "github": {
-        "downloads": 6383,
+        "downloads": 6438,
         "latest_release": "v0.2.20",
         "latest_release_at": "2026-04-23T14:44:26Z",
         "release_count": 299,
         "releases": [
           {
-            "downloads": 98,
+            "downloads": 108,
             "published_at": "2026-04-23T14:44:26Z",
             "tag": "v0.2.20"
           },
           {
-            "downloads": 92,
+            "downloads": 95,
             "published_at": "2026-04-15T08:45:47Z",
             "tag": "v0.2.19"
           },
           {
-            "downloads": 67,
+            "downloads": 70,
             "published_at": "2026-04-14T10:01:38Z",
             "tag": "v0.2.18"
           },
           {
-            "downloads": 96,
+            "downloads": 99,
             "published_at": "2026-04-02T09:16:08Z",
             "tag": "v0.2.17"
           },
           {
-            "downloads": 85,
+            "downloads": 88,
             "published_at": "2026-03-27T16:48:10Z",
             "tag": "v0.2.16"
           },
           {
-            "downloads": 62,
+            "downloads": 65,
             "published_at": "2026-03-27T08:47:00Z",
             "tag": "v0.2.15"
           },
@@ -2395,12 +2400,12 @@
             "tag": "v0.2.14"
           },
           {
-            "downloads": 63,
+            "downloads": 66,
             "published_at": "2026-03-18T15:46:17Z",
             "tag": "v0.2.13"
           },
           {
-            "downloads": 58,
+            "downloads": 61,
             "published_at": "2026-03-18T11:18:04Z",
             "tag": "v0.2.12"
           },
@@ -2410,7 +2415,7 @@
             "tag": "v0.2.10-beta.20260313155222"
           },
           {
-            "downloads": 84,
+            "downloads": 87,
             "published_at": "2026-03-05T12:34:50Z",
             "tag": "v0.2.9"
           },
@@ -2450,7 +2455,7 @@
             "tag": "v0.2.9-beta.1"
           },
           {
-            "downloads": 133,
+            "downloads": 136,
             "published_at": "2026-02-09T12:20:36Z",
             "tag": "v0.2.8"
           },
@@ -2505,7 +2510,7 @@
             "tag": "v0.2.8-beta.1"
           },
           {
-            "downloads": 133,
+            "downloads": 136,
             "published_at": "2026-01-13T14:36:27Z",
             "tag": "v0.2.7"
           },
@@ -2615,7 +2620,7 @@
             "tag": "v0.2.7-beta.1"
           },
           {
-            "downloads": 279,
+            "downloads": 282,
             "published_at": "2025-10-29T09:53:11Z",
             "tag": "v0.2.6"
           },
@@ -2815,7 +2820,7 @@
             "tag": "v0.2.6-beta.1"
           },
           {
-            "downloads": 400,
+            "downloads": 403,
             "published_at": "2025-08-07T12:31:24Z",
             "tag": "v0.2.5"
           },
@@ -2825,7 +2830,7 @@
             "tag": "v0.2.5-beta.1"
           },
           {
-            "downloads": 87,
+            "downloads": 90,
             "published_at": "2025-08-06T07:32:30Z",
             "tag": "v0.2.4"
           },
@@ -2930,7 +2935,7 @@
             "tag": "v0.2.4-beta.1"
           },
           {
-            "downloads": 149,
+            "downloads": 152,
             "published_at": "2025-07-16T15:42:51Z",
             "tag": "v0.2.3"
           },
@@ -3020,7 +3025,7 @@
             "tag": "v0.2.3-beta.1"
           },
           {
-            "downloads": 130,
+            "downloads": 133,
             "published_at": "2025-06-20T15:42:10Z",
             "tag": "v0.2.2"
           },
@@ -3884,13 +3889,18 @@
     },
     {
       "github": {
-        "downloads": 10126,
-        "latest_release": "v1.0.1",
-        "latest_release_at": "2026-05-08T14:46:46Z",
-        "release_count": 793,
+        "downloads": 10216,
+        "latest_release": "v1.0.2",
+        "latest_release_at": "2026-05-20T09:19:58Z",
+        "release_count": 813,
         "releases": [
           {
-            "downloads": 7,
+            "downloads": 43,
+            "published_at": "2026-05-20T09:19:58Z",
+            "tag": "v1.0.2"
+          },
+          {
+            "downloads": 8,
             "published_at": "2026-05-08T14:46:46Z",
             "tag": "v1.0.1"
           },
@@ -4015,7 +4025,7 @@
             "tag": "v0.2.13-unstable.58"
           },
           {
-            "downloads": 2,
+            "downloads": 3,
             "published_at": "2026-03-12T09:26:49Z",
             "tag": "v0.2.13-unstable.57"
           },
@@ -4350,12 +4360,12 @@
             "tag": "v0.2.12-beta.1"
           },
           {
-            "downloads": 577,
+            "downloads": 597,
             "published_at": "2026-02-11T14:01:39Z",
             "tag": "v0.2.11"
           },
           {
-            "downloads": 104,
+            "downloads": 106,
             "published_at": "2026-02-09T12:20:49Z",
             "tag": "v0.2.10"
           },
@@ -4385,7 +4395,7 @@
             "tag": "v0.2.10-unstable.4"
           },
           {
-            "downloads": 5,
+            "downloads": 6,
             "published_at": "2026-01-29T13:38:22Z",
             "tag": "v0.2.10-unstable.3"
           },
@@ -4465,7 +4475,7 @@
             "tag": "v0.2.10-beta.73"
           },
           {
-            "downloads": 7,
+            "downloads": 8,
             "published_at": "2026-01-27T11:34:57Z",
             "tag": "v0.2.10-beta.72"
           },
@@ -4795,7 +4805,7 @@
             "tag": "v0.2.10-beta.12"
           },
           {
-            "downloads": 7,
+            "downloads": 8,
             "published_at": "2026-01-18T09:54:01Z",
             "tag": "v0.2.10-beta.11"
           },
@@ -4810,7 +4820,7 @@
             "tag": "v0.2.10-beta.1"
           },
           {
-            "downloads": 250,
+            "downloads": 252,
             "published_at": "2026-01-13T15:39:29Z",
             "tag": "v0.2.9"
           },
@@ -5035,7 +5045,7 @@
             "tag": "v0.2.9-beta.1"
           },
           {
-            "downloads": 392,
+            "downloads": 394,
             "published_at": "2025-11-14T12:35:42Z",
             "tag": "v0.2.8"
           },
@@ -5170,7 +5180,7 @@
             "tag": "v0.2.8-beta.1"
           },
           {
-            "downloads": 209,
+            "downloads": 211,
             "published_at": "2025-10-29T09:53:08Z",
             "tag": "v0.2.7"
           },
@@ -5960,7 +5970,7 @@
             "tag": "v0.2.7-beta.1"
           },
           {
-            "downloads": 453,
+            "downloads": 455,
             "published_at": "2025-08-14T09:21:15Z",
             "tag": "v0.2.6"
           },
@@ -5990,7 +6000,7 @@
             "tag": "v0.2.6-beta.1"
           },
           {
-            "downloads": 142,
+            "downloads": 144,
             "published_at": "2025-08-06T07:31:53Z",
             "tag": "v0.2.5"
           },
@@ -6115,7 +6125,7 @@
             "tag": "v0.2.5-beta.1"
           },
           {
-            "downloads": 179,
+            "downloads": 181,
             "published_at": "2025-07-18T13:54:58Z",
             "tag": "v0.2.4"
           },
@@ -6125,7 +6135,7 @@
             "tag": "v0.2.4-beta.1"
           },
           {
-            "downloads": 88,
+            "downloads": 90,
             "published_at": "2025-07-17T13:30:01Z",
             "tag": "v0.2.3"
           },
@@ -6325,12 +6335,12 @@
             "tag": "v0.2.3-beta.1"
           },
           {
-            "downloads": 226,
+            "downloads": 228,
             "published_at": "2025-06-20T15:40:14Z",
             "tag": "v0.2.2"
           },
           {
-            "downloads": 65,
+            "downloads": 67,
             "published_at": "2025-06-20T14:54:54Z",
             "tag": "v0.1.80"
           },
@@ -6370,7 +6380,7 @@
             "tag": "v0.1.80-beta.1"
           },
           {
-            "downloads": 20,
+            "downloads": 21,
             "published_at": "2025-05-22T14:13:48Z",
             "tag": "v0.1.78-beta.99"
           },
@@ -6940,7 +6950,7 @@
             "tag": "v0.1.78-beta.101"
           },
           {
-            "downloads": 8,
+            "downloads": 9,
             "published_at": "2025-05-22T14:20:42Z",
             "tag": "v0.1.78-beta.100"
           },
@@ -7343,11 +7353,12 @@
       "store": {
         "categories": [
           "organization",
+          "search",
           "tools"
         ],
         "in_store": true,
         "last_release_at": null,
-        "latest_version": "0.2.9-beta.9",
+        "latest_version": "1.0.2",
         "rating_count": 0,
         "rating_overall": 0.5,
         "rating_recent": 0.5,
@@ -7369,11 +7380,12 @@
       "store": {
         "categories": [
           "organization",
+          "search",
           "tools"
         ],
         "in_store": true,
         "last_release_at": null,
-        "latest_version": "0.2.9-beta.9",
+        "latest_version": "1.0.2",
         "rating_count": 0,
         "rating_overall": 0.5,
         "rating_recent": 0.5,
@@ -7410,18 +7422,18 @@
     },
     {
       "github": {
-        "downloads": 756,
+        "downloads": 815,
         "latest_release": "v0.1.19",
         "latest_release_at": "2026-04-27T20:42:31Z",
         "release_count": 9,
         "releases": [
           {
-            "downloads": 313,
+            "downloads": 369,
             "published_at": "2026-04-27T20:42:31Z",
             "tag": "v0.1.19"
           },
           {
-            "downloads": 438,
+            "downloads": 441,
             "published_at": "2026-03-19T14:35:29Z",
             "tag": "v0.1.18"
           },
@@ -7446,7 +7458,7 @@
             "tag": "v0.1.16-beta.20260313143737"
           }
         ],
-        "stars": 4,
+        "stars": 5,
         "url": "https://github.com/ConductionNL/pipelinq"
       },
       "id": "pipelinq",
@@ -7559,7 +7571,7 @@
     },
     {
       "github": {
-        "downloads": 8706,
+        "downloads": 8894,
         "latest_release": "v0.1.139",
         "latest_release_at": "2026-02-19T10:55:05Z",
         "release_count": 213,
@@ -7790,7 +7802,7 @@
             "tag": "v0.1.140"
           },
           {
-            "downloads": 709,
+            "downloads": 749,
             "published_at": "2026-02-19T10:55:05Z",
             "tag": "v0.1.139"
           },
@@ -7880,7 +7892,7 @@
             "tag": "v0.1.137-beta.26"
           },
           {
-            "downloads": 7,
+            "downloads": 8,
             "published_at": "2026-01-25T23:09:44Z",
             "tag": "v0.1.137-beta.25"
           },
@@ -7970,247 +7982,247 @@
             "tag": "v0.1.137-beta.1"
           },
           {
-            "downloads": 223,
+            "downloads": 226,
             "published_at": "2026-01-05T21:40:26Z",
             "tag": "v0.1.136"
           },
           {
-            "downloads": 77,
+            "downloads": 80,
             "published_at": "2026-01-05T21:36:53Z",
             "tag": "v0.1.135"
           },
           {
-            "downloads": 81,
+            "downloads": 84,
             "published_at": "2026-01-05T08:08:14Z",
             "tag": "v0.1.134"
           },
           {
-            "downloads": 100,
+            "downloads": 103,
             "published_at": "2025-12-29T10:56:57Z",
             "tag": "v0.1.133"
           },
           {
-            "downloads": 114,
+            "downloads": 117,
             "published_at": "2025-12-19T16:22:58Z",
             "tag": "v0.1.132"
           },
           {
-            "downloads": 74,
+            "downloads": 77,
             "published_at": "2025-12-19T16:15:03Z",
             "tag": "v0.1.131"
           },
           {
-            "downloads": 98,
+            "downloads": 101,
             "published_at": "2025-12-17T12:29:47Z",
             "tag": "v0.1.130"
           },
           {
-            "downloads": 76,
+            "downloads": 79,
             "published_at": "2025-12-17T12:27:25Z",
             "tag": "v0.1.129"
           },
           {
-            "downloads": 88,
+            "downloads": 91,
             "published_at": "2025-12-16T12:48:05Z",
             "tag": "v0.1.128"
           },
           {
-            "downloads": 89,
+            "downloads": 92,
             "published_at": "2025-12-15T11:20:05Z",
             "tag": "v0.1.127"
           },
           {
-            "downloads": 117,
+            "downloads": 120,
             "published_at": "2025-12-10T09:34:59Z",
             "tag": "v0.1.126"
           },
           {
-            "downloads": 93,
+            "downloads": 96,
             "published_at": "2025-12-08T14:08:55Z",
             "tag": "v0.1.125"
           },
           {
-            "downloads": 78,
+            "downloads": 81,
             "published_at": "2025-12-08T13:39:10Z",
             "tag": "v0.1.124"
           },
           {
-            "downloads": 79,
+            "downloads": 82,
             "published_at": "2025-12-08T11:14:07Z",
             "tag": "v0.1.123"
           },
           {
-            "downloads": 79,
+            "downloads": 82,
             "published_at": "2025-12-08T09:59:09Z",
             "tag": "v0.1.122"
           },
           {
-            "downloads": 96,
+            "downloads": 99,
             "published_at": "2025-12-05T15:09:02Z",
             "tag": "v0.1.121"
           },
           {
-            "downloads": 81,
+            "downloads": 84,
             "published_at": "2025-12-05T14:57:07Z",
             "tag": "v0.1.120"
           },
           {
-            "downloads": 76,
+            "downloads": 79,
             "published_at": "2025-12-05T14:51:53Z",
             "tag": "v0.1.119"
           },
           {
-            "downloads": 76,
+            "downloads": 79,
             "published_at": "2025-12-05T13:41:09Z",
             "tag": "v0.1.118"
           },
           {
-            "downloads": 77,
+            "downloads": 80,
             "published_at": "2025-12-05T13:01:59Z",
             "tag": "v0.1.117"
           },
           {
-            "downloads": 76,
+            "downloads": 79,
             "published_at": "2025-12-05T11:00:15Z",
             "tag": "v0.1.116"
           },
           {
-            "downloads": 89,
+            "downloads": 92,
             "published_at": "2025-12-04T14:08:35Z",
             "tag": "v0.1.115"
           },
           {
-            "downloads": 108,
+            "downloads": 111,
             "published_at": "2025-11-28T11:46:18Z",
             "tag": "v0.1.114"
           },
           {
-            "downloads": 79,
+            "downloads": 82,
             "published_at": "2025-11-28T08:43:36Z",
             "tag": "v0.1.113"
           },
           {
-            "downloads": 131,
+            "downloads": 134,
             "published_at": "2025-11-15T15:42:37Z",
             "tag": "v0.1.112"
           },
           {
-            "downloads": 77,
+            "downloads": 80,
             "published_at": "2025-11-15T14:33:48Z",
             "tag": "v0.1.111"
           },
           {
-            "downloads": 82,
+            "downloads": 85,
             "published_at": "2025-11-14T14:02:49Z",
             "tag": "v0.1.110"
           },
           {
-            "downloads": 119,
+            "downloads": 122,
             "published_at": "2025-11-06T15:24:53Z",
             "tag": "v0.1.109"
           },
           {
-            "downloads": 84,
+            "downloads": 87,
             "published_at": "2025-11-05T07:54:28Z",
             "tag": "v0.1.108"
           },
           {
-            "downloads": 96,
+            "downloads": 99,
             "published_at": "2025-10-30T10:22:06Z",
             "tag": "v0.1.107"
           },
           {
-            "downloads": 90,
+            "downloads": 93,
             "published_at": "2025-10-28T06:48:48Z",
             "tag": "v0.1.106"
           },
           {
-            "downloads": 81,
+            "downloads": 84,
             "published_at": "2025-10-27T15:29:56Z",
             "tag": "v0.1.105"
           },
           {
-            "downloads": 130,
+            "downloads": 133,
             "published_at": "2025-10-15T05:50:47Z",
             "tag": "v0.1.104"
           },
           {
-            "downloads": 79,
+            "downloads": 82,
             "published_at": "2025-10-14T11:05:47Z",
             "tag": "v0.1.103"
           },
           {
-            "downloads": 82,
+            "downloads": 85,
             "published_at": "2025-10-11T20:19:29Z",
             "tag": "v0.1.102"
           },
           {
-            "downloads": 83,
+            "downloads": 86,
             "published_at": "2025-10-10T13:23:58Z",
             "tag": "v0.1.101"
           },
           {
-            "downloads": 92,
+            "downloads": 95,
             "published_at": "2025-10-08T19:19:06Z",
             "tag": "v0.1.100"
           },
           {
-            "downloads": 85,
+            "downloads": 88,
             "published_at": "2025-10-08T12:56:14Z",
             "tag": "v0.1.99"
           },
           {
-            "downloads": 85,
+            "downloads": 88,
             "published_at": "2025-10-07T12:33:24Z",
             "tag": "v0.1.98"
           },
           {
-            "downloads": 82,
+            "downloads": 85,
             "published_at": "2025-10-07T05:58:55Z",
             "tag": "v0.1.97"
           },
           {
-            "downloads": 76,
+            "downloads": 79,
             "published_at": "2025-10-07T05:50:02Z",
             "tag": "v0.1.96"
           },
           {
-            "downloads": 80,
+            "downloads": 83,
             "published_at": "2025-10-06T21:05:43Z",
             "tag": "v0.1.95"
           },
           {
-            "downloads": 86,
+            "downloads": 89,
             "published_at": "2025-10-06T09:57:49Z",
             "tag": "v0.1.94"
           },
           {
-            "downloads": 78,
+            "downloads": 81,
             "published_at": "2025-10-06T09:47:33Z",
             "tag": "v0.1.93"
           },
           {
-            "downloads": 74,
+            "downloads": 77,
             "published_at": "2025-10-05T19:09:14Z",
             "tag": "v0.1.92"
           },
           {
-            "downloads": 74,
+            "downloads": 77,
             "published_at": "2025-10-05T10:10:43Z",
             "tag": "v0.1.91"
           },
           {
-            "downloads": 79,
+            "downloads": 82,
             "published_at": "2025-10-03T08:59:49Z",
             "tag": "v0.1.90"
           },
           {
-            "downloads": 70,
+            "downloads": 73,
             "published_at": "2025-10-03T08:53:06Z",
             "tag": "v0.1.89"
           },
           {
-            "downloads": 94,
+            "downloads": 97,
             "published_at": "2025-10-01T07:10:29Z",
             "tag": "v0.1.88"
           },
@@ -8664,33 +8676,33 @@
     },
     {
       "github": {
-        "downloads": 1833,
+        "downloads": 1853,
         "latest_release": "v0.1.30",
         "latest_release_at": "2026-03-05T10:25:29Z",
         "release_count": 107,
         "releases": [
           {
-            "downloads": 83,
+            "downloads": 86,
             "published_at": "2026-03-05T10:25:29Z",
             "tag": "v0.1.30"
           },
           {
-            "downloads": 121,
+            "downloads": 124,
             "published_at": "2025-10-07T09:34:43Z",
             "tag": "v0.1.29"
           },
           {
-            "downloads": 77,
+            "downloads": 80,
             "published_at": "2025-10-03T09:52:22Z",
             "tag": "v0.1.28"
           },
           {
-            "downloads": 73,
+            "downloads": 76,
             "published_at": "2025-10-02T09:14:13Z",
             "tag": "v0.1.27"
           },
           {
-            "downloads": 70,
+            "downloads": 73,
             "published_at": "2025-10-02T08:47:34Z",
             "tag": "v0.1.26"
           },
@@ -8800,7 +8812,7 @@
             "tag": "v0.1.3"
           },
           {
-            "downloads": 602,
+            "downloads": 607,
             "published_at": "2024-10-23T09:23:50Z",
             "tag": "v0.0.9"
           },
@@ -8944,7 +8956,7 @@
       }
     }
   ],
-  "generated_at": "2026-05-18T12:37:40+00:00",
+  "generated_at": "2026-05-21T15:14:32+00:00",
   "source": {
     "notes": "github.downloads counts every release-asset fetch (CI, mirrors, re-installs) \u2014 upper bound on real installs.",
     "org": "ConductionNL",
@@ -8953,6 +8965,6 @@
   "totals": {
     "apps_in_store": 12,
     "apps_total": 29,
-    "downloads": 37103
+    "downloads": 37588
   }
 }

--- a/i18n/nl/code.json
+++ b/i18n/nl/code.json
@@ -354,6 +354,10 @@
     "message": "Uitgelicht: {type}",
     "description": "Eyebrow on the featured academy card. {type} is the content type slug (blog, guide, case-study, webinar, tutorial)"
   },
+  "theme.academy.seriesLabel.deskdesk": {
+    "message": "Bouw een Nextcloud-app",
+    "description": "Series chip label for the DeskDesk tutorial series on the academy landing page"
+  },
   "theme.academy.featuredCta": {
     "message": "Lees meer",
     "description": "CTA label on the featured academy card"

--- a/i18n/nl/docusaurus-plugin-content-blog/2026-05-05-deskdesk-tutorial-0-three-paths/index.mdx
+++ b/i18n/nl/docusaurus-plugin-content-blog/2026-05-05-deskdesk-tutorial-0-three-paths/index.mdx
@@ -1,0 +1,161 @@
+---
+slug: deskdesk-tutorial-0-three-paths
+title: "Bouw een Nextcloud-app op de Conduction-stack, Deel 0: Drie paden, één leerlijn"
+contentType: tutorial
+authors: [conduction]
+date: 2026-05-05
+summary: Voor je een regel code schrijft, bepaal welk van de drie Conduction app-bouwpaden past bij de app die je in gedachten hebt. Traditioneel Nextcloud, OpenRegister + nextcloud-vue, of volledige manifest. Elk pad bouwt voort op wat het vorige je geeft, en de rest van de DeskDesk-serie leert het manifest-pad omdat dáár de curve steil in ons voordeel buigt.
+tags: [App development, Architecture, OpenRegister, nextcloud-vue, Manifest, Tutorial series]
+apps: [openregister]
+durationMinutes: 15
+series: deskdesk-tutorial
+partNumber: 0
+---
+
+import {
+  Outcomes,
+  Outcome,
+  Prerequisites,
+  PrerequisiteItem,
+  NextSteps,
+  NextStep,
+  HexCard,
+} from '@conduction/docusaurus-preset/components';
+
+Dit is **Deel 0** van de zesdelige DeskDesk-tutorial, de oriëntatieronde. Voor scaffolds, schema's of manifests is het nuttigste dat we een nieuwe ontwikkelaar kunnen geven een eerlijke kaart van de drie manieren waarop Conduction-apps daadwerkelijk gebouwd worden, wat elk pad kost, en wat elk pad teruggeeft. De rest van de serie kiest één pad en laat de bonnetjes zien. Deel 0 legt uit waarom.
+
+Iets anders is al vanaf minuut één belangrijk: **het manifest-systeem en de `@conduction/nextcloud-vue` componentenbibliotheek zijn twee verschillende oppervlakken**. Het manifest is de *declaratieve wat*, één `manifest.json` die navigatie, pagina's en configuratie beschrijft. `nextcloud-vue` is de *rendering hoe*, de `Cn*`-componenten waar het manifest naartoe dispatcht (`CnAppRoot`, `CnPageRenderer`, `CnIndexPage`, `CnDetailPage`, `CnDashboardPage`, en de rest). Technisch zijn ze los te koppelen. In de praktijk zijn ze zo verweven dat de rest van deze serie ze samen leert, en elke les noemt welk oppervlak hij aanraakt.
+
+{/* truncate */}
+
+<Outcomes title="Wat je hebt aan het eind van Deel 0">
+  <Outcome>Een helder beeld van de <strong>drie Conduction app-bouwpaden</strong>, traditioneel Nextcloud, OpenRegister + nextcloud-vue, en volledige manifest, met eerlijke trade-offs voor elk.</Outcome>
+  <Outcome>Een mentaal model voor <strong>welk pad te kiezen</strong> op basis van app-scope, teamgrootte, en hoeveel van je gedrag echt maatwerk is.</Outcome>
+  <Outcome>Het besef dat <strong>OpenRegister alleen</strong> je al RBAC, audit logging, GraphQL en cross-app integraties geeft, zelfs als je helemaal geen manifest schrijft.</Outcome>
+  <Outcome>Een helder gevoel voor hoe het <strong>manifest en nextcloud-vue</strong> zich verhouden als twee oppervlakken van dezelfde leerlijn.</Outcome>
+</Outcomes>
+
+## De drie paden in één oogopslag
+
+Dezelfde DeskDesk-feature, een lijst met bureaus met een detailpagina, een boekingsdialoog, en een sidebar die audit-historie toont, kan op drie manieren gebouwd worden. Kies de tabelcel die klinkt als jouw team.
+
+| | **Pad 1: Traditioneel Nextcloud** | **Pad 2: OpenRegister + nextcloud-vue** | **Pad 3: Manifest + nextcloud-vue** |
+|---|---|---|---|
+| **Wat je schrijft** | PHP-controllers, Doctrine entities + migraties, handgemaakte Vue-views, eigen routes, je eigen CRUD-endpoints | Schema's in JSON, register-configuratie, handgemaakte Vue-views opgebouwd uit `Cn*`-componenten, je eigen `App.vue` + router | Schema's in JSON, **één `manifest.json`** die pagina's + config beschrijft, alleen de echt-maatwerk-views als `type: 'custom'` |
+| **Per-app code voor de DeskDesk-feature hierboven** | ~1500 LOC | ~600 LOC | ~30 LOC + het manifest |
+| **Waar de data leeft** | App-private databasetabellen die je zelf hebt gedefinieerd | Een gedeeld OpenRegister-register, elke andere app op dezelfde Nextcloud kan via de registry lezen/schrijven | Hetzelfde als Pad 2 |
+| **RBAC, audit log, GraphQL, cross-app-referenties, bestandsbijlagen, calendar/contacts-integraties** | Bouw elk zelf | **Gratis**, OpenRegister levert ze mee. Zie "Wat OpenRegister je hoe dan ook geeft" hieronder | **Gratis**, hetzelfde als Pad 2 |
+| **Lijstpagina's, detailpagina's, filter-sidebars, mass-action-dialogen** | Bouw elk zelf | Hergebruik `CnIndexPage`, `CnDetailPage`, `CnDashboardPage`, schema stuurt kolommen en formulieren | Hergebruik dezelfde componenten, declaratief gedispatcht door `CnPageRenderer` vanuit je `manifest.json` |
+| **Een `priority`-veld toevoegen aan bookings** | Nieuwe migratie, nieuwe controller-code, nieuw Vue-veld, nieuwe validatie | Veld toevoegen aan schema → formulieren en tabellen pikken het automatisch op | Hetzelfde als Pad 2, schema-gedreven door en door |
+| **Een kanban-bord toevoegen (echt maatwerk)** | Bouw het | Bouw het als Vue-component, mount het in je router | Bouw het als Vue-component, declareer `{type:'custom', component:'PipelineBoard'}` in het manifest |
+| **Onderhoudslast over 10 vergelijkbare apps** | Elke app drift weg. 10 lijstpagina's, 10 detailpagina's, allemaal net iets anders. | Het Vue-oppervlak drift nog steeds, elke `App.vue` en router is handgeschreven. Schema-migraties blijven schoon. | Eén manifest-vorm over de hele vloot. Een lib-bump fixt elke app tegelijk. |
+| **Leercurve tot eerste werkende pagina** | Laagst als je al Nextcloud-app-ontwikkeling kent. De patronen zijn gedocumenteerd. | Middelmatig, schema's + `Cn*`-componenten zijn nieuw maar goed uitgesleten. | Steilst *in het begin*, je moet eerst manifest-dispatch doorgronden. Na Deel 2 keert de curve om. |
+| **Plafond** | Wat je in PHP + Vue kunt bouwen. Geen plafond maar ook geen hefboom. | Schema-gedreven CRUD schaalt prachtig. Maatwerkflows zijn nog steeds handgemaakte Vue. | Hetzelfde als Pad 2 plus: elke Conduction-app upgrade samen wanneer het manifest-schema of `nextcloud-vue` evolueert. |
+
+### Wanneer welk pad de juiste keuze is
+
+**Pad 1, Traditioneel Nextcloud** is de juiste keuze wanneer:
+- Je een Nextcloud-native feature levert zonder gebruik van cross-app gedeelde data (bijv. een Talk-command-extensie, een OAuth-provider, een calendar-provider-plugin).
+- Je gedrag nodig hebt dat onder de datalaag leeft, file storage-hooks, dav-endpoints, sharing-extensies.
+- Je een legacy-app onderhoudt waarvan de patronen ouder zijn dan OpenRegister en een herschrijving niet te rechtvaardigen is.
+- Je expliciet de vrijheid nodig hebt om af te wijken van de Conduction-stack, bring-your-own-database, bring-your-own-frontend-framework, alles waar de beperkingen je zouden vertragen.
+
+**Pad 2, OpenRegister + nextcloud-vue** is de juiste keuze wanneer:
+- Je data fundamenteel CRUD is tegen een kleine set schema's, maar je de *paginacompositie* voorlopig handgeschreven wilt houden, misschien omdat de bestaande app al een eigen `App.vue` heeft, of omdat je incrementeel wilt migreren.
+- Je aan het prototypen bent en eerst een paar handgemaakte views wilt voelen voor je commit aan een manifest-gedreven vorm.
+- Het team de manifest-mechanica nog niet heeft geleerd en je een deadline hebt.
+
+**Pad 3, Manifest + nextcloud-vue** is de juiste keuze wanneer:
+- De app voornamelijk een verzameling register-backed CRUD-oppervlakken is met een paar maatwerkflows erbovenop, wat de overgrote meerderheid van Conduction-apps beschrijft.
+- Je de app op de upgrade-trein wilt houden: lib-bumps, schema-verbeteringen, toegankelijkheidsverbeteringen stromen binnen zonder per-app-werk.
+- Je vers begint. De totale tijd tot een werkende app op Pad 3 is *minder* dan op Pad 2 zodra je het één keer hebt gedaan, ook al is het eerste uur steiler.
+- Je de navigatie wilt kunnen herontwerpen, een lijst voor een dashboard wilt wisselen, of een wiki-sectie wilt toevoegen door JSON te bewerken in plaats van Vue te herschrijven.
+
+De DeskDesk-tutorialserie leert **Pad 3**. Deel 1 legt het chassis. Deel 2 introduceert het manifest. Deel 3 laat zien hoe één schema-annotatie boekingen in Nextcloud Calendar laat verschijnen zonder lijmcode. Deel 4 voegt een kennis-sidebar toe gevoed vanuit xWiki en levert de app op.
+
+## Wat OpenRegister je hoe dan ook geeft, ongeacht het pad
+
+Dit onderdeel verrast mensen. OpenRegister is niet zomaar "een register met CRUD-endpoints", het is een dataplatform dat een aantal Nextcloud-native superkrachten meelevert op het moment dat je er een schema in stopt. Of je nu op Pad 2 of Pad 3 bouwt, je erft dit allemaal zonder het te schrijven:
+
+<HexCard title="RBAC per schema + property">
+  Schema's declareren per-property lees-/schrijfrechten, group-restricties en eigenaarsregels. De OpenRegister-API handhaaft ze; <code>CnIndexPage</code> en <code>CnDetailPage</code> respecteren ze; <code>CnFormDialog</code> verbergt velden die de huidige gebruiker niet mag schrijven. Voeg een property toe aan een schema, markeer hem <code>readOnly: true</code> voor de <code>users</code>-group, en elk oppervlak in elke app respecteert die regel.
+</HexCard>
+
+<HexCard title="Audit log voor elke wijziging">
+  Elke create, update en delete schrijft een audit-entry. Het audit-spoor is zichtbaar in het standaard <code>CnObjectSidebar</code>-tabblad op elke detailpagina. Het audit-spoor opvragen is een normale OR API-call, je manifest kan audit-views samenstellen zonder logging-code te schrijven.
+</HexCard>
+
+<HexCard title="GraphQL-endpoint, automatisch">
+  Elk register exposeert een GraphQL-schema gegenereerd uit het JSON Schema. Cross-app queries (<em>"geef me elke booking waar het bureau op verdieping 2 staat en de boeker in de engineering-group zit"</em>) zijn één query, geen controller. Het endpoint wordt op register-niveau geactiveerd.
+</HexCard>
+
+<HexCard title="Cross-app referenties (schema-relaties)">
+  Een booking-schema kan een desk-schema in het register van een andere app refereren. De referentie is een getypeerde UUID-relatie die OR bij het lezen resolved. <code>CnDetailGrid</code> rendert de titel van het gerelateerde object als een link naar de detailpagina van de andere app. Geen HTTP-roundtrip in jouw code.
+</HexCard>
+
+<HexCard title="Bestanden gekoppeld aan objecten">
+  Elk register-backed object kan bestanden gekoppeld hebben, opgeslagen in de Nextcloud Files van de gebruiker. Het ingebouwde Files-tabblad van <code>CnObjectSidebar</code> handelt upload, preview en download af. Je schema declareert de attachment-property; je schrijft nul file-handling-code.
+</HexCard>
+
+<HexCard title="Calendar / Contacts / Talk integraties">
+  Annoteer een schema-property met <code>format: "calendar"</code> en boekingen verschijnen in de Nextcloud Calendar van de gebruiker. Tag een person-referentie met <code>format: "contact"</code> en de gelinkte vCard wordt een click-through. De pluggable integration registry (ADR-019) laat je Talk-threads, ondertekende documenten of elk ander Nextcloud-oppervlak aan een register toevoegen zonder de apps die het register consumeren aan te raken.
+</HexCard>
+
+<HexCard title="Multi-tenant defaults">
+  OR's register-lifecycle handelt tenant-isolatie af op register-niveau. Zichtbaarheid van objecten, user scoping en group-based read filters zijn configuratie, geen code. Apps erven het tenant-model van hun register.
+</HexCard>
+
+Pad 2 en Pad 3 bouwen beide op dit fundament. Pad 1 niet, elk van de bullets hierboven is een apart engineering-project als je vanaf rauw Nextcloud begint.
+
+## Twee oppervlakken, één leerlijn
+
+Een veelvoorkomende verwarring bij het lezen van de rest van deze serie: **het manifest is niet hetzelfde als de componentenbibliotheek**, ook al leren we ze samen.
+
+- Het **manifest** is `src/manifest.json`. Het is een JSON-document gevalideerd door een schema (`https://raw.githubusercontent.com/ConductionNL/nextcloud-vue/main/src/schemas/app-manifest-v2.schema.json`, op dit moment versie 2.7.0). Het beschrijft navigatie-entries, routes, en wat elke pagina rendert. Het heeft op zichzelf geen runtime-gedrag.
+- De **componentenbibliotheek** is `@conduction/nextcloud-vue`. Het is een set Vue 2-componenten met de prefix `Cn*`, `CnAppRoot` mount de app-shell, `CnPageRenderer` leest het manifest en dispatcht de juiste paginacomponent, `CnIndexPage`/`CnDetailPage`/`CnDashboardPage` renderen de daadwerkelijke pagina-oppervlakken.
+
+Je kunt de bibliotheek gebruiken zonder het manifest. Pad 2 in de tabel hierboven doet precies dat, een handgemaakte `App.vue` mount `Cn*`-componenten direct in een handgeschreven router. Je schrijft meer Vue, maar je houdt het schema-gedreven listing/detail/form-gedrag en je houdt alle OpenRegister-perks.
+
+Je kunt het manifest niet gebruiken zonder de bibliotheek. Het manifest is betekenisloos totdat iets het leest, `CnPageRenderer` is dat iets. Dus het manifest-pad is altijd een *manifest + bibliotheek*-leerlijn.
+
+De implicatie voor hoe je deze serie leest:
+
+| Les | Manifest-oppervlak | Bibliotheek-oppervlak |
+|---|---|---|
+| **Deel 1: Scaffold** | nog geen | `CnAppRoot`-chassis |
+| **Deel 2: Schema's + manifest** | introduceer `manifest.json`, page types, `config`-props | `CnPageRenderer`-dispatch, `CnIndexPage` + `CnDetailPage` props |
+| **Deel 3: Schema-gedreven integraties** | onveranderd | calendar-provider-annotatie stroomt door `CnDetailGrid` |
+| **Deel 4: Knowledge-tab + ship** | sidebar-tabs in `config.sidebar`, `type: 'custom'` voor de wiki-view | host-app SFC geregistreerd als custom component, `CnObjectSidebar` consumeert manifest-tabs |
+
+Als je maar één ding onthoudt over de relatie: **het manifest beantwoordt "wat moet deze app renderen"; de bibliotheek beantwoordt "hoe wordt dat gerenderd". De bibliotheek maakt het manifest levend.**
+
+## Een notitie over één keer kiezen versus later kiezen
+
+Je hoeft niet voor altijd een pad te kiezen. Apps bewegen routinematig tussen Pad 2 en Pad 3, een aantal Conduction-apps begon op Pad 2 en verhuisde naar Pad 3 zodra het team het manifest leerde. De migratie is meestal 1 tot 2 dagen voor een app met 5 tot 10 schema's, omdat de schema's helemaal niet veranderen; alleen `App.vue` + de router worden vervangen door `CnAppRoot` + een manifest.
+
+Van Pad 1 naar Pad 2 of Pad 3 gaan is moeilijker omdat je de datalaag naar een register moet migreren. Plan dat als een echt project, niet als een refactor tussen sprints door.
+
+## Waar nu naartoe
+
+<NextSteps>
+  <NextStep
+    title="Deel 1: Scaffold de app"
+    href="/nl/academy/deskdesk-tutorial-1-scaffold"
+    description="Kloon de Conduction-app-template, hernoem hem naar DeskDesk, bouw, activeer, zie het canonieke chassis. Nog geen data, alleen het skelet."
+  />
+  <NextStep
+    title="Deel 2: Schema's + manifest"
+    href="/nl/academy/deskdesk-tutorial-2-schemas-manifest"
+    description="Drie JSON-bestanden worden een CRUD-app. Waar Pad 3 de steilere initiële curve begint terug te betalen."
+  />
+  <NextStep
+    title="OpenRegister-documentatie"
+    href="https://openregister.conduction.nl"
+    description="Het dataplatform dat Pad 2 en Pad 3 aandrijft. Lees de RBAC-, audit- en GraphQL-secties om te zien waarom die bullets echt zijn."
+  />
+  <NextStep
+    title="App-manifest-referentie"
+    href="https://nextcloud-vue.conduction.nl/docs/architecture/manifest/"
+    description="Volledige manifest-spec, page types, slots, sidebar-config, route-param-sentinels, en de getypeerde vormen geïntroduceerd in schema 2.7.0."
+  />
+</NextSteps>

--- a/i18n/nl/docusaurus-plugin-content-blog/2026-05-07-nextcloud-lokaal-draaien/index.mdx
+++ b/i18n/nl/docusaurus-plugin-content-blog/2026-05-07-nextcloud-lokaal-draaien/index.mdx
@@ -22,7 +22,7 @@ Voor elke andere tutorial in deze academy heb je een werkende Nextcloud nodig. D
   <Outcome>Met één commando de hele stack weer opruimen.</Outcome>
 </Outcomes>
 
-Daarna kun je verder met [Een Woo-register opzetten](/academy/woo-register-opzetten), [Bestanden uploaden bij een Woo-publicatie](/academy/woo-bestanden-uploaden), of een eigen experiment.
+Daarna kun je verder met [Een Woo-register opzetten](/nl/academy/woo-register-opzetten), [Bestanden uploaden bij een Woo-publicatie](/nl/academy/woo-bestanden-uploaden), of een eigen experiment.
 
 <Prerequisites title="Wat je nodig hebt">
   <PrerequisiteItem>Een laptop met minimaal 4 GB vrij geheugen.</PrerequisiteItem>
@@ -217,9 +217,9 @@ Na `down -v` is je laptop weer schoon. Twee minuten later kun je opnieuw beginne
 
 Een werkende Nextcloud is de aanleiding voor de andere tutorials in deze serie:
 
-- [Een Woo-register opzetten](/academy/woo-register-opzetten) — importeer het canonieke Woo-register in OpenRegister
-- [Bestanden uploaden bij een Woo-publicatie](/academy/woo-bestanden-uploaden) — vier upload-modes voor documenten
-- [Build je eerste Conduction-app](/academy/build-an-app) — eindigt met een geïnstalleerde app op deze stack
+- [Een Woo-register opzetten](/nl/academy/woo-register-opzetten) — importeer het canonieke Woo-register in OpenRegister
+- [Bestanden uploaden bij een Woo-publicatie](/nl/academy/woo-bestanden-uploaden) — vier upload-modes voor documenten
+- [Build je eerste Conduction-app](/nl/academy/build-an-app) — eindigt met een geïnstalleerde app op deze stack
 
 Stuur het `docker-compose.yml` naar een collega als je dit samen wilt zien werken.
 

--- a/i18n/nl/docusaurus-plugin-content-blog/2026-05-07-nextcloud-lokaal-draaien/index.mdx
+++ b/i18n/nl/docusaurus-plugin-content-blog/2026-05-07-nextcloud-lokaal-draaien/index.mdx
@@ -56,7 +56,11 @@ Daarna kun je verder met [Een Woo-register opzetten](/nl/academy/woo-register-op
   <PrerequisiteItem>Een teksteditor: Kladblok (Windows), TextEdit (Mac) of nano (Linux) is genoeg.</PrerequisiteItem>
 </Prerequisites>
 
-> **Dit is een lokale ontwikkelomgeving.** Er draait dezelfde software als een echte Nextcloud-installatie en het gedraagt zich op dezelfde manier, dus alles wat je hier leert is direct toepasbaar op een productieomgeving. Data die je hier opslaat wordt echter niet bewaard, wordt niet gedeeld met anderen en kan op elk moment worden gewist — zo verwijdert `docker compose down -v` alles permanent. Gebruik deze omgeving om te verkennen, te experimenteren en te leren. Sla geen echte, gevoelige of productiedata op in deze omgeving.
+:::info Dit is een lokale ontwikkelomgeving
+
+Er draait dezelfde software als een echte Nextcloud-installatie en het gedraagt zich op dezelfde manier, dus alles wat je hier leert is direct toepasbaar op een productieomgeving. Data die je hier opslaat wordt echter niet bewaard, wordt niet gedeeld met anderen en kan op elk moment worden gewist — zo verwijdert `docker compose down -v` alles permanent. Gebruik deze omgeving om te verkennen, te experimenteren en te leren. Sla geen echte, gevoelige of productiedata op in deze omgeving.
+
+:::
 
 Geen eerdere ervaring nodig. Op een schone laptop is stap 0 (Docker installeren en de terminal leren kennen) ongeveer tien minuten. Stap 1 t/m 5 samen daarna een halfuur.
 
@@ -288,7 +292,11 @@ Nextcloud waarschuwt je dat het wachtwoord te zwak is — dat klopt, maar deze i
 
 Gebruik je ooit een Nextcloud die anderen kunnen bereiken — via internet of binnen een netwerk — kies dan altijd een sterk, uniek wachtwoord. Een goede vuistregel: minimaal 12 tekens, met hoofdletters, cijfers en een speciaal teken.
 
-> **Let op:** onder het wachtwoordveld zie je een ingeklapt onderdeel **Storage & database**. Je hoeft dit niet open te klikken — de databaseconfiguratie is al geregeld via het `docker-compose.yml`-bestand.
+:::note
+
+Onder het wachtwoordveld zie je een ingeklapt onderdeel **Storage & database**. Je hoeft dit niet open te klikken — de databaseconfiguratie is al geregeld via het `docker-compose.yml`-bestand.
+
+:::
 
 1. Vul `admin` in als **gebruikersnaam** en `admin` als **wachtwoord**. **Druk nog niet op Enter terwijl je de velden invult** — wacht tot beide velden zijn ingevuld voordat je verdergaat.
 2. Klik op **Install** of druk op Enter nadat je het wachtwoord hebt ingevuld. Het scherm verdwijnt direct en Nextcloud begint met installeren.
@@ -307,7 +315,11 @@ Open eerst de Nextcloud app store:
 
 Installeer de Conduction-apps nu één voor één. Begin met **Open Register** — OpenCatalogi en Open Connector zijn daar allebei van afhankelijk.
 
-> **Let op:** als je op **Download en activeren** klikt, kan Nextcloud vragen om je wachtwoord te bevestigen voordat de installatie wordt toegestaan. Vul `admin` in en bevestig.
+:::note
+
+Als je op **Download en activeren** klikt, kan Nextcloud vragen om je wachtwoord te bevestigen voordat de installatie wordt toegestaan. Vul `admin` in en bevestig.
+
+:::
 
 ---
 
@@ -442,7 +454,11 @@ docker compose start
 docker compose down -v
 ```
 
-> ⚠️ **Dit verwijdert alles.** Al je Nextcloud-data, elke geïnstalleerde app, elke instelling en elk bestand dat je hebt geüpload verdwijnt permanent. Er is geen hersteloptie. Voer dit alleen uit als je zeker weet dat je helemaal opnieuw wilt beginnen.
+:::danger Dit verwijdert alles
+
+Al je Nextcloud-data, elke geïnstalleerde app, elke instelling en elk bestand dat je hebt geüpload verdwijnt permanent. Er is geen hersteloptie. Voer dit alleen uit als je zeker weet dat je helemaal opnieuw wilt beginnen.
+
+:::
 
 Na `docker compose down -v` is je laptop weer in de oorspronkelijke staat. Wil je opnieuw beginnen, voer dan `docker compose up -d` uit vanuit de map `conduction-demo` en doorloop de volledige setup opnieuw vanaf stap 3.
 
@@ -460,7 +476,11 @@ Docker Desktop is waarschijnlijk niet actief. Open Docker Desktop en wacht tot h
 
 Virtualisatie is waarschijnlijk uitgeschakeld in de BIOS van je pc. De BIOS is een instellingenscherm dat onder Windows zit en je hardware beheert — het ziet er anders uit dan alles wat je normaal gesproken ziet. Op de meeste moderne laptops (2018+) staat virtualisatie standaard al aan, dus deze fout komt weinig voor.
 
-> **Niet comfortable met BIOS-wijzigingen?** Dat is heel begrijpelijk — vraag iemand met IT-kennis om je te helpen met de onderstaande stappen.
+:::tip Niet comfortabel met BIOS-wijzigingen?
+
+Dat is heel begrijpelijk — vraag iemand met IT-kennis om je te helpen met de onderstaande stappen.
+
+:::
 
 **Stap 1 — toegang tot de BIOS.** De makkelijkste manier op Windows 10 en 11:
 1. Klik op **Start** → **Instellingen** (het tandwiel-icoon) → **Systeem** → **Herstel**.
@@ -489,7 +509,11 @@ Weet je het niet? Kijk goed naar het scherm direct na het opstarten — er staat
 
 **Stap 3 — opslaan en afsluiten.** Druk op **F10** om op te slaan en te sluiten, of zoek een tabblad **Save & Exit** en druk op **Enter** bij **Save Changes and Exit**. Bevestig met **Yes** als daarom gevraagd wordt.
 
-> **Belangrijk:** wijzig alleen de virtualisatie-instelling. Raak niets anders aan.
+:::warning Belangrijk
+
+Wijzig alleen de virtualisatie-instelling. Raak niets anders aan.
+
+:::
 
 Je computer herstart. Open Docker Desktop en het zou nu normaal moeten starten.
 

--- a/i18n/nl/docusaurus-plugin-content-blog/2026-05-07-nextcloud-lokaal-draaien/index.mdx
+++ b/i18n/nl/docusaurus-plugin-content-blog/2026-05-07-nextcloud-lokaal-draaien/index.mdx
@@ -56,11 +56,7 @@ Daarna kun je verder met [Een Woo-register opzetten](/nl/academy/woo-register-op
   <PrerequisiteItem>Een teksteditor: Kladblok (Windows), TextEdit (Mac) of nano (Linux) is genoeg.</PrerequisiteItem>
 </Prerequisites>
 
-:::info Dit is een lokale ontwikkelomgeving
-
-Er draait dezelfde software als een echte Nextcloud-installatie en het gedraagt zich op dezelfde manier, dus alles wat je hier leert is direct toepasbaar op een productieomgeving. Data die je hier opslaat wordt echter niet bewaard, wordt niet gedeeld met anderen en kan op elk moment worden gewist — zo verwijdert `docker compose down -v` alles permanent. Gebruik deze omgeving om te verkennen, te experimenteren en te leren. Sla geen echte, gevoelige of productiedata op in deze omgeving.
-
-:::
+> **Dit is een lokale ontwikkelomgeving.** Er draait dezelfde software als een echte Nextcloud-installatie en het gedraagt zich op dezelfde manier, dus alles wat je hier leert is direct toepasbaar op een productieomgeving. Data die je hier opslaat wordt echter niet bewaard, wordt niet gedeeld met anderen en kan op elk moment worden gewist — zo verwijdert `docker compose down -v` alles permanent. Gebruik deze omgeving om te verkennen, te experimenteren en te leren. Sla geen echte, gevoelige of productiedata op in deze omgeving.
 
 Geen eerdere ervaring nodig. Op een schone laptop is stap 0 (Docker installeren en de terminal leren kennen) ongeveer tien minuten. Stap 1 t/m 5 samen daarna een halfuur.
 
@@ -292,11 +288,7 @@ Nextcloud waarschuwt je dat het wachtwoord te zwak is — dat klopt, maar deze i
 
 Gebruik je ooit een Nextcloud die anderen kunnen bereiken — via internet of binnen een netwerk — kies dan altijd een sterk, uniek wachtwoord. Een goede vuistregel: minimaal 12 tekens, met hoofdletters, cijfers en een speciaal teken.
 
-:::note
-
-Onder het wachtwoordveld zie je een ingeklapt onderdeel **Storage & database**. Je hoeft dit niet open te klikken — de databaseconfiguratie is al geregeld via het `docker-compose.yml`-bestand.
-
-:::
+> **Let op:** onder het wachtwoordveld zie je een ingeklapt onderdeel **Storage & database**. Je hoeft dit niet open te klikken — de databaseconfiguratie is al geregeld via het `docker-compose.yml`-bestand.
 
 1. Vul `admin` in als **gebruikersnaam** en `admin` als **wachtwoord**. **Druk nog niet op Enter terwijl je de velden invult** — wacht tot beide velden zijn ingevuld voordat je verdergaat.
 2. Klik op **Install** of druk op Enter nadat je het wachtwoord hebt ingevuld. Het scherm verdwijnt direct en Nextcloud begint met installeren.
@@ -315,11 +307,7 @@ Open eerst de Nextcloud app store:
 
 Installeer de Conduction-apps nu één voor één. Begin met **Open Register** — OpenCatalogi en Open Connector zijn daar allebei van afhankelijk.
 
-:::note
-
-Als je op **Download en activeren** klikt, kan Nextcloud vragen om je wachtwoord te bevestigen voordat de installatie wordt toegestaan. Vul `admin` in en bevestig.
-
-:::
+> **Let op:** als je op **Download en activeren** klikt, kan Nextcloud vragen om je wachtwoord te bevestigen voordat de installatie wordt toegestaan. Vul `admin` in en bevestig.
 
 ---
 
@@ -454,11 +442,7 @@ docker compose start
 docker compose down -v
 ```
 
-:::danger Dit verwijdert alles
-
-Al je Nextcloud-data, elke geïnstalleerde app, elke instelling en elk bestand dat je hebt geüpload verdwijnt permanent. Er is geen hersteloptie. Voer dit alleen uit als je zeker weet dat je helemaal opnieuw wilt beginnen.
-
-:::
+> ⚠️ **Dit verwijdert alles.** Al je Nextcloud-data, elke geïnstalleerde app, elke instelling en elk bestand dat je hebt geüpload verdwijnt permanent. Er is geen hersteloptie. Voer dit alleen uit als je zeker weet dat je helemaal opnieuw wilt beginnen.
 
 Na `docker compose down -v` is je laptop weer in de oorspronkelijke staat. Wil je opnieuw beginnen, voer dan `docker compose up -d` uit vanuit de map `conduction-demo` en doorloop de volledige setup opnieuw vanaf stap 3.
 
@@ -476,11 +460,7 @@ Docker Desktop is waarschijnlijk niet actief. Open Docker Desktop en wacht tot h
 
 Virtualisatie is waarschijnlijk uitgeschakeld in de BIOS van je pc. De BIOS is een instellingenscherm dat onder Windows zit en je hardware beheert — het ziet er anders uit dan alles wat je normaal gesproken ziet. Op de meeste moderne laptops (2018+) staat virtualisatie standaard al aan, dus deze fout komt weinig voor.
 
-:::tip Niet comfortabel met BIOS-wijzigingen?
-
-Dat is heel begrijpelijk — vraag iemand met IT-kennis om je te helpen met de onderstaande stappen.
-
-:::
+> **Niet comfortable met BIOS-wijzigingen?** Dat is heel begrijpelijk — vraag iemand met IT-kennis om je te helpen met de onderstaande stappen.
 
 **Stap 1 — toegang tot de BIOS.** De makkelijkste manier op Windows 10 en 11:
 1. Klik op **Start** → **Instellingen** (het tandwiel-icoon) → **Systeem** → **Herstel**.
@@ -509,11 +489,7 @@ Weet je het niet? Kijk goed naar het scherm direct na het opstarten — er staat
 
 **Stap 3 — opslaan en afsluiten.** Druk op **F10** om op te slaan en te sluiten, of zoek een tabblad **Save & Exit** en druk op **Enter** bij **Save Changes and Exit**. Bevestig met **Yes** als daarom gevraagd wordt.
 
-:::warning Belangrijk
-
-Wijzig alleen de virtualisatie-instelling. Raak niets anders aan.
-
-:::
+> **Belangrijk:** wijzig alleen de virtualisatie-instelling. Raak niets anders aan.
 
 Je computer herstart. Open Docker Desktop en het zou nu normaal moeten starten.
 

--- a/i18n/nl/docusaurus-plugin-content-blog/2026-05-07-woo-bestanden-uploaden/index.mdx
+++ b/i18n/nl/docusaurus-plugin-content-blog/2026-05-07-woo-bestanden-uploaden/index.mdx
@@ -26,7 +26,7 @@ Een Woo-publicatie zonder bestanden is metadata zonder bewijs. In deze tutorial 
 
 <Prerequisites title="Wat je nodig hebt">
   <PrerequisiteItem>
-    Een werkend Woo-register. Volg eerst <a href="/academy/woo-register-opzetten">Een Woo-register opzetten</a> als je dat nog niet hebt.
+    Een werkend Woo-register. Volg eerst <a href="/nl/academy/woo-register-opzetten">Een Woo-register opzetten</a> als je dat nog niet hebt.
   </PrerequisiteItem>
   <PrerequisiteItem>Een publicatie-object met bekende UUID.</PrerequisiteItem>
   <PrerequisiteItem><code>curl</code>, basisauth, en een paar testbestanden.</PrerequisiteItem>

--- a/i18n/nl/docusaurus-plugin-content-blog/2026-05-07-woo-register-opzetten/index.mdx
+++ b/i18n/nl/docusaurus-plugin-content-blog/2026-05-07-woo-register-opzetten/index.mdx
@@ -24,10 +24,10 @@ De [Wet open overheid (Woo)](https://www.rijksoverheid.nl/onderwerpen/wet-open-o
   <Outcome>Een werkend startpunt opzetten om publicaties aan te maken en bestanden te koppelen.</Outcome>
 </Outcomes>
 
-De <a href="/academy/woo-bestanden-uploaden">vervolgtutorial over bestanden uploaden</a> bouwt hierop voort.
+De <a href="/nl/academy/woo-bestanden-uploaden">vervolgtutorial over bestanden uploaden</a> bouwt hierop voort.
 
 <Prerequisites title="Wat je nodig hebt">
-  <PrerequisiteItem>Een draaiende Nextcloud met OpenRegister geïnstalleerd. Heb je dat nog niet, volg dan eerst <a href="/academy/nextcloud-lokaal-draaien">Nextcloud lokaal draaien met Docker</a>.</PrerequisiteItem>
+  <PrerequisiteItem>Een draaiende Nextcloud met OpenRegister geïnstalleerd. Heb je dat nog niet, volg dan eerst <a href="/nl/academy/nextcloud-lokaal-draaien">Nextcloud lokaal draaien met Docker</a>.</PrerequisiteItem>
   <PrerequisiteItem>Een gebruiker met admin-rechten, of een gebruiker die registers mag aanmaken.</PrerequisiteItem>
   <PrerequisiteItem><code>curl</code> of een vergelijkbare HTTP-client.</PrerequisiteItem>
 </Prerequisites>
@@ -206,7 +206,7 @@ Je hebt:
 - Eén testpublicatie met UUID
 - Een patroon om eigen velden toe te voegen waar nodig
 
-In de [vervolgtutorial koppel je bestanden aan deze publicatie](/academy/woo-bestanden-uploaden), van enkele PDF's tot grote videobestanden in chunks.
+In de [vervolgtutorial koppel je bestanden aan deze publicatie](/nl/academy/woo-bestanden-uploaden), van enkele PDF's tot grote videobestanden in chunks.
 
 ## Opruimen
 

--- a/i18n/nl/docusaurus-plugin-content-blog/2026-05-10-deskdesk-tutorial-1-scaffold/index.mdx
+++ b/i18n/nl/docusaurus-plugin-content-blog/2026-05-10-deskdesk-tutorial-1-scaffold/index.mdx
@@ -53,7 +53,7 @@ Dezelfde vorm, twee repos:
 - **Tutorial-broncode:** [`ConductionNL/conduction-website`](https://github.com/ConductionNL/conduction-website), de post die je nu leest.
 
 <Prerequisites title="Wat je nodig hebt">
-  <PrerequisiteItem>Een draaiende Nextcloud (28+) met admin-toegang. Heb je er nog geen, volg dan eerst <a href="/academy/nextcloud-lokaal-draaien">Nextcloud lokaal draaien met Docker</a>.</PrerequisiteItem>
+  <PrerequisiteItem>Een draaiende Nextcloud (28+) met admin-toegang. Heb je er nog geen, volg dan eerst <a href="/nl/academy/nextcloud-lokaal-draaien">Nextcloud lokaal draaien met Docker</a>.</PrerequisiteItem>
   <PrerequisiteItem><strong>OpenRegister</strong> geïnstalleerd en actief in die Nextcloud (Apps → zoek "OpenRegister" → Download).</PrerequisiteItem>
   <PrerequisiteItem>Node.js 20+ en PHP 8.1+ op je host, plus Composer en de GitHub CLI (<code>gh</code>). De template komt met PHPCS, Psalm, PHPStan en ESLint-configs klaar voor gebruik.</PrerequisiteItem>
   <PrerequisiteItem>Een GitHub-account zodat je de template kunt forken naar je eigen organisatie (of <code>ConductionNL</code> als je toegang hebt).</PrerequisiteItem>
@@ -202,7 +202,7 @@ In Deel 2 leer je hoe `manifest.json` plus een JSON-schema deze atomen vult met 
 <NextSteps>
   <NextStep
     title="Deel 2: Schema's + manifest"
-    href="/academy/deskdesk-tutorial-2-schemas-manifest"
+    href="/nl/academy/deskdesk-tutorial-2-schemas-manifest"
     description="Definieer de desk-, booking- en floor-schema's in OpenRegister. Bedraad ze in een manifest.json die CnAppRoot leest. Zie CnIndexPage / CnDetailPage / CnDashboardPage volledige CRUD renderen zonder lijmcode."
   />
   <NextStep

--- a/i18n/nl/docusaurus-plugin-content-blog/2026-05-12-hydra-tutorial-1-wat-is-hydra/index.mdx
+++ b/i18n/nl/docusaurus-plugin-content-blog/2026-05-12-hydra-tutorial-1-wat-is-hydra/index.mdx
@@ -1,0 +1,224 @@
+---
+slug: hydra-tutorial-1-wat-is-hydra
+title: "Hydra leerlijn — Deel 1: Wat is Hydra?"
+contentType: tutorial
+authors: [conduction]
+date: 2026-05-12
+summary: Een korte introductie op Hydra, Conductions agentic CI/CD-platform. Wat doet het, waarom bestaat het, en welke plek het heeft binnen onze app-fabriek. Eerste van zes korte modules.
+tags: [Hydra, AI, CI/CD, Tutorial series]
+apps: []
+durationMinutes: 10
+series: hydra-tutorial
+partNumber: 1
+---
+
+import {Outcomes, Outcome, Prerequisites, PrerequisiteItem, NextSteps, NextStep, HexCard, ContactCta} from '@conduction/docusaurus-preset/components';
+import Details from '@theme/Details';
+
+:::tip Aanbevolen vooraf — de OpenSpec-leerlijn
+Hydra werkt op OpenSpec-changes. Ben je nog niet bekend met begrippen als **spec**, **change**, **requirement** en **scenario**? Doe dan eerst de [OpenSpec-leerlijn](/nl/academy/openspec-tutorial-1-wat-is-openspec) (deel 1 + 2, samen ~30 minuten). Dat scheelt veel terugzoeken in de rest van deze modules.
+:::
+
+:::tip Ook nuttig vooraf — de Claude Skills-leerlijn
+Een groot deel van Hydra's interne werking leunt op **Claude Skills**: `opsx-*`, `hydra-gate-*`, `team-*`, `test-*`. Als je nog nooit een skill geschreven of bekeken hebt, doe dan eerst [deel 1 van de Claude Skills-leerlijn](/nl/academy/claude-skills-tutorial-1-wat-zijn-claude-skills) (10 minuten). Dat maakt deel 4 van deze leerlijn — waar we de skill-families in Hydra opensnijden — veel makkelijker te volgen.
+:::
+
+Hydra is Conductions interne **agentic CI/CD-platform**: een fabriek die OpenSpec-voorstellen omzet in gereviewde, geteste code op een feature branch. Deze module legt in tien minuten uit wát Hydra is, waaróm het bestaat, en hoe het past binnen onze app-fabriek. Het is het eerste deel van een leerlijn van zes; aan het eind sta je klaar voor deel 2 over de drie pipelines.
+
+{/* truncate */}
+
+<Outcomes title="Wat je leert in dit deel">
+  <Outcome>Wat Hydra is in één zin, en waarom we het hebben gebouwd.</Outcome>
+  <Outcome>De vier container-personas in grote lijnen: Al Gorithm, Juan Claude, Clyde, Axel.</Outcome>
+  <Outcome>Wanneer je Hydra wél inzet, en wanneer juist niet.</Outcome>
+</Outcomes>
+
+<Prerequisites title="Wat je nodig hebt">
+  <PrerequisiteItem>Basiskennis Git, GitHub issues + PRs, en een idee van wat een Nextcloud-app is.</PrerequisiteItem>
+  <PrerequisiteItem>Bekendheid met Claude Code-CLI op hoofdlijnen (we duiken hier niet in commando's; daarvoor zie deel 4).</PrerequisiteItem>
+  <PrerequisiteItem>Optioneel — de publieke 1-pagina-versie op <a href="https://github.com/ConductionNL/.github/blob/main/docs/hydra/README.md">.github/docs/hydra/README.md</a>. Goede warming-up als je nooit eerder van Hydra hebt gehoord.</PrerequisiteItem>
+  <PrerequisiteItem>Alleen nodig als je Hydra zelf wilt draaien (i.p.v. de leerlijn lezen): toegang tot de private <a href="https://github.com/ConductionNL/hydra">ConductionNL/hydra</a>-repo. Vraag dit aan bij je teamlead.</PrerequisiteItem>
+</Prerequisites>
+
+## In één zin
+
+Hydra is een **stateless, label-gedreven pipeline** die OpenSpec-voorstellen verandert in feature branches met code, tests, een review-history en een PR — klaar voor menselijke goedkeuring.
+
+Geen "AI assistent die de developer helpt", maar een **fabriek**. Je gooit er een OpenSpec-change in en aan de andere kant rolt er een PR uit waar twee onafhankelijke reviewers naar gekeken hebben.
+
+Concreet: Hydra werkt op het `openspec/changes/<slug>/` mapje — `proposal.md`, `design.md`, `tasks.md` en de spec-delta. Als die termen nieuw zijn, doe eerst de OpenSpec-leerlijn (zie tip bovenaan).
+
+## Waarom bestaat Hydra?
+
+Conduction bouwt veel open-source apps voor de Nextcloud-werkplek. Het ritme van die fabriek wordt bepaald door twee dingen: hoe snel we **changes** kunnen schrijven, en hoe snel die changes **code** worden. Hydra automatiseert die tweede stap, met drie expliciete doelen:
+
+1. **Doorlooptijd verkorten.** Een gemiddeld OpenSpec-voorstel wordt zonder Hydra in een halve dag tot drie dagen geïmplementeerd. Met Hydra is dat een halfuur tot een paar uur, afhankelijk van complexiteit.
+2. **Kwaliteit borgen.** Geen enkele PR komt het systeem uit zonder mechanische quality gates (PHPCS, Psalm, PHPStan, ESLint, PHPUnit), een onafhankelijke code review en een onafhankelijke security review. Twee paar AI-ogen vóór er een mens kijkt.
+3. **4-eyes principle behouden.** Hydra **merge-t niet zelf** — behalve wanneer een issue expliciet de `yolo`-vlag heeft, en zelfs dan moeten alle gates groen zijn. Een mens drukt op de knop.
+
+## De vier personas
+
+Hydra is intern opgebouwd uit vier ephemere container-personas. Elk speelt één rol, in één container, met scoped credentials en strakke turn-budgets. Je hoeft hun namen nu niet uit het hoofd te kennen — ze komen terug in deel 2 — maar het helpt om vroeg het rollenpatroon te zien:
+
+<HexCard title="Al Gorithm (builder, Haiku)">
+  Bouwt code uit de change. Ziet nooit reviews terug. Stopt na een vast turn-budget.
+</HexCard>
+
+<HexCard title="Juan Claude van Damme (code reviewer, Sonnet)">
+  Leest alleen de PR-diff. Kan zelf mechanische fixes doorvoeren binnen scope.
+</HexCard>
+
+<HexCard title="Clyde Barcode (security reviewer, Sonnet)">
+  Loopt na Juan Claude. Zelfde shape, plus Semgrep en patroon-matching op CWE-klassen.
+</HexCard>
+
+<HexCard title="Axel Pliér (applier, Sonnet — géén schrijfrechten)">
+  Beslist binair: gaat dit door of niet? Leest beide reviews en de uiteindelijke code. Géén fix-tools.
+</HexCard>
+
+Belangrijk: **Al Gorithm draait op Haiku, de andere drie op Sonnet** (met Opus als fallback). Reden: bouwen volgt patronen en is goedkoop te doen met Haiku; oordelen vraagt meer diepgang. Op Claude Max heb je een aparte Sonnet-only en all-models quota, dus deze splitsing rekt het budget op.
+
+## Wanneer wel, wanneer niet
+
+Hydra is geen wondermiddel. De vuistregel:
+
+**Wel inzetten als:**
+
+- Het werk past binnen één coherente OpenSpec-change (één feature, niet een refactor van het hele systeem).
+- De acceptatiecriteria mechanisch te toetsen zijn (er bestaan tests of die zijn met PHPUnit/Newman/Playwright snel te schrijven).
+- De doel-repo is **gereed** voor Hydra: heeft `hydra-gate-*` labels, een `app-config.json`, en draait de standaard quality-suite.
+
+**Niet inzetten als:**
+
+- Het gaat om een eenmalige spike, prototype, of "even iets uitproberen" zonder reviewer-discipline.
+- De architectuur wijzigt op een manier die niet in één PR past (multi-repo refactor, breaking schema-change met datamigratie).
+- Je geen vertrouwen hebt in de gates op de doel-repo — Hydra is alleen zo veilig als zijn quality checks.
+- Het werk vereist menselijke onderhandeling met een externe partij (klant, leverancier) voordat het kan beginnen.
+
+## Wat Hydra **niet** doet
+
+Een veelgemaakte vergissing: denken dat Hydra je hele product bedenkt. Het tegendeel is waar.
+
+- **Hydra schrijft geen changes (of specs).** Die worden vooraf aangeleverd, of een mens schrijft ze handmatig (met `/opsx-ff`).
+- **Hydra doet niet aan visie of strategie.** Welke features we bouwen is een mensenkeuze.
+- **Hydra besluit niet over architectuur.** Daarvoor zijn ADR's, beheerd door mensen (zie `hydra/openspec/architecture/`).
+- **Hydra merge-t niet eigenmachtig.** Behalve `yolo`-issues — en daar zijn alle gates nog steeds harde voorwaarden.
+
+## Test jezelf
+
+Vier korte vragen om te checken of je dit deel begrepen hebt. Vastgelopen? Klik **Hint**. Curieus naar het antwoord? Klik **Antwoord**.
+
+<div className="tutorial-quiz">
+
+**1. Wat is het primaire doel van Hydra?**
+
+<Details summary="Hint">
+
+Hydra doet één specifieke stap in onze fabriek. Welke stap, en welke twee voordelen levert dat op?
+
+</Details>
+
+<Details summary="Antwoord">
+
+Hydra automatiseert de stap van **OpenSpec-change naar gereviewde feature-branch + PR**. Drie expliciete doelen:
+
+1. **Doorlooptijd verkorten** — van een halve dag tot drie dagen handmatig naar een halfuur tot een paar uur.
+2. **Kwaliteit borgen** — verplichte mechanische gates (PHPCS, Psalm, PHPStan, ESLint, PHPUnit) + twee onafhankelijke AI-reviews.
+3. **4-eyes-principe behouden** — Hydra merge-t niet zelf; een mens drukt op de knop. Uitzondering: `yolo`-issues, en zelfs dan moeten alle gates groen zijn.
+
+</Details>
+
+</div>
+
+<div className="tutorial-quiz">
+
+**2. Waarom kiest Hydra voor mechanische quality gates (PHPCS, Psalm, PHPStan, ESLint, PHPUnit) in plaats van alleen AI-review?**
+
+<Details summary="Hint">
+
+AI-reviewers kunnen overtuigend klinken zonder feitelijk correct te zijn. Mechanische checks hebben één eigenschap die AI-review per definitie mist.
+
+</Details>
+
+<Details summary="Antwoord">
+
+Mechanische gates zijn **deterministisch en niet te overtuigen**. PHPStan kun je niet ompraten; ESLint trekt zich niets aan van een goed onderbouwd verhaal. Twee gevolgen:
+
+1. **Vals-positieven en hallucinaties worden gefilterd** vóórdat een reviewer ernaar kijkt — een PR die de gates niet haalt komt niet eens bij Juan Claude of Clyde langs.
+2. **Standaarden zijn afdwingbaar over de hele fleet** — codestijl, types en testresultaten zijn objectief, niet afhankelijk van wie er die dag reviewed.
+
+AI-review komt erbovenop, niet in plaats ervan. Beide lagen vangen verschillende klassen van problemen.
+
+</Details>
+
+</div>
+
+<div className="tutorial-quiz">
+
+**3. Welke vier personas heeft Hydra, en welke is degene die NIET kan schrijven?**
+
+<Details summary="Hint">
+
+Eén persona is bewust read-only — zijn rol is een binaire gate ("gaat dit door of niet?"). Hij heeft geen Write- of Edit-tools.
+
+</Details>
+
+<Details summary="Antwoord">
+
+De vier personas:
+
+- **Al Gorithm** — builder (Haiku). Schrijft code.
+- **Juan Claude van Damme** — code reviewer (Sonnet). Mag bounded fixes pushen.
+- **Clyde Barcode** — security reviewer (Sonnet). Mag ook bounded fixes pushen.
+- **Axel Pliér** — applier (Sonnet, **géén schrijfrechten**). Leest de uiteindelijke diff + beide reviews en geeft één binair antwoord: `pass: true` of `pass: false`. Hij oordeelt, hij grijpt niet in.
+
+</Details>
+
+</div>
+
+<div className="tutorial-quiz">
+
+**4. Noem twee situaties waarin je Hydra juist NIET inzet en handmatig werkt.**
+
+<Details summary="Hint">
+
+Denk aan: past het werk in één change, is de doel-repo klaar, en is er iets niet-technisch dat eerst opgelost moet worden.
+
+</Details>
+
+<Details summary="Antwoord">
+
+Een paar veelgenoemde:
+
+- **Het werk past niet in één OpenSpec-change** — multi-repo refactor, breaking schema-change met datamigratie.
+- **De doel-repo is niet gereed** — geen `hydra-gate-*` labels, geen `app-config.json`, of een onbetrouwbare quality-suite. Hydra is alleen zo veilig als zijn gates.
+- **Spike of prototype zonder reviewer-discipline** — "even iets uitproberen". De overhead weegt niet op tegen de winst.
+- **Menselijke onderhandeling vereist** — een klant, leverancier of juridisch punt moet eerst opgelost worden voor het werk kan beginnen.
+
+</Details>
+
+</div>
+
+<NextSteps title="Volgende stap" lede="Nu je weet wat Hydra is, kijken we in deel 2 binnen in de drie pipelines.">
+  <NextStep
+    title="Deel 2 — De drie pipelines"
+    href="/nl/academy/hydra-tutorial-2-drie-pipelines"
+    description="Build, code review, security review. Wie doet wat, in welke volgorde, en hoe komt een issue uiteindelijk bij needs-input of done."
+  />
+  <NextStep
+    title="Publieke Hydra-overzichtspagina"
+    href="https://github.com/ConductionNL/.github/blob/main/docs/hydra/README.md"
+    description="De openbare 1-pagina-versie in onze .github-repo. Bedoeld voor wie alleen het wat-en-hoe op hoofdlijnen hoeft te weten, zonder IP-details."
+  />
+  <NextStep
+    title="Het volledige architectuur-document (privé)"
+    href="https://github.com/ConductionNL/hydra/blob/main/openspec/project.md"
+    description="Voor wie nu al het hele plaatje wil zien — alle details, geen samenvattingen. Vereist toegang tot de privé hydra-repo."
+  />
+</NextSteps>
+
+<ContactCta
+  title="Vragen over Hydra of deze leerlijn?"
+  body="Spreek je teamlead aan of stel je vraag in #hydra op Slack. Issues op deze tutorial graag op het bijbehorende GitHub-issue."
+  cta={{ label: "Mail het Hydra-team", href: "mailto:wilco@conduction.nl?subject=Hydra%20leerlijn%20deel%201" }}
+/>

--- a/i18n/nl/docusaurus-plugin-content-blog/2026-05-12-hydra-tutorial-2-drie-pipelines/index.mdx
+++ b/i18n/nl/docusaurus-plugin-content-blog/2026-05-12-hydra-tutorial-2-drie-pipelines/index.mdx
@@ -1,0 +1,249 @@
+---
+slug: hydra-tutorial-2-drie-pipelines
+title: "Hydra leerlijn — Deel 2: De drie pipelines"
+contentType: tutorial
+authors: [conduction]
+date: 2026-05-12
+summary: Build, code-review en security-review. Wie doet wat, in welke volgorde, en hoe een label-state-machine de hele rit aan elkaar plakt. Tweede van zes korte modules.
+tags: [Hydra, Pipelines, Personas, Tutorial series]
+apps: []
+durationMinutes: 15
+series: hydra-tutorial
+partNumber: 2
+---
+
+import {Outcomes, Outcome, Prerequisites, PrerequisiteItem, NextSteps, NextStep, HexCard} from '@conduction/docusaurus-preset/components';
+import Details from '@theme/Details';
+
+In deel 1 zag je dat Hydra vier personas heeft. In dit deel kijken we naar de **pipeline**: hoe die personas na elkaar werken aan één issue, welke labels de overgangen markeren, en wanneer de pijplijn afslaat naar `needs-input`. Aan het eind weet je het label-state-machine van Hydra van buiten en kun je een issue terugleiden naar de juiste fase als hij ergens vastloopt.
+
+{/* truncate */}
+
+<Outcomes title="Wat je leert in dit deel">
+  <Outcome>De drie pipelines (build, code-review, security-review) en hoe ze sequentieel op elkaar overdragen.</Outcome>
+  <Outcome>Het complete label-state-machine: <code>build:queued → ... → done / needs-input</code>.</Outcome>
+  <Outcome>Wat de applier (Axel Pliér) doet, en waarom hij overgeslagen kan worden.</Outcome>
+  <Outcome>Het verschil tussen <code>retry:queued</code> en <code>rebuild:queued</code>.</Outcome>
+</Outcomes>
+
+<Prerequisites title="Wat je nodig hebt">
+  <PrerequisiteItem>
+    Deel 1 doorgenomen: <a href="/nl/academy/hydra-tutorial-1-wat-is-hydra">Wat is Hydra?</a>
+  </PrerequisiteItem>
+  <PrerequisiteItem>Een idee van wat labels op een GitHub-issue zijn en hoe je die toevoegt.</PrerequisiteItem>
+</Prerequisites>
+
+## Drie pipelines, één pijplijn
+
+Hydra heeft technisch gezien drie pipelines: **build**, **code-review** en **security-review**. Maar in praktijk werken ze altijd in dezelfde volgorde, automatisch aangestuurd door labels. Onder de motorkap is dat één state-machine:
+
+```
+ready-to-build (of <prefix>-ready-to-build op een dev-werkstation — zie deel 5)
+    ↓
+build:queued → build:running → build:pass
+    ↓
+code-review:queued → :running → :pass / :fail
+    ↓  (altijd doorlopen — ook bij :fail)
+security-review:queued → :running → :pass / :fail
+    ↓
+beslissing:
+    beide reviews :pass + 0 fixes → done (Axel overgeslagen)
+    beide reviews :pass + ≥1 fix → applier:queued → :running → :pass / :fail
+    één van beide reviews :fail   → needs-input (Axel overgeslagen, mens beslist)
+```
+
+De pijplijn heeft één belangrijke regel: **iedere uitkomst na review is terminaal**. Hydra fix-t niet automatisch in een loop. Slaagt het in één run, mooi. Slaagt het niet, dan komt het issue op `needs-input` en moet een mens beslissen wat de volgende stap is. Daarover meer in deel 6.
+
+## Pipeline 1: Build (Al Gorithm, Haiku)
+
+De builder krijgt de change, een schone clone van de doel-repo, en een turn-budget. Geen review-history, geen feedback van eerdere runs. Hij implementeert de tasks uit `tasks.md`, draait de quality-suite, opent een draft-PR.
+
+Volgorde binnen de build-fase:
+
+1. **Implementatie** — leest `proposal.md`, `design.md` en `tasks.md` uit `openspec/changes/<slug>/` in de doel-repo, schrijft code.
+2. **Quality checks** — PHPCS, PHPMD, Psalm, PHPStan, ESLint, Stylelint, `composer audit`, `npm audit`.
+3. **PHPUnit + Newman** — backend en API-tests.
+4. **Browser-tests** — Playwright MCP loopt door de UI heen.
+5. **`fix-quality` / `fix-browser`** — als checks rood worden, krijgt Al Gorithm één tot twee pogingen om mechanisch te repareren. Dit is een *pre-review* fixup, geen review-loop.
+6. **Verdict** — `build:pass` (PR is opengezet) of `build:fail` (kapotte build, `needs-input`).
+
+Belangrijk: Al Gorithm draait op **Haiku**. Reden uit deel 1: hij volgt patronen, hij oordeelt niet. Door hem op Haiku te zetten houden we Sonnet-budget vrij voor de reviewers.
+
+<HexCard title="Wat ziet de builder niet?">
+  Geen reviews, geen verdict-history, geen labels behalve het eigen <code>build:*</code>. Hij weet dus niet dat een eerdere reviewer iets afkeurde — die feedback bereikt hem alleen via een expliciete <code>retry:queued</code>-cyclus (zie onder).
+</HexCard>
+
+## Pipeline 2: Code review (Juan Claude van Damme, Sonnet)
+
+Zodra `build:pass` gezet wordt, queue-t de supervisor automatisch `code-review:queued`. Juan Claude pakt het op:
+
+1. Leest **alleen de PR-diff** (`HYDRA_REVIEW_SCOPE=diff`, ADR-020). Zo blijft de scope behapbaar en wordt elke regel die hij commentaar geeft daadwerkelijk in deze PR aangeraakt.
+2. Loopt de ADR-bibliotheek en gate-skills langs (zie deel 3).
+3. Voor **mechanische, in-scope fouten** mag hij zelf fixen (ADR-021: bounded-fix scope). PHPCS-headers ontbreken? Hij voegt ze toe. Pijnlijke variabele-naam? Niet zijn pakkie-an.
+4. Voor elk gevonden probleem schrijft hij een inline-comment op de PR met prefix `[fixed:...]` of `[unfixed:...]`.
+5. Hij commit + pusht zijn fixes naar de feature branch en zet `code-review:pass` of `code-review:fail` op het issue.
+
+Juan's `fixes_applied[]` en `unfixed[]` schrijft hij niet zelf weg als JSON — de orchestrator bundelt ze pas na de volgende stap (Clyde) tot één rondebestand. Zie ["Hoe verdicts gepersisteerd worden"](#hoe-verdicts-gepersisteerd-worden) hieronder.
+
+## Pipeline 3: Security review (Clyde Barcode, Sonnet)
+
+Direct na code-review (of die nu `:pass` of `:fail` was) queue-t de supervisor `security-review:queued`. Clyde Barcode loopt op de PR-staat ná Juan Claude's fixes:
+
+- Zelfde shape als code-review, plus **Semgrep** en patroon-matching op CWE-klassen (SQL-injectie, XSS, path-traversal, hardcoded secrets, …).
+- Mag ook bounded fixes pushen in PR-mode.
+- Schrijft `security-review:pass` of `security-review:fail`.
+
+Waarom sequentieel en niet parallel? Omdat Clyde reviewed wat Juan Claude heeft achtergelaten. Parallel zou betekenen dat Clyde naar pre-fix code kijkt — dan zou hij security-issues vinden die Juan Claude al weggepoetst had en moet je de verdicts gaan reconciliëren. Sequentieel is simpeler en duidelijker.
+
+## Hoe verdicts gepersisteerd worden
+
+Na een complete review-ronde (Juan + Clyde achter elkaar) bundelt de orchestrator beide verdicts in **één** bestand op de feature branch: `openspec/changes/<slug>/reviews/<ronde>.json` in de doel-repo. Rondes nummeren sequentieel — `1.json` na de eerste pass, `2.json` na een `retry:queued`-cyclus, enzovoort (gewoon `ls reviews/*.json | wc -l` plus één). Daarin zitten de `fixes_applied[]` én `unfixed[]` van **beide** reviewers samen — dat is wat Axel Pliér straks leest. Een geaggregeerde status-snapshot loopt parallel mee naar `openspec/changes/<slug>/hydra.json` (zie deel 6 voor de structuur en hoe je hem uitleest).
+
+## De applier: Axel Pliér's binaire gate
+
+Met beide reviews binnen heeft Hydra drie opties:
+
+1. **Beide reviews `:pass` én Juan en Clyde hebben samen 0 fixes gepusht.**  
+   Niets veranderd ná de oorspronkelijke build, dus geen nieuwe risico's. **Axel wordt overgeslagen.** Issue krijgt `done`. Bespaart tokens.
+
+2. **Beide reviews `:pass` én er is ≥ 1 fix gepusht.**  
+   De code is gewijzigd na de oorspronkelijke build. Voor we vertrouwen op de uiteindelijke staat draait de orchestrator opnieuw de mechanische gates (PHPCS, Psalm, PHPStan, ...). Slagen die, dan komt Axel Pliér aan zet. Hij leest:
+   - de uiteindelijke diff,
+   - de `fixes_applied[]` + `unfixed[]` uit beide reviews,
+   - alle inline-comments op de PR.
+   
+   En geeft één binair antwoord: `{pass: true}` of `{pass: false, blocking: [...]}`. Hij heeft géén Write- of Edit-tools. Hij oordeelt, hij grijpt niet in.
+
+3. **Eén van beide reviews `:fail`.**  
+   De reviewers zijn de autoriteit. Axel wordt overgeslagen. Issue gaat naar `needs-input`. Een mens beslist of dit een `retry:queued` of `rebuild:queued` waard is (zie deel 6).
+
+## Labels: één bron van waarheid
+
+Hydra is **stateless**. Het hele state-machine staat op de issue-labels op GitHub. De supervisor (de daemon) leest om de zoveel seconden de labels en beslist wat te doen. Crasht een container, dan kijkt de supervisor opnieuw naar de labels en pakt op waar het ophield.
+
+Per stage zijn er vier mogelijke states: `:queued`, `:running`, `:pass`, `:fail`. Die staan **altijd op het issue, nooit op de PR.** Dat is een bewuste keuze: het issue is de eenheid van werk, de PR is een artefact van een buildcycle.
+
+Naast de stage-labels zijn er metadata-labels die ernaast bestaan:
+
+| Label | Betekenis |
+|---|---|
+| `openspec` | Issue volgt het OpenSpec-werkmodel |
+| `yolo` | Mag auto-mergen mits alle gates groen zijn — geen menselijke approve nodig |
+| `agent-maxed-out` | Persona heeft zijn turn-budget opgemaakt; output is mogelijk incompleet |
+| `needs-input` | Hydra heeft de pijplijn gestopt, mens is aan zet |
+
+## `retry:queued` versus `rebuild:queued`
+
+Twee menselijk-getriggerde herstel-labels die teruggrijpen in de pijplijn. Allebei **single-shot** (geen loop):
+
+- **`retry:queued`** — de bestaande PR blijft staan. Hydra bouwt een efemere `feedback.md` (in een `/tmp/hydra-retry-XXXXXX/`-werkmap, niet gecommit) met daarin de `unfixed[]`-bevindingen + applier-blockers, mount die als `/workspace/feedback.md` in de builder-container, en dispatcht Al Gorithm in `HYDRA_MODE=fix` gescoped tot precies de geflagde bestanden. Goedkoop. Geschikt voor: "de reviewers hadden gelijk, builder moet alleen even bijschaven".
+- **`rebuild:queued`** — bestaande PR sluit, branch reset naar `development`, alle cycle-labels eraf, terug naar `build:queued`. Duur. Geschikt voor: "de aanpak van Al Gorithm klopte niet, we beginnen opnieuw met dezelfde change".
+
+Stelregel: pak altijd het goedkoopste herstel eerst. Eerst `gh pr update-branch <N>` (development → PR mergen), dan `retry:queued`, dan pas `rebuild:queued`. Deel 6 gaat hier dieper op in.
+
+## Test jezelf
+
+Vier korte vragen om te checken of je dit deel begrepen hebt. Vastgelopen? Klik **Hint**. Curieus naar het antwoord? Klik **Antwoord**.
+
+<div className="tutorial-quiz">
+
+**1. In welke volgorde lopen de drie pipelines, en waarom is security-review sequentieel ná code-review en niet parallel?**
+
+<Details summary="Hint">
+
+Denk aan welke versie van de code Clyde Barcode ziet: vóór of ná de fixes van Juan Claude?
+
+</Details>
+
+<Details summary="Antwoord">
+
+De volgorde is **build → code-review → security-review** (en daarna applier of `needs-input`).
+
+Security-review draait **na** code-review zodat Clyde Barcode de PR-staat ziet **ná** Juan Claude's bounded fixes. Parallel zou betekenen dat Clyde naar pre-fix code kijkt en security-issues vindt die Juan al weggepoetst had. Je zou dan verdicts moeten gaan reconciliëren. Sequentieel is simpeler en houdt de "wie reviewed wat"-grens scherp.
+
+</Details>
+
+</div>
+
+<div className="tutorial-quiz">
+
+**2. Wat is het verschil tussen `build:fail` en `code-review:fail` qua vervolgactie?**
+
+<Details summary="Hint">
+
+Bij één stopt de pijplijn meteen, bij de andere loopt hij nog door naar de volgende stage. Welke is welke, en waarom?
+
+</Details>
+
+<Details summary="Antwoord">
+
+- **`build:fail`** = de PR is niet (correct) opengezet, er valt niets te reviewen. Issue gaat **direct naar `needs-input`**. Pijplijn stopt.
+- **`code-review:fail`** = de PR staat, Juan Claude heeft afgekeurd, maar de pijplijn **loopt nog door** naar `security-review` (altijd, ook bij `:fail`). Pas na security-review wordt besloten: minstens één review `:fail` → applier overgeslagen → `needs-input`.
+
+Reden voor het verschil: zonder PR is er geen werk om over te oordelen; mét PR willen we beide reviewers laten zien wat er ligt, zodat een mens later een compleet beeld heeft.
+
+</Details>
+
+</div>
+
+<div className="tutorial-quiz">
+
+**3. In welke situatie wordt Axel Pliér (de applier) overgeslagen, en waarom is dat een bewuste keuze?**
+
+<Details summary="Hint">
+
+Er zijn twee scenario's. Het ene draait om "is er na de oorspronkelijke build iets veranderd?", het andere om "wie heeft het laatste woord?"
+
+</Details>
+
+<Details summary="Antwoord">
+
+Twee scenario's:
+
+1. **Beide reviews `:pass` én 0 fixes gepusht** door Juan/Clyde. De code is identiek aan wat de builder oplevert; er is niets nieuws om te beoordelen. Axel overgeslagen → `done`. Bespaart Sonnet-tokens.
+2. **Eén van beide reviews `:fail`.** De reviewers zijn de autoriteit; hun afwijzing trumpt de applier. Axel overgeslagen → `needs-input`.
+
+Axel draait dus **alleen** wanneer er wél fixes zijn gepusht én beide reviews zijn geslaagd — dan oordeelt hij of die fixes de uiteindelijke staat goed maken.
+
+</Details>
+
+</div>
+
+<div className="tutorial-quiz">
+
+**4. Wanneer kies je `retry:queued` en wanneer `rebuild:queued`?**
+
+<Details summary="Hint">
+
+Het kantelpunt is: **deugde de build-aanpak van Al Gorithm?** Bij ja → goedkoop pad. Bij nee → opnieuw beginnen.
+
+</Details>
+
+<Details summary="Antwoord">
+
+- **`retry:queued`** als de **builder-aanpak in principe goed was** en de reviewers terechte, lokale bevindingen hadden. De bestaande PR blijft staan; de builder krijgt `feedback.md` en fixed gescoped tot de geflagde files. **Goedkoop, single-shot.**
+- **`rebuild:queued`** als de **build-aanpak zelf verkeerd was** — verkeerde implementatie, stub-methods, requirements gemist. PR sluit, branch reset naar `development`, alle cycle-labels eraf, terug naar `build:queued`. **Duur.**
+
+Stelregel: altijd het goedkoopste eerst — `gh pr update-branch` → `retry:queued` → pas dán `rebuild:queued`.
+
+</Details>
+
+</div>
+
+<NextSteps title="Volgende stap" lede="Nu je het pipeline-skelet ziet, gaan we in deel 3 in op de quality gates — de mechanische scheidsrechters die alle drie de personas in toom houden.">
+  <NextStep
+    title="Deel 3 — Quality gates"
+    href="/nl/academy/hydra-tutorial-3-quality-gates"
+    description="Wat zijn de gates? Waarom mechanisch en niet AI-geoordeeld? Wat doe je als een gate fout positief slaat?"
+  />
+  <NextStep
+    title="Vorige stap — Wat is Hydra?"
+    href="/nl/academy/hydra-tutorial-1-wat-is-hydra"
+    description="Korte herhaling van het waarom en de vier personas."
+  />
+  <NextStep
+    title="De pipeline-architectuur in detail"
+    href="https://github.com/ConductionNL/hydra/blob/main/docs/pipeline-overview.md"
+    description="De volledige pipeline-overview-doc, met alle subtiliteiten over rate-limit fallback, sloten en cron-schedule."
+  />
+</NextSteps>

--- a/i18n/nl/docusaurus-plugin-content-blog/2026-05-12-hydra-tutorial-3-quality-gates/index.mdx
+++ b/i18n/nl/docusaurus-plugin-content-blog/2026-05-12-hydra-tutorial-3-quality-gates/index.mdx
@@ -1,0 +1,237 @@
+---
+slug: hydra-tutorial-3-quality-gates
+title: "Hydra leerlijn — Deel 3: Quality gates"
+contentType: tutorial
+authors: [conduction]
+date: 2026-05-12
+summary: Wat zijn de mechanische quality gates van Hydra, waarom werken ze juist NIET met AI-oordeel, en wat doe je als een gate per ongeluk fout slaat? Derde van zes korte modules.
+tags: [Hydra, Gates, Quality, Tutorial series]
+apps: []
+durationMinutes: 12
+series: hydra-tutorial
+partNumber: 3
+---
+
+import {Outcomes, Outcome, Prerequisites, PrerequisiteItem, NextSteps, NextStep, HexCard} from '@conduction/docusaurus-preset/components';
+import Details from '@theme/Details';
+
+In deel 2 zag je dat de drie personas worden aangevuld door **mechanische quality gates** — checks die deterministisch slagen of falen, zonder AI in de loop. Dit deel legt uit welke gates we hebben, waarom ze mechanisch zijn, en hoe je omgaat met de uitzondering: de fout positief.
+
+{/* truncate */}
+
+<Outcomes title="Wat je leert in dit deel">
+  <Outcome>De twee soorten gates: <strong>generieke</strong> code-quality-tools en Hydra-specifieke <strong><code>hydra-gate-*</code></strong> skills.</Outcome>
+  <Outcome>Waarom mechanische checks naast AI-review hard nodig zijn (en niet "AI lost dat wel op").</Outcome>
+  <Outcome>Hoe je een fout-positieve gate herkent en wat de juiste fix is.</Outcome>
+  <Outcome>Wat ADR-020 betekent: <strong>gates draaien op de PR-diff.</strong></Outcome>
+</Outcomes>
+
+<Prerequisites title="Wat je nodig hebt">
+  <PrerequisiteItem>Deel 1 en 2 doorgenomen: <a href="/nl/academy/hydra-tutorial-1-wat-is-hydra">Wat is Hydra?</a> en <a href="/nl/academy/hydra-tutorial-2-drie-pipelines">De drie pipelines</a>.</PrerequisiteItem>
+  <PrerequisiteItem>Basisbegrip van wat een linter is en wat een statische analyser is.</PrerequisiteItem>
+</Prerequisites>
+
+## Waarom mechanische gates?
+
+AI-review schaalt mee, maar is **niet voorspelbaar.** Twee runs op precies dezelfde diff kunnen verschillende bevindingen opleveren. En AI is juist niet sterk in het saaie nakijkwerk dat geen oordeel vraagt — bijvoorbeeld: "heeft elke nieuwe PHP-file bovenaan een SPDX-licentie-header staan?". Zo'n check kun je veel sneller en goedkoper met een simpel `grep`-commando doen.
+
+De stelregel binnen Hydra:
+
+> **Wat objectief te controleren is, doet een mechanische gate — één script dat per check slaagt of faalt. Pas waar je oordeel nodig hebt, schakelen we een reviewer in.**
+
+Concreet betekent dat: voor we Juan Claude of Clyde duur Sonnet-tijd laten verspillen aan "deze functie heet `doSomething` en dat zou een werkwoord-zelfstandig-naamwoord-paar moeten zijn", draaien we eerst PHPCS. Pas daarna gaan de AI-paar-ogen aan het werk, en die concentreren zich op wat een tool níet kan vangen.
+
+## Categorie 1: generieke code-quality tools
+
+Deze checks draaien in `scripts/run-quality.sh` inside een Docker `php:X.Y-cli` container, met `--keep-server` om Nextcloud daarna voor de browser-tests te laten staan:
+
+| Tool | Wat het vangt |
+|---|---|
+| `lint` | Syntax-fouten in PHP. |
+| `phpcs` | Coding standard (PSR-12 + Nextcloud-conventie). |
+| `phpmd` | Code-mess detector (te lange methodes, te diepe nesting, dode code). |
+| `psalm` | Statische type-analyse, level 4 baseline. |
+| `phpstan` | Tweede statische type-analyser (vangt dingen die Psalm mist en vice versa). |
+| `phpmetrics` | Complexiteits-metriek (cyclomatic, maintainability-index). |
+| `composer audit` | CVE-check op `composer.lock`-dependencies. |
+| `eslint` | JS-/TS-lint. |
+| `stylelint` | CSS-/SCSS-lint. |
+| `npm audit` | CVE-check op `package-lock.json`. |
+| `PHPUnit` | Unit + integration tests met een gecontaineriseerd Nextcloud + SQLite. |
+| `Newman` | API-tests tegen de PHP built-in server. |
+
+Iedere check is rood of groen. Eén rode check → `build:fail` (in de pre-review-fase) of `code-review:fail` / `security-review:fail` (post-fixes).
+
+## Categorie 2: Hydra-specifieke gates
+
+Naast de generieke tools heeft Hydra **een eigen reeks `hydra-gate-*` skills** voor zaken die Conduction-specifiek zijn. Die zitten in `hydra/.claude/skills/`. De huidige set telt 14 skills: één dispatcher die de andere 13 mechanische gates achter elkaar aanroept.
+
+| Gate | Wat het controleert |
+|---|---|
+| `hydra-gates` | Dispatcher: roept de 13 gates hieronder achter elkaar aan en levert één pass/fail-overzicht. |
+| `hydra-gate-spdx` | Iedere nieuwe PHP-file heeft een EUPL-1.2 SPDX-header. |
+| `hydra-gate-forbidden-patterns` | Geen `dd(`, `var_dump`, `dump(`, `console.log` blijft over. |
+| `hydra-gate-composer-audit` | Mirror van de generieke composer-audit, voor de reviewer's mandatory block. |
+| `hydra-gate-stub-scan` | Geen lege stub-methods met TODO's blijven over. |
+| `hydra-gate-route-auth` | Iedere route in `appinfo/routes.php` heeft expliciete auth-annotaties. |
+| `hydra-gate-orphan-auth` | Geen `@AuthorizedAdminSetting` op een endpoint dat niet bestaat. |
+| `hydra-gate-unsafe-auth-resolver` | Auth resolvers slaan geen claim-bypass. |
+| `hydra-gate-semantic-auth` | Authorisatie-logica klopt semantisch met de route-doel. |
+| `hydra-gate-admin-router` | Admin-routes hebben de admin-router en niet de gewone. |
+| `hydra-gate-no-admin-idor` | Geen Insecure Direct Object Reference op admin-endpoints. |
+| `hydra-gate-modal-isolation` | Modal components isoleren state correct. |
+| `hydra-gate-nc-input-labels` | Nextcloud `<NcTextField>`-componenten hebben `<label>`-koppeling. |
+| `hydra-gate-initial-state` | Geen `initialState` lekt naar de client zonder bewuste expose. |
+
+Een groot deel hiervan is geboren uit incidenten: een gate ontstaat als reactie op een bug die door alle eerdere mazen heen glipte. `hydra-gate-stub-scan` bijvoorbeeld kwam uit het [`decidesk-44-45` retrospectief](https://github.com/ConductionNL/hydra/blob/main/docs/retrospectives/decidesk-44-45-phase-g.md), waar een builder een methode opleverde die slechts `return null;` deed met een TODO. PHPCS slikte het, PHPUnit had geen test, code review las het als "in scope", en het brak in productie.
+
+## ADR-020: gate-scope is de PR-diff
+
+Een belangrijke regel die je in deel 2 al kort tegenkwam: **gates draaien op de PR-diff, niet op de hele repo**. Dat staat in [ADR-020](https://github.com/ConductionNL/hydra/blob/main/openspec/architecture/adr-020-gate-scope-to-pr-diff.md).
+
+Waarom? Omdat veel van onze repo's een achterstand aan technische schuld dragen. Als je `phpcs` op de hele repo loslaat krijg je honderden findings die niets met de huidige PR te maken hebben — en wordt elke PR rood. Door de scope te beperken tot de regels die in de PR-diff aangeraakt worden, valt de gate alleen om *wat de huidige builder net heeft toegevoegd of gewijzigd*.
+
+Override-mechanisme: `HYDRA_REVIEW_SCOPE=full` in `secrets/.env` zet de scope om naar de hele repo. Gebruik dat als je een nieuwe repo onboardt of een dedicated tech-debt-sweep doet. Verwacht in alle andere gevallen veel rood.
+
+## Fout-positieven herkennen
+
+Mechanische gates zijn deterministisch, maar niet altijd correct. Een klassieker uit eigen huis: `hydra-gate-forbidden-patterns` zocht naar `dd(` zonder word-boundary, en sloeg dus ook foutief alarm op een legitieme `$builder->add(`. Eén grep-flag verkeerd en je hebt een herhaalbare fout-positief.
+
+Hoe je een fout-positief herkent:
+
+1. **De gate slaat steeds op dezelfde regel** in elke retry, terwijl de regel zelf onschuldig oogt.
+2. **Een handmatige test van de gate-implementatie** (open `scripts/run-quality.sh` of de bijbehorende skill, run hem lokaal) bevestigt het: ja, het patroon matched, maar niet om de bedoelde reden.
+3. **Niemand in het team kan uitleggen waarom dit specifieke regel-niveau erover zou moeten klagen.**
+
+In dat geval is de fix **niet** "nog een retry". De fix is: ga naar `scripts/run-quality.sh` of de gate-skill, en repareer de detectie. Voorbeeld voor `hydra-gate-forbidden-patterns`: van `grep 'dd('` naar `grep -wE '(^|[^A-Za-z0-9_])dd\('`.
+
+## Recheck na reviewer-fixes
+
+Een subtiele maar belangrijke regel: na elke reviewer-fix-cyclus draait de orchestrator **opnieuw** de mechanische gates op de uiteindelijke PR-staat. Dit is de "quality-recheck"-fase. Reden: een reviewer kan tijdens zijn bounded-fix wel een PHPCS-style fout repareren en daarbij per ongeluk een nieuwe overtreding introduceren.
+
+Slaat de recheck rood, dan gaat het issue naar `needs-input`. Geen retry. De reviewer is gestopt, de bouwer is gestopt, een mens kijkt.
+
+<HexCard title="Let op: wanneer de retry-loop blijft hangen">
+  De recheck hierboven is je vangnet — maar dat vangnet kan zelf in een lus terechtkomen. Eén patroon om te herkennen:
+
+  De builder vergeet in één file een gate-regel die hij in andere files wél correct toepast (in de praktijk meestal de <code>spdx-headers</code>-licentiekop). De reviewer pikt het niet op, omdat hij de file als "bestaande boilerplate" leest en eroverheen kijkt. De mechanische recheck slaat dan rood, het issue gaat terug naar de builder, en die maakt bij de retry exact dezelfde fout opnieuw. Hetzelfde gate-issue blijft zo terugkomen.
+
+  **Wat te doen:** zie je 3 of meer retries op precies hetzelfde gate-issue, stop dan de loop. Twee opties — fix het handmatig, of scherp de gate-detectie aan zodat de reviewer hem niet meer als boilerplate kan wegklasseren. De volledige post-mortem van dit patroon (incidenten van 19–23 april 2026) staat in <a href="https://github.com/ConductionNL/hydra/blob/main/docs/retrospectives/decidesk-44-45-phase-g.md">decidesk-44-45-phase-g</a>.
+</HexCard>
+
+## Test jezelf
+
+Vier korte vragen om te checken of je dit deel begrepen hebt. Vastgelopen? Klik **Hint**. Curieus naar het antwoord? Klik **Antwoord**.
+
+<div className="tutorial-quiz">
+
+**1. Waarom heeft Hydra mechanische gates *en* AI-reviewers, en niet alleen één van de twee?**
+
+<Details summary="Hint">
+
+Eén soort check is voorspelbaar en goedkoop, de andere is duur maar kan oordelen. Wat is sterk en zwak aan elk?
+
+</Details>
+
+<Details summary="Antwoord">
+
+Ze vullen elkaar precies aan op de plekken waar de ander zwak is.
+
+- **Mechanische gates** zijn **deterministisch**: zelfde input → zelfde uitkomst, slagen of falen. Perfect voor saai, objectief nakijkwerk — bijvoorbeeld "heeft elke nieuwe PHP-file een SPDX-header?". Goedkoop en herhaalbaar.
+- **AI-reviewers** doen **oordeel**: "klopt deze authorization-logica semantisch met het route-doel", "is dit in deze context een veiligheidsrisico". Niet voorspelbaar en duurder, dus zet je ze in waar oordeel nodig is.
+
+Alleen-mechanisch mist context-afhankelijke fouten; alleen-AI is duur, niet voorspelbaar, en verspilt Sonnet-tijd aan dingen die een `grep` kan.
+
+</Details>
+
+</div>
+
+<div className="tutorial-quiz">
+
+**2. Wat zegt ADR-020 over de gate-scope, en wanneer schakel je dat via `HYDRA_REVIEW_SCOPE=full` uit?**
+
+<Details summary="Hint">
+
+Denk aan wat er gebeurt als je `phpcs` op een repo met veel oude technische schuld loslaat. En wanneer wil je dat juist wél?
+
+</Details>
+
+<Details summary="Antwoord">
+
+ADR-020 zegt: **gates draaien op de PR-diff, niet op de hele repo**.
+
+Reden: veel repo's slepen technische schuld mee. `phpcs` over alles geeft honderden findings die niets met de huidige PR te maken hebben — elke PR zou rood worden. Door alleen de geraakte regels te checken slaat de gate alleen om op wat de builder net heeft toegevoegd of gewijzigd.
+
+**`HYDRA_REVIEW_SCOPE=full`** in `secrets/.env` schakelt dit uit — gates draaien dan op de hele repo. Gebruik bij:
+- **Onboarding van een nieuwe repo** in Hydra.
+- Een **dedicated tech-debt-sweep**.
+
+NIET voor reguliere PRs — verwacht veel rood.
+
+</Details>
+
+</div>
+
+<div className="tutorial-quiz">
+
+**3. Hoe herken je een fout-positieve gate, en wat is de juiste fix? Wat NIET?**
+
+<Details summary="Hint">
+
+Drie signalen samen wijzen op een fout-positief. En de "verleidelijke maar verkeerde" reflex is hetzelfde nóg een keer doen.
+
+</Details>
+
+<Details summary="Antwoord">
+
+**Herkenning** — drie signalen samen:
+
+1. De gate slaat in elke retry op **dezelfde regel**, terwijl die regel onschuldig oogt.
+2. **Handmatig lokaal de gate runnen** bevestigt: het patroon matched, maar niet om de bedoelde reden (bijv. `grep 'dd('` matcht ook `$builder->add(`).
+3. Niemand in het team kan uitleggen waarom dit specifieke regel-niveau erover zou moeten klagen.
+
+**Juiste fix:** scherp de **gate-detectie** aan in `scripts/run-quality.sh` of de bijbehorende skill. Voorbeeld: `grep 'dd('` → `grep -wE '(^|[^A-Za-z0-9_])dd\('`.
+
+**NIET:** nog een keer `retry:queued`. Dat reproduceert hetzelfde fout-positief en verspilt cycles.
+
+</Details>
+
+</div>
+
+<div className="tutorial-quiz">
+
+**4. Waarom draait Hydra de mechanische gates nogmaals NA de reviewer-fixes (de "quality-recheck"-fase)?**
+
+<Details summary="Hint">
+
+De reviewers mogen binnen scope zelf fixen. Wat kan daarbij misgaan?
+
+</Details>
+
+<Details summary="Antwoord">
+
+Reviewers (Juan + Clyde) mogen binnen scope mechanische fixes pushen (ADR-021). Daarbij kan een reviewer **per ongeluk een nieuwe overtreding introduceren** — bijvoorbeeld een PHPCS-style fix die elders een regel breekt.
+
+De **quality-recheck** draait alle mechanische gates opnieuw op de uiteindelijke PR-staat zodat zeker is dat wat er nu staat ook objectief schoon is. Slaat de recheck rood → `needs-input`, geen retry. De reviewer is gestopt, de bouwer is gestopt, een mens kijkt. Het is de laatste deterministische gate vóór er een menselijke beslissing valt.
+
+</Details>
+
+</div>
+
+<NextSteps title="Volgende stap" lede="In deel 4 kijken we naar de skills en commands die de personas tijdens hun werk gebruiken — inclusief hoe je zelf een nieuwe skill kunt toevoegen.">
+  <NextStep
+    title="Deel 4 — Skills & commands"
+    href="/nl/academy/hydra-tutorial-4-skills"
+    description="Hoe passen <code>opsx-*</code>, <code>hydra-gate-*</code> en <code>team-*</code> skills in de loop. Wanneer schrijf je zelf een nieuwe."
+  />
+  <NextStep
+    title="Vorige stap — De drie pipelines"
+    href="/nl/academy/hydra-tutorial-2-drie-pipelines"
+    description="Korte herhaling van het label-state-machine."
+  />
+  <NextStep
+    title="ADR-020 — gate scope = PR diff"
+    href="https://github.com/ConductionNL/hydra/blob/main/openspec/architecture/adr-020-gate-scope-to-pr-diff.md"
+    description="De officiële motivatie achter de diff-only scope."
+  />
+</NextSteps>

--- a/i18n/nl/docusaurus-plugin-content-blog/2026-05-12-hydra-tutorial-4-skills/index.mdx
+++ b/i18n/nl/docusaurus-plugin-content-blog/2026-05-12-hydra-tutorial-4-skills/index.mdx
@@ -1,0 +1,352 @@
+---
+slug: hydra-tutorial-4-skills
+title: "Hydra leerlijn — Deel 4: Skills"
+contentType: tutorial
+authors: [conduction]
+date: 2026-05-12
+summary: Welke skills draaien in de automatische Hydra-fabriek, welke zijn er voor mensen op de CLI, hoe ze worden aangeroepen, en wanneer je zelf een skill aan de loop toevoegt. Vierde van zes korte modules.
+tags: [Hydra, Skills, OPSX, Testing, Tutorial series]
+apps: []
+durationMinutes: 14
+series: hydra-tutorial
+partNumber: 4
+---
+
+import {Outcomes, Outcome, Prerequisites, PrerequisiteItem, NextSteps, NextStep, HexCard} from '@conduction/docusaurus-preset/components';
+import Details from '@theme/Details';
+
+:::tip Niet bekend met Claude Skills in het algemeen?
+Dit deel duikt direct in de **Hydra-specifieke** skill-families. Wil je eerst weten wat een Claude Skill überhaupt is, hoe de frontmatter werkt, en wanneer je er zelf eentje schrijft? Doe dan de publieke [Claude Skills-leerlijn](/nl/academy/claude-skills-tutorial-1-wat-zijn-claude-skills) (drie korte modules, ~40 minuten). Vanaf hier gaan we ervan uit dat je de basics kent.
+:::
+
+In de vorige delen ging het over *wat* Hydra doet. Dit deel gaat over *hoe*: de **skills** die de personas hun werk laten doen. Aan het eind weet je welke skills de automatische pipeline (de "Hydra-fabriek") draait en welke je als mens zelf aanroept, ken je de vijf families, en kun je inschatten wanneer een nieuwe skill de moeite waard is.
+
+{/* truncate */}
+
+<Outcomes title="Wat je leert in dit deel">
+  <Outcome>Wat een Claude-Code-skill is en hoe Hydra ze gebruikt om gedrag bij personas te bundelen.</Outcome>
+  <Outcome>Welke skills <strong>de automatische Hydra-fabriek</strong> in zijn Docker-containers heeft staan (per agent: Builder, Reviewer, Security) — en welke skills <strong>alleen voor mensen op de CLI</strong> zijn.</Outcome>
+  <Outcome>De vijf skill-families binnen Hydra: <code>{'opsx-*'}</code>, <code>{'hydra-gate-*'}</code>, <code>{'team-*'}</code>, <code>{'test-*'}</code>, en de utility/maintenance-skills.</Outcome>
+  <Outcome>De twee manieren waarop een skill geactiveerd kan worden — handmatig via <code>/{'<naam>'}</code> of automatisch door Claude — en hoe je dat per skill stuurt.</Outcome>
+  <Outcome>Wanneer je zelf een skill toevoegt en hoe je dat structureel doet.</Outcome>
+</Outcomes>
+
+<Prerequisites title="Wat je nodig hebt">
+  <PrerequisiteItem>Deel 1, 2 en 3 doorgenomen.</PrerequisiteItem>
+  <PrerequisiteItem>Een idee van wat <code>~/.claude/skills/</code> is op je eigen laptop, of in elk geval dat skills bestanden onder die naam zijn.</PrerequisiteItem>
+</Prerequisites>
+
+## Skills, in één alinea
+
+Een **skill** in Claude Code is een mapje met een `SKILL.md` (en optioneel scripts, `examples/`, helpers). Het mapje hangt onder `.claude/skills/<naam>/`. De `description` in de frontmatter vertelt Claude wanneer de skill relevant is; de inhoud is de instructie die Claude volgt zodra de skill geladen wordt.
+
+Voor Hydra zijn skills de **bundel-eenheid van gedrag**: in plaats van duizend regels prompt-tekst direct in een persona's `CLAUDE.md` te plakken, zit het in een skill, hergebruikbaar en testbaar.
+
+## Hoe een skill wordt aangeroepen
+
+Eén skill kan op twee manieren in actie komen:
+
+1. **Handmatig** — je typt `/opsx-apply` in een Claude-sessie. Direct, voorspelbaar, en de skill draait precies wanneer jij dat wilt.
+2. **Automatisch** — Claude leest de `description` van alle beschikbare skills mee en kiest er zelf eentje wanneer de huidige situatie matcht. Vraag "wat is er veranderd?" en Claude triggert vanzelf een skill als `summarize-changes` als die voorhanden is.
+
+Welke mode is toegestaan, regel je in de frontmatter van de skill zelf:
+
+- `disable-model-invocation: true` — alleen jij kunt 'm aanroepen via `/<naam>`. Gebruik dit voor skills met side-effects (`/opsx-apply` past code aan, `/create-pr` opent een PR). Claude mag dit niet zomaar uit zichzelf doen.
+- `user-invocable: false` — alleen Claude zelf mag 'm laden. Gebruik dit voor achtergrondkennis (bijvoorbeeld een `legacy-system-context` die niet als actie zinvol is).
+- Geen van beide gezet — beide mogen.
+
+Dat onderscheid — handmatig vs. automatisch — gaat dus over **configuratie van één skill**, niet over twee verschillende soorten bestanden. Een persona in een Docker-container heeft geen toetsenbord en leunt vooral op auto-activatie; een mens op de CLI wil meestal expliciete controle en typt `/`.
+
+## Twee werelden: de Hydra-fabriek vs. skills voor mensen
+
+Hydra's `hydra/.claude/skills/` bevat ~70 skills, maar de **automatische pipeline gebruikt er maar een handvol**. De rest is gereedschap voor jou, achter een toetsenbord. Belangrijk om uit elkaar te houden:
+
+### Wat de Hydra-fabriek echt draait
+
+Elke pipeline-container heeft een eigen, beperkte set skills in zijn Docker-image gebakken:
+
+| Container | Persona | Skills in image | Hoofdfunctie |
+|---|---|---|---|
+| **Builder** | Al Gorithm | **Alle** `.claude/skills/*` + alle vendor skills | Implementeert taken; primair `opsx-apply`. Heeft de overige opsx-skills bij de hand voor context bij verifiëren, hertrouw zoeken, fixen na quality-fail. |
+| **Reviewer** | Juan Claude | `hydra-gates` + 13 `hydra-gate-*` skills + vendor `code-review` | Mandatory hydra-gates check + diepere code-review via de Anthropic community-skill. |
+| **Security** | Clyde Barcode | `hydra-gates` + 13 `hydra-gate-*` skills + vendor `trailofbits` + vendor `owasp` | Mandatory hydra-gates + SAST (Semgrep) + OWASP-top-10-checklists. |
+| **Applier** | Axel Plier | **Geen skills** | Past kleine, deterministische fixes toe puur via zijn `CLAUDE.md` — geen skill-laag nodig. |
+| **Browser UI Tester** | (sonnet, headless) | Eén skill: `hydra-ui-test` | Logt in, navigeert de live app via Playwright MCP, levert verdict JSON. |
+
+Daarnaast draait **`scripts/run-hydra-gates.sh`** in elke container alle **14** hydra-gates mechanisch — los van welke skill-files er in de image staan. De skill-files dienen voor Claude als documentatie bij een fix; het script doet de detectie.
+
+### Wat de fabriek **niet** doet — voor mensen op de CLI
+
+Alle andere skills (~50 van de 70) zijn voor jou, of voor een collega-dev in een Claude Code sessie op zijn laptop. Voorbeelden:
+
+- **Een change voorbereiden** — `opsx-new`, `opsx-ff`, `opsx-explore`, `opsx-plan-to-issues` doe je als mens vóór je het werk in de pipeline gooit. De Builder runt alleen `opsx-apply` op een al-bestaande change.
+- **Een role aannemen** — `team-architect`, `team-backend`, `team-po` enz. zijn pure roleplay-frames voor één-mens-één-rol sessies. De pipeline gebruikt ze niet.
+- **Testen draaien** — `/test-counsel` (alle 8 personas) of `/test-app` (één browser-sweep) start je met de hand. De fabriek heeft een eigen browser-tester (`hydra-ui-test`); de `test-*` familie staat los daarvan.
+- **PR's en dag-werk** — `/create-pr`, `/review-pr`, `/report-out` zijn de "drie keer per dag"-tools voor jou, niet voor de pipeline.
+
+Onthoud: **de fabriek pakt 5 skills, een mens kan tegen alle 70 aanroepen**. Dat is het hele verschil.
+
+## De vijf skill-families compleet
+
+Met die scheiding in het achterhoofd, hier zijn alle vijf families. Het tag-systeem in de tabel: **🤖 fabriek** = staat in een pipeline-container, **⌨️ mens** = alleen via CLI.
+
+### Familie 1: OpenSpec workflow (`opsx-*`, 16 skills)
+
+De OPSX-skills implementeren de Conduction-workflow voor OpenSpec-changes — van proposal tot archief.
+
+| Skill | Voor wie | Doet |
+|---|---|---|
+| `opsx-apply` | 🤖 Builder | Implementeert taken uit een change (de pipeline-default). |
+| `opsx-verify` | 🤖 Builder | Controleert dat de implementatie de change-artefacten dekt. |
+| `opsx-archive` | 🤖 Builder + ⌨️ | Archiveert een afgeronde change, syncing delta naar de spec. |
+| `opsx-new` | ⌨️ | Start een nieuwe change (proposal scaffold, schema-keuze). |
+| `opsx-ff` | ⌨️ | "Fast-forward": maakt change + alle artefacten in één pass. |
+| `opsx-continue` | ⌨️ | Pak een onderbroken change op. |
+| `opsx-explore` | ⌨️ | Verken pre-spec wat een change überhaupt zou moeten zijn. |
+| `opsx-onboard` | ⌨️ | Onboarding-flow op een nieuwe repo (zet OpenSpec config + structuur op). |
+| `opsx-plan-to-issues` | ⌨️ | Converteert `tasks.md` naar GitHub-issues + tracking-issue. |
+| `opsx-sync` | ⌨️ | Sync delta-specs terug naar de hoofdspec. |
+| `opsx-bulk-archive` | ⌨️ | Archiveer meerdere afgeronde changes in één keer. |
+| `opsx-apply-loop` | ⌨️ | Headless build → quality-fix lus voor lokale dev-runs. |
+| `opsx-pipeline` | ⌨️ | Parallel meerdere changes tegelijk laten lopen (multi-agent). |
+| `opsx-coverage-scan` | ⌨️ | Audit een legacy app op spec ↔ code coverage. |
+| `opsx-annotate` | ⌨️ | Past `@spec` PHPDoc-tags toe na een coverage-scan. |
+| `opsx-reverse-spec` | ⌨️ | Reverse-engineert een spec uit bestaande code. |
+
+### Familie 2: Quality + security gates (`hydra-gate-*`, 14 skills)
+
+De parent-skill **`hydra-gates`** is een dispatcher die alle gates samen afroept. De script-engine onder de motorkap (`scripts/run-hydra-gates.sh`) draait alle 14 gates in elke container; de skill-files dienen Claude als referentie bij het fixen van een failure.
+
+| Gate-skill | Wat hij detecteert |
+|---|---|
+| `hydra-gates` (dispatcher) | Roept alle 14 gates achter elkaar aan, levert pass/fail-overzicht. |
+| `hydra-gate-spdx` | Ontbrekende `@license`/`@copyright`-headers op PHP/Vue-files. |
+| `hydra-gate-forbidden-patterns` | Debug-calls (`var_dump`, `console.log`), TODO's in productiecode, hardcoded secrets. |
+| `hydra-gate-stub-scan` | Stub-methods die `return null;` of niets doen — geen test, geen logica. |
+| `hydra-gate-composer-audit` | `composer audit` met kwetsbaarheden in afhankelijkheden. |
+| `hydra-gate-route-auth` | `routes.php` zonder auth-attribuut waar dat hoort. |
+| `hydra-gate-orphan-auth` | Auth-checks in methodes die nergens aangeroepen worden (verlaten). |
+| `hydra-gate-no-admin-idor` | `Application::APP_ID` ontbreekt bij admin-only methodes → IDOR-risico. |
+| `hydra-gate-unsafe-auth-resolver` | `catch(\Throwable) { return null; }` rond auth-logica. |
+| `hydra-gate-semantic-auth` | `#[NoAdminRequired]` op een methode die toch `requireAdmin()` aanroept. |
+| `hydra-gate-admin-router` | Admin-routes die niet via de admin-router lopen. |
+| `hydra-gate-initial-state` | Frontend `initialState` zonder serverside hydration. |
+| `hydra-gate-modal-isolation` | Vue-modals die buiten hun container teleporteren. |
+| `hydra-gate-nc-input-labels` | Nextcloud-input-components zonder gekoppeld label (a11y). |
+
+Alle 14 draaien **🤖 in de Hydra-fabriek** (Reviewer + Security containers; Builder voert ze óók uit als post-flight check tijdens fix-quality).
+
+### Familie 3: Team-rollen (`team-*`, 7 skills) — **alleen ⌨️ voor mensen**
+
+Skills die een specifiek soort werk modelleren via een persona-frame. Bedoeld voor een mens die naast Hydra in een terminal werkt en even één rol wil invullen.
+
+- `team-po` (Product Owner) — schrijft user stories en acceptatiecriteria.
+- `team-sm` (Scrum Master) — beheert backlog en sprint-planning artefacten.
+- `team-architect` — neemt architectuurbeslissingen, schrijft ADR-drafts.
+- `team-backend` — implementeert backend-werk (PHP, services, mappers).
+- `team-frontend` — implementeert frontend-werk (Vue 2, Pinia, NL Design System).
+- `team-reviewer` — een handmatige variant van het reviewer-werk.
+- `team-qa` — schrijft testcases en testplannen.
+
+Geen van deze staat in een pipeline-container — ze hebben geen plek in de automatische loop.
+
+### Familie 4: Test-suites (`test-*`, 19 skills) — bijna allemaal ⌨️ voor mensen
+
+De grootste familie qua aantal: rond de twintig skills die agentic browser- en API-testen drijven, in drie clusters:
+
+**Test-types** (één per test-soort):
+- `test-app` — automatische browsertest van een hele Nextcloud-app (Playwright MCP).
+- `test-functional` — functionele scenario's tegen geïmplementeerde features.
+- `test-api` — API-checks tegen de PHP built-in server.
+- `test-accessibility`, `test-performance`, `test-security`, `test-regression` — gespecialiseerde varianten.
+
+**Personas** (`test-persona-*`) — acht Nederlandse gebruikersprofielen die elk een eigen blik op een app werpen: `annemarie`, `fatima`, `henk`, `janwillem`, `mark`, `noor`, `priya`, `sem`. Henk leest met grote letters en zoekt eenvoudige navigatie; Noor hamert op RBAC en audit-trails; Annemarie controleert NLGov/GEMMA-mapping. De persona-cards zelf liggen in [`hydra/personas/`](https://github.com/ConductionNL/hydra/tree/main/personas).
+
+**Scenario-management** — `test-scenario-create`, `test-scenario-edit`, `test-scenario-run` schrijven, bewerken en draaien herbruikbare `TS-NNN-*.md` scenario's per app.
+
+De dispatcher van deze familie is **`test-counsel`**: hij coördineert alle acht personas tegen één feature en levert een gecombineerd rapport. Zelfde patroon als `hydra-gates` voor de quality-gates familie.
+
+:::note Geen overlap met de fabriek's browser-tester
+De Hydra-fabriek heeft een **eigen** browser-tester (`hydra-ui-test`) die in de Browser UI Tester-stap draait. Die staat **los** van deze `test-*` familie. De `test-*` skills zijn voor wanneer jij — als mens — een feature wilt testen voordat of nadat de pipeline 'm heeft aangeraakt. Gates uit deel 3 draaien statische checks (regex/AST); `test-*` draait de echte applicatie in een browser.
+:::
+
+### Familie 5: Utility & maintenance (~13 skills) — vrijwel allemaal ⌨️ voor mensen
+
+De rest, dat is de overige ~13 skills. Vooral dev-comfort en meta-werk:
+
+| Skill | Doet |
+|---|---|
+| `create-pr` | Maakt een PR vanuit een feature-branch — local checks → branch pick → PR-tekst. |
+| `review-pr` | Reviewt een GitHub PR (NB: handmatige variant; de fabriek heeft zijn eigen Juan Claude). |
+| `report-out` | End-of-day rapport: vandaag's commits + GitHub-activiteit → Nederlandse Slack-melding. |
+| `clean-env` | Reset de lokale Docker-dev-omgeving volledig. |
+| `local-run` | Lokale Nextcloud-dev-omgeving opstarten. |
+| `sync-docs` | Sync `{app}/docs/` of `.github/docs/claude/` met de werkelijkheid in de repo. |
+| `skill-creator` | Wizard voor het maken van een nieuwe skill (scaffold, frontmatter, evals). |
+| `feature-counsel` | Pre-build spec-analyse vanuit acht persona-perspectieven (zusje van `test-counsel`). |
+| `persistence-audit` | Audit hoe een app omgaat met data-persistence (objectstore, sessies, etc.). |
+| `journeydoc-init` / `journeydoc-add-story` / `journeydoc-instrument` | Handmatige instrumentatie + uitbreiding van Journey-docs. |
+| `verify-global-settings-version` | Check of `global-settings/VERSION` is opgehoogd na een wijziging. |
+
+Niets uit deze familie draait in de pipeline. Het zijn jouw dagelijkse `/`-commando's.
+
+## Vendor skills (community)
+
+Naast de eigen skills heeft Hydra **vendor skills** onder `hydra/vendor/skills/`:
+
+- `code-review` — communautaire review-skill van Anthropic. → 🤖 Reviewer container.
+- `trailofbits` — Semgrep-based static-analysis methodologie van Trail of Bits. → 🤖 Security container.
+- `owasp` — OWASP-top-10:2025 + ASVS 5.0-checklists. → 🤖 Security container.
+
+Die drie zitten dus **wél** in de fabriek (containers). Ze worden bij Juan en Clyde geladen voor extra dekking boven op de eigen `hydra-gate-*`. Onderhoud ligt bij externe partijen — updaten gaat door de bron te volgen, niet door zelf te editen.
+
+## Wanneer schrijf je een nieuwe skill?
+
+De pragmatische test: schrijf een skill als…
+
+1. **De check / het gedrag is herhaalbaar** — meer dan eens nodig, op meer dan één plek.
+2. **Het is mechanisch beschrijfbaar** — je kunt het in 1-3 alinea's instrueren, zonder dat het ontaardt in "het hangt van de context af".
+3. **Een persona of een mens zou er baat bij hebben.** Geen skill schrijven omdat het kan.
+
+Voor een fout-positieve gate (deel 3): je past de bestaande skill aan, je schrijft geen nieuwe. Voor een nieuw klasse-fout dat je 3x ziet langskomen: ja, daar verdient het een eigen `hydra-gate-*` skill.
+
+<HexCard title="Tip: gebruik /skill-creator">
+  Hydra heeft een ingebouwde <code>/skill-creator</code> skill die je door het maken van een nieuwe skill leidt: scaffold, frontmatter, eval-harness, performance-meting. Roep hem aan vanuit een Claude-sessie in de hydra-repo om met de juiste structuur te starten in plaats van zelf een mapje op te bouwen. Een uitgewerkte walkthrough vind je in <a href="/nl/academy/claude-skills-tutorial-2-je-eerste-skill">deel 2 van de Claude Skills-leerlijn</a>; meten en evalueren wordt behandeld in <a href="/nl/academy/claude-skills-tutorial-3-skill-evals">deel 3</a>.
+</HexCard>
+
+## Test jezelf
+
+Vier korte vragen om te checken of je dit deel begrepen hebt. Vastgelopen? Klik **Hint**. Curieus naar het antwoord? Klik **Antwoord**.
+
+<div className="tutorial-quiz">
+
+**1. Wat zijn de twee manieren waarop een skill kan worden geactiveerd, en hoe stuur je dat per skill?**
+
+<Details summary="Hint">
+
+Eén manier vergt dat een mens iets typt. De andere laat Claude zelf beslissen op basis van de skill-omschrijving. Welke frontmatter-velden bepalen welke mode mag?
+
+</Details>
+
+<Details summary="Antwoord">
+
+- **Handmatig**: jij typt `/<naam>` in een Claude-sessie. Direct, voorspelbaar.
+- **Automatisch**: Claude leest de `description` van alle skills mee en kiest er zelf eentje wanneer de huidige conversatie matcht.
+
+In de frontmatter van een skill zet je:
+
+- `disable-model-invocation: true` — alleen handmatig. Gebruikt voor skills met side-effects (`/opsx-apply`, `/create-pr`).
+- `user-invocable: false` — alleen automatisch. Gebruikt voor achtergrondkennis die niet als actie zinvol is.
+- Beide leeg → beide mogen. Default voor de meeste Hydra-skills.
+
+In de Hydra-pipeline gebruiken de containers vooral auto-activatie (Claude pikt zelf de juiste skill op); een mens op de CLI typt meestal expliciet `/`.
+
+</Details>
+
+</div>
+
+<div className="tutorial-quiz">
+
+**2. Welke skills draaien er nou écht in de pipeline-containers, en welke staan alleen in de repo voor mensen?**
+
+<Details summary="Hint">
+
+Drie containers (Builder, Reviewer, Security) hebben elk een specifieke set in hun image. Wat zit erin — en welke families staan er volledig buiten?
+
+</Details>
+
+<Details summary="Antwoord">
+
+**In de pipeline-containers** (🤖 fabriek):
+
+- **Builder** — alle `.claude/skills/*` ingebakken, maar de standaard-run is `opsx-apply`. De andere opsx-skills zijn er voor context.
+- **Reviewer** — `hydra-gates` + 13 individuele `hydra-gate-*` + vendor `code-review`.
+- **Security** — `hydra-gates` + 13 individuele `hydra-gate-*` + vendor `trailofbits` + vendor `owasp`.
+- **Applier** — géén skills (puur CLAUDE.md).
+- **Browser UI Tester** — alleen `hydra-ui-test`.
+
+Plus: `scripts/run-hydra-gates.sh` draait alle **14** gates mechanisch in elke container, ongeacht welke skill-files in de image staan.
+
+**Niet in de fabriek**, alleen voor mensen op de CLI:
+
+- Vrijwel de hele `team-*` familie (7 skills).
+- Vrijwel de hele `test-*` familie (19 skills) — de fabriek heeft zijn eigen `hydra-ui-test`.
+- De meeste `opsx-*` skills behalve `opsx-apply`/`verify`/`archive` (humans starten changes; de pipeline implementeert ze).
+- De hele utility-familie (`create-pr`, `review-pr`, `report-out`, `clean-env`, `sync-docs`, `skill-creator`, `feature-counsel`, `persistence-audit`, `journeydoc-*`, `verify-global-settings-version`).
+
+In totaal: van ~70 skills in de repo gebruikt de automatische pipeline er een handvol; de rest is jouw gereedschap.
+
+</Details>
+
+</div>
+
+<div className="tutorial-quiz">
+
+**3. Wanneer pas je een bestaande gate-skill aan en wanneer schrijf je een nieuwe?**
+
+<Details summary="Hint">
+
+Eén beslissing gaat over "de gate doet niet wat we al wilden". De ander over "we hebben een nieuwe categorie fout ontdekt".
+
+</Details>
+
+<Details summary="Antwoord">
+
+- **Bestaande aanpassen** bij een **fout-positief**: de gate triggert te breed of te smal op iets dat al bedoeld werd te checken. Voorbeeld: `hydra-gate-forbidden-patterns` matchte `$builder->add(` ten onrechte — je past de regex aan, je voegt geen tweede gate toe.
+- **Nieuwe schrijven** voor een **nieuw klasse-fout** dat je 3× ziet langskomen en dat door alle bestaande mazen heen glipt. Voorbeeld: `hydra-gate-stub-scan` ontstond toen een builder een `return null;`-methode oplevert die PHPCS slikte en geen test had — dat was een nieuwe categorie, niet een fix op een bestaande check.
+
+Rule of three: één keer is toeval, twee keer toeval, drie keer is een patroon dat een eigen gate verdient.
+
+</Details>
+
+</div>
+
+<div className="tutorial-quiz">
+
+**4. Wat doen de "vendor skills" en waarom houden we die apart van onze eigen `hydra-gate-*`?**
+
+<Details summary="Hint">
+
+Denk aan herkomst (wie heeft ze geschreven?), bij welke pipeline-container ze worden ingeladen, en wat er gebeurt als je een externe partij hun werk moet updaten.
+
+</Details>
+
+<Details summary="Antwoord">
+
+Vendor-skills (`hydra/vendor/skills/`) zijn skills die **niet door ons** zijn geschreven, en zitten **wél** in de fabriek:
+
+- `code-review` (Anthropic-community) → Reviewer-container (Juan Claude).
+- `trailofbits` (Trail of Bits, Semgrep-methodologie) → Security-container (Clyde).
+- `owasp` (OWASP-top-10:2025 + ASVS 5.0) → Security-container.
+
+Apart houden omdat:
+
+- **Onderhoud** ligt bij externe partijen — we updaten ze door de bron te volgen (zie `vendor/skills/VERSIONS.md`), niet door zelf te editen. Onze eigen gates muteren we vrij; vendor-skills laten we met rust.
+- **Audit-spoor** blijft duidelijk: wat is van ons vs. wat is community/extern? Bij een failure weet je meteen welk kamp verantwoordelijk is voor de fix.
+
+</Details>
+
+</div>
+
+<NextSteps title="Volgende stap" lede="In deel 5 gaan we praktisch worden: een echte Hydra-run starten op een echte app, inclusief de label-prefix-truc voor parallelle dev-runs.">
+  <NextStep
+    title="Deel 5 — Een Hydra-run starten op een echte app"
+    href="/nl/academy/hydra-tutorial-5-een-hydra-run-starten"
+    description="Het hele recept: van issue openen tot PR groen krijgen. Met de juiste config in <code>secrets/.env</code> en de <code>HYDRA_LABEL_PREFIX</code>-truc voor wie naast collega-devs werkt."
+  />
+  <NextStep
+    title="Vorige stap — Quality gates"
+    href="/nl/academy/hydra-tutorial-3-quality-gates"
+    description="De mechanische scheidsrechters die deze skills aanvullen."
+  />
+  <NextStep
+    title="Skills directory"
+    href="https://github.com/ConductionNL/hydra/tree/main/.claude/skills"
+    description="Browse de volledige lijst skills in de hydra-repo."
+  />
+  <NextStep
+    title="Claude Skills-leerlijn (publiek)"
+    href="/nl/academy/claude-skills-tutorial-1-wat-zijn-claude-skills"
+    description="Een aparte, publieke leerlijn die wat dieper ingaat op Claude Skills in het algemeen: wat ze zijn, hoe je er een schrijft, en hoe je hem meet met evals. Goed voor de bredere achtergrond."
+  />
+</NextSteps>

--- a/i18n/nl/docusaurus-plugin-content-blog/2026-05-12-hydra-tutorial-5-een-hydra-run-starten/index.mdx
+++ b/i18n/nl/docusaurus-plugin-content-blog/2026-05-12-hydra-tutorial-5-een-hydra-run-starten/index.mdx
@@ -1,0 +1,356 @@
+---
+slug: hydra-tutorial-5-een-hydra-run-starten
+title: "Hydra leerlijn — Deel 5: Een Hydra-run starten op een echte app"
+contentType: tutorial
+authors: [conduction]
+date: 2026-05-12
+summary: Het hele recept van issue tot groene PR, inclusief de HYDRA_LABEL_PREFIX-instelling waarmee meerdere devs gelijktijdig Hydra kunnen draaien zonder elkaars labels te overschrijven. Vijfde van zes korte modules.
+tags: [Hydra, Operations, Setup, Labels, Tutorial series]
+apps: []
+durationMinutes: 20
+series: hydra-tutorial
+partNumber: 5
+---
+
+import {Outcomes, Outcome, Prerequisites, PrerequisiteItem, NextSteps, NextStep, HexCard, Troubleshooting, TroubleshootingItem} from '@conduction/docusaurus-preset/components';
+import Details from '@theme/Details';
+
+In de eerste vier delen ging het om concept, pipelines, gates en skills. Tijd om te draaien. In dit deel start je een complete Hydra-run op een doel-app, met aandacht voor de praktische valkuilen: tokens, images, en — als je met meerdere devs aan dezelfde repo's werkt — de `HYDRA_LABEL_PREFIX`-truc.
+
+{/* truncate */}
+
+<Outcomes title="Wat je leert in dit deel">
+  <Outcome>Hoe je <code>secrets/.env</code> + <code>secrets/credentials.json</code> opzet voor een lokale Hydra-run.</Outcome>
+  <Outcome>Hoe je de container images lokaal bouwt (of uit GHCR pulled).</Outcome>
+  <Outcome>Hoe je een OpenSpec-change klaar maakt en het issue triggert.</Outcome>
+  <Outcome>Hoe je via <strong><code>HYDRA_LABEL_PREFIX</code></strong> een eigen label-namespace claimt zodat je met meerdere devs niet op elkaars stage-labels staat.</Outcome>
+  <Outcome>Hoe je de pijplijn volgt: <code>logs/supervisor.log</code>, sloten, en pipeline-comments op de PR.</Outcome>
+</Outcomes>
+
+<Prerequisites title="Wat je nodig hebt">
+  <PrerequisiteItem>Deel 1 t/m 4 doorgenomen.</PrerequisiteItem>
+  <PrerequisiteItem>De hydra-repo gecloned: <code>git clone git@github.com:ConductionNL/hydra.git</code>.</PrerequisiteItem>
+  <PrerequisiteItem>Een werkende Docker engine (rootless of root maakt niet uit). Lokaal draaien we de drie images zonder kubernetes.</PrerequisiteItem>
+  <PrerequisiteItem>Een Claude Max-account met OAuth ingelogd (Hydra gebruikt geen API keys; zie <code>secrets/credentials.json</code> verderop).</PrerequisiteItem>
+  <PrerequisiteItem>GitHub PATs met de juiste scopes voor builder/reviewer/security — vraag aan je teamlead als je ze nog niet hebt.</PrerequisiteItem>
+</Prerequisites>
+
+## Stap 1: clone en bekijk
+
+```bash
+git clone git@github.com:ConductionNL/hydra.git
+cd hydra
+cat CLAUDE.md
+```
+
+`CLAUDE.md` is de canonieke architectuur-doc. Goed om voor de eerste keer doorheen te scrollen. Daarna naar `secrets/` — die map zit niet in git en moet je zelf vullen.
+
+## Stap 2: credentials.json
+
+Hydra leest één bestand voor alle Claude-OAuth-tokens en alle GitHub-PATs:
+
+```json title="secrets/credentials.json"
+{
+  "claude_tokens": [
+    { "name": "account-1", "token": "sk-ant-oat-…" },
+    { "name": "account-2", "token": "sk-ant-oat-…" }
+  ],
+  "git_tokens": {
+    "builder":  "gho_…",
+    "reviewer": "gho_…",
+    "security": "gho_…"
+  }
+}
+```
+
+Drie aparte GitHub-PATs. Geen gedeelde org-admin tokens. De reden zag je in deel 1: elk persona heeft zijn eigen scope.
+
+Heb je meerdere Claude Max accounts? Zet ze allemaal in `claude_tokens` in volgorde van voorkeur. `run_container_with_fallback()` rouleert automatisch op rate-limit.
+
+## Stap 3: `secrets/.env`
+
+De **niet**-credential overrides. Cruciaal — verschillende voor productie/CI dan voor je laptop.
+
+```bash title="secrets/.env (lokaal werkstation)"
+# Welke images en tag te gebruiken. Lokaal bouw je vaak met -t localhost/hydra-*:test.
+HYDRA_IMAGE_PREFIX=localhost/hydra
+HYDRA_IMAGE_TAG=test
+
+# Optioneel: label-namespace zodat je collega's niet op je tenen staat.
+HYDRA_LABEL_PREFIX=wilco
+
+# Default review-scope (ADR-020): alleen PR-diff. Zet op 'full' alleen bij onboarding van een repo.
+HYDRA_REVIEW_SCOPE=diff
+```
+
+Tip: de defaults zijn `ghcr.io/conductionnl/hydra` als prefix en `latest` als tag. Op productie/CI laat je `HYDRA_IMAGE_*` weg en pakt Hydra die defaults op.
+
+:::tip secrets/.env wordt automatisch geladen
+`scripts/hydra-supervisor.sh` en `scripts/orchestrate.sh` sourcen dit bestand **zelf** bij opstart. Eerder moest je het in je shell exporteren — een silly bug die maanden onopgemerkt bleef en gefixt is als onderdeel van het [decidesk-44-45 retrospectief](https://github.com/ConductionNL/hydra/blob/main/docs/retrospectives/decidesk-44-45-phase-g.md) (april 2026). Iedere nieuwe long-running entrypoint MOET dit bestand sourcen aan de start; dat is een repo-wide contract.
+:::
+
+## Stap 4: HYDRA_LABEL_PREFIX — waarom en hoe
+
+Default werkt Hydra met **kale** labels: `build:queued`, `code-review:running`, `security-review:pass`, enzovoort. Eén supervisor draait, eén pipeline tegelijk per issue. Geen probleem.
+
+**Maar:** zodra meerdere devs lokaal Hydra draaien tegen **dezelfde** target-repo's gaat het knetteren. Jouw supervisor schrijft `build:queued`. De supervisor van een collega ziet datzelfde label, pakt het op, gaat *zijn* build doen. Resultaat: race-conditions, dubbele PRs, labels die over elkaar pingen.
+
+`HYDRA_LABEL_PREFIX` is de oplossing. Zet hem in `secrets/.env`:
+
+```bash
+HYDRA_LABEL_PREFIX=wilco
+```
+
+Vanaf dat moment prefixed Hydra **ELK door hem beheerd label** met `wilco-`:
+
+| Default (geen prefix)        | Met `HYDRA_LABEL_PREFIX=wilco`     |
+|---|---|
+| `ready-to-build`             | `wilco-ready-to-build`             |
+| `build:queued`               | `wilco-build:queued`               |
+| `build:running`              | `wilco-build:running`              |
+| `code-review:queued`         | `wilco-code-review:queued`         |
+| `security-review:pass`       | `wilco-security-review:pass`       |
+| `applier:fail`               | `wilco-applier:fail`               |
+| `needs-input`                | `wilco-needs-input`                |
+| `retry:queued`, `rebuild:queued` | `wilco-retry:queued`, `wilco-rebuild:queued` |
+| `yolo`, `openspec` (metadata) | **niet** geprefixed — gedeelde metadata |
+
+Jouw Hydra leest én schrijft **alleen** labels in zijn eigen namespace. De supervisor van een collega met `HYDRA_LABEL_PREFIX=jan` werkt in een andere namespace, dus jullie zien elkaars in-flight werk niet en blokkeren elkaar niet.
+
+### Constraints op de waarde
+
+- Regex: `^[a-z0-9]([a-z0-9-]{0,14}[a-z0-9])?$` — 1 t/m 16 tekens, lowercase a-z 0-9 en koppelteken, niet beginnen of eindigen met een streepje.
+- Empty / unset = default-gedrag (geen prefix). Dat is ook wat productie/CI altijd draait.
+- Wijzigen tijdens een lopende run = NIET DOEN. Eerst pijplijn drainen.
+
+### Labels seeden op een target-repo
+
+Voor je eerste run met een nieuwe prefix moet je de labels op de doel-repo's eenmalig aanmaken:
+
+```bash
+./scripts/create-labels.sh --repo ConductionNL/<app> --prefix wilco
+```
+
+Idempotent — herhaalde aanroepen overschrijven alleen kleuren. Het script seedt ook de juiste kleurcodes (rood/oranje/geel/groen/blauw) zodat het board in één oogopslag leesbaar blijft.
+
+### Wanneer wel, wanneer niet
+
+| Situatie | Prefix gebruiken? |
+|---|---|
+| Productie / GitHub Actions / cron-managed deployment | **Nee.** Laat hem leeg. Productie = de canonieke labels. |
+| Lokale dev-werkstation, één Hydra-instance | Kan, hoeft niet. Werkt zonder ook. |
+| Lokaal, meerdere devs, gedeelde target-repo's | **Ja.** Iedereen z'n eigen prefix. |
+| Demo / experiment op een target-repo waar productie ook draait | **Ja, zeker.** Anders pakt productie-Hydra je demo-issue op. |
+
+<HexCard title="Gerelateerd: HYDRA_REVIEW_SCOPE=full">
+  Naast prefix is er nog een tweede knop voor lokaal werken: <code>HYDRA_REVIEW_SCOPE=full</code> zet de reviewer-scope van diff-only naar de hele repo. Handig voor onboarding van een nieuwe repo of een dedicated tech-debt-sweep, NIET voor reguliere PRs (verwacht veel rood — zie deel 3).
+</HexCard>
+
+## Stap 5: build de container images
+
+In CI worden alle images door GitHub Actions gepushd naar GHCR. Lokaal — als je `HYDRA_IMAGE_PREFIX=localhost/hydra` hebt staan — bouw je ze zelf:
+
+```bash
+# Base image: Nextcloud + PostgreSQL + OpenRegister (afhankelijkheid van builder)
+docker build -t ghcr.io/conductionnl/hydra-nextcloud-test:stable32 \
+    -f images/nextcloud-test/Dockerfile .
+
+# De drie pipeline images
+docker build -t localhost/hydra-builder:test  -f images/builder/Dockerfile  .
+docker build -t localhost/hydra-reviewer:test -f images/reviewer/Dockerfile .
+docker build -t localhost/hydra-security:test -f images/security/Dockerfile .
+```
+
+Daarna controleer met `docker images | grep hydra` of de drie tags er staan. Reviewer en security zijn standalone (geen NC-dependency); de builder leunt op de `hydra-nextcloud-test` base.
+
+## Stap 6: start de supervisor
+
+```bash
+# Foreground voor je eerste run zodat je live ziet wat gebeurt
+./scripts/hydra-supervisor.sh
+```
+
+Wat je verwacht te zien:
+
+```
+[supervisor] loaded HYDRA_LABEL_PREFIX=wilco — restricting to own namespace
+[supervisor] image prefix=localhost/hydra tag=test
+[supervisor] pool size=5, slots free=5
+[supervisor] polling …
+```
+
+In een tweede terminal kun je de logs volgen:
+
+```bash
+tail -f logs/supervisor.log
+ls /tmp/hydra-slots/    # zien welke slots in gebruik zijn
+```
+
+## Stap 7: trigger een issue
+
+In de doel-repo open je een issue. Op dat issue zet je:
+
+- Het trigger-label. **Met prefix:** `wilco-ready-to-build`. Zonder prefix: `ready-to-build`.
+- Optioneel `yolo` — niet geprefixed, want metadata.
+- Optioneel `openspec` als je via OpenSpec werkt.
+
+Voorbeeld via `gh`:
+
+```bash
+# Met prefix (lokale dev-run):
+gh issue edit <N> --repo ConductionNL/<app> --add-label "wilco-ready-to-build"
+
+# Of via de Hydra-helper (synct meteen het board):
+./scripts/hydra-label.sh ConductionNL/<app> <N> add ready-to-build
+```
+
+`scripts/hydra-label.sh` is de **voorkeursweg**: hij respecteert `HYDRA_LABEL_PREFIX` automatisch, gebruikt de label-helpers uit `scripts/lib/labels.sh`, en synct het bijbehorende GitHub Project-bord in real-time. Direct `gh issue edit --add-label` werkt ook, maar dan blijft het board "in de oude kolom" tot reconcile (om de 10 minuten) het opraapt.
+
+## Stap 8: volg de pijplijn
+
+Zodra de supervisor het issue ziet, gebeurt dit (geprefixed of niet, afhankelijk van je config):
+
+```
+ready-to-build → build:queued → build:running → build:pass
+              ↳ code-review:queued → :running → :pass / :fail
+              ↳ security-review:queued → :running → :pass / :fail
+              ↳ applier:queued → :running → :pass / :fail → done / needs-input
+```
+
+Je volgt het op drie plekken:
+
+1. **`logs/supervisor.log`** — wat de supervisor doet.
+2. **GitHub-issue** — labels veranderen automatisch.
+3. **GitHub PR** — pipeline-status-comment wordt elke fase bijgewerkt door `scripts/lib/pipeline-comment.sh`.
+
+Heb je `yolo` gezet en is alles groen? Dan zie je `done` op het issue verschijnen, een goedkeuring op de PR, en een auto-merge. Geen `yolo`? Dan staat de PR klaar voor een mens om te mergen.
+
+## Troubleshooting
+
+<Troubleshooting title="Eerste-run problemen">
+  <TroubleshootingItem symptom="Supervisor kiest standaard ghcr.io images terwijl ik lokaal heb gebouwd">
+    Controleer dat <code>secrets/.env</code> daadwerkelijk <code>HYDRA_IMAGE_PREFIX=localhost/hydra</code> en <code>HYDRA_IMAGE_TAG=test</code> bevat — en dat het bestand bestaat in <code>secrets/</code> en niet in je home-dir. De supervisor en orchestrate.sh sourcen <code>secrets/.env</code> via een vast pad relatief aan de repo-root.
+  </TroubleshootingItem>
+  <TroubleshootingItem symptom="Issue blijft op wilco-ready-to-build staan, supervisor pakt 'm niet op">
+    Heb je <code>./scripts/create-labels.sh --repo ... --prefix wilco</code> al gedraaid? Zonder de geprefixeerde labels op de doel-repo kan de supervisor wel polled, maar GitHub geeft geen matches terug. Verifieer met <code>gh label list --repo ConductionNL/&lt;app&gt; | grep wilco</code>.
+  </TroubleshootingItem>
+  <TroubleshootingItem symptom="Build start, geen image found error">
+    <code>docker images | grep hydra-builder</code>. Geen treffer? Bouw eerst de base image (<code>hydra-nextcloud-test</code>) en daarna pas de builder. De builder-Dockerfile heeft de base als <code>FROM</code>.
+  </TroubleshootingItem>
+  <TroubleshootingItem symptom="Issue gaat direct naar wilco-needs-input zonder dat ik iets zie">
+    Stale labels van een vorige run blijven hangen. Strip de oude stage-labels met <code>./scripts/hydra-label.sh ConductionNL/&lt;app&gt; &lt;N&gt; transition ready-to-build</code> — dat zet de issue terug in een definieerde startstate.
+  </TroubleshootingItem>
+  <TroubleshootingItem symptom="HYDRA_LABEL_PREFIX validatie faalt op startup">
+    Regex is <code>^[a-z0-9]([a-z0-9-]{0,14}[a-z0-9])?$</code>. Geen hoofdletters, geen leestekens, geen underscore, geen leading/trailing streepje. Max 16 tekens.
+  </TroubleshootingItem>
+</Troubleshooting>
+
+## Test jezelf
+
+Vier korte vragen om te checken of je dit deel begrepen hebt. Vastgelopen? Klik **Hint**. Curieus naar het antwoord? Klik **Antwoord**.
+
+<div className="tutorial-quiz">
+
+**1. Wat is het probleem dat `HYDRA_LABEL_PREFIX` oplost, en wanneer hoef je hem expliciet NIET te zetten?**
+
+<Details summary="Hint">
+
+Wat gebeurt er als twee Hydra-instances tegelijk dezelfde target-repo bekijken? En waarom is dat juist géén probleem in productie?
+
+</Details>
+
+<Details summary="Antwoord">
+
+**Probleem dat het oplost:** zodra meerdere devs lokaal tegelijk Hydra draaien tegen dezelfde target-repos zien hun supervisors elkaars labels en pakken elkaars werk op. Race-conditions, dubbele PRs, labels die over elkaar pingen. Met een eigen prefix (`wilco-build:queued`) heeft elke dev zijn eigen namespace.
+
+**Wanneer NIET zetten:**
+
+- **Productie / GitHub Actions / cron-managed deployment** — daar wil je juist de canonieke (kale) labels: één bron van waarheid, geen verdwaalde dev-prefix.
+- **Lokale solo-run** zonder collega's op dezelfde repos — werkt zonder ook; mag wel maar hoeft niet.
+
+</Details>
+
+</div>
+
+<div className="tutorial-quiz">
+
+**2. Welke labels worden door `HYDRA_LABEL_PREFIX` WEL en welke NIET geprefixed?**
+
+<Details summary="Hint">
+
+Wat Hydra zelf doorzet in zijn state-machine wordt geprefixed. Wat over het werk-zélf gaat (eigenschap van het issue, geen pipeline-state) wordt gedeeld.
+
+</Details>
+
+<Details summary="Antwoord">
+
+- **WEL geprefixed**: **stage-labels** (`ready-to-build`, `build:queued/running/pass/fail`, `code-review:*`, `security-review:*`, `applier:*`) en **herstel-labels** (`retry:queued`, `rebuild:queued`, `needs-input`). Allemaal labels die Hydra zelf beheert in de state-machine.
+- **NIET geprefixed**: **metadata** die over de aard van het werk gaat, niet over een Hydra-instance: **`yolo`** (mag auto-mergen) en **`openspec`** (volgt OpenSpec-werkmodel). Twee devs op één issue zijn het immers eens over of het een yolo-issue is — geen reden om dat per-dev op te splitsen.
+
+</Details>
+
+</div>
+
+<div className="tutorial-quiz">
+
+**3. Waarom roep je `./scripts/hydra-label.sh` aan in plaats van `gh issue edit --add-label` bij het triggeren van een run?**
+
+<Details summary="Hint">
+
+Twee dingen waar het script automatisch voor zorgt en de directe `gh`-aanroep niet.
+
+</Details>
+
+<Details summary="Antwoord">
+
+Twee redenen:
+
+1. **Respecteert `HYDRA_LABEL_PREFIX` automatisch** — je tikt `add ready-to-build`, het script maakt er `wilco-ready-to-build` van. Met `gh issue edit --add-label` moet je de prefix met de hand meetypen en bij elke verandering aanpassen — recipe voor typos en namespace-drift.
+2. **Synct het GitHub Project-bord direct.** `gh issue edit` werkt ook, maar het board blijft dan "in de oude kolom" tot `reconcile.sh` (om de 10 minuten) het opraapt. Met `hydra-label.sh` zie je de kolom-overgang meteen.
+
+</Details>
+
+</div>
+
+<div className="tutorial-quiz">
+
+**4. Wat gebeurt er als je `HYDRA_LABEL_PREFIX` wijzigt terwijl er nog een Hydra-run loopt? En wat is de juiste werkwijze als je toch wilt wijzigen?**
+
+<Details summary="Hint">
+
+De lopende run kijkt naar labels in de oude namespace, jouw nieuwe supervisor in een andere. Wat blijft er over?
+
+</Details>
+
+<Details summary="Antwoord">
+
+**Wat er gebeurt:** de lopende run kijkt naar labels in de oude namespace; jouw supervisor met nieuwe prefix kijkt naar een andere set. Lopend werk wordt door niemand meer opgepakt (orphaned), of erger — labels van beide namespaces komen op één issue terecht.
+
+**Juiste werkwijze:**
+
+1. Zet geen nieuw werk meer in de oude prefix.
+2. **Drain de pijplijn**: wacht tot alle issues met de oude prefix op `done` of `needs-input` staan.
+3. Pas dán `HYDRA_LABEL_PREFIX` aanpassen in `secrets/.env` en de supervisor herstarten.
+4. `./scripts/create-labels.sh --repo ... --prefix <nieuw>` om de nieuwe namespace op de doel-repo's te seeden.
+
+</Details>
+
+</div>
+
+<NextSteps title="Volgende stap" lede="Pijplijn loopt? Mooi. Maar wat doe je als het mis gaat? Deel 6 behandelt herstel- en escalatie-patronen.">
+  <NextStep
+    title="Deel 6 — Troubleshooting & escalatie"
+    href="/nl/academy/hydra-tutorial-6-troubleshooting-escalatie"
+    description="<code>needs-input</code>, <code>retry:queued</code>, <code>rebuild:queued</code>: welke kies je wanneer en wat kost het."
+  />
+  <NextStep
+    title="Vorige stap — Skills & commands"
+    href="/nl/academy/hydra-tutorial-4-skills"
+    description="Wat de personas tijdens hun werk gebruiken."
+  />
+  <NextStep
+    title="dev-run.md — operationele referentie"
+    href="https://github.com/ConductionNL/hydra/blob/main/docs/operations/dev-run.md"
+    description="De volledige operationele doc met alle dev-run-flags en label-prefix-uitleg."
+  />
+</NextSteps>

--- a/i18n/nl/docusaurus-plugin-content-blog/2026-05-12-hydra-tutorial-6-troubleshooting-escalatie/index.mdx
+++ b/i18n/nl/docusaurus-plugin-content-blog/2026-05-12-hydra-tutorial-6-troubleshooting-escalatie/index.mdx
@@ -1,0 +1,259 @@
+---
+slug: hydra-tutorial-6-troubleshooting-escalatie
+title: "Hydra leerlijn — Deel 6: Troubleshooting & escalatie"
+contentType: tutorial
+authors: [conduction]
+date: 2026-05-12
+summary: Wat te doen als de pijplijn vastloopt. Het keuzemenu tussen development-merge, label-reset, retry:queued, en rebuild:queued — geordend van goedkoop naar duur. Laatste van zes korte modules.
+tags: [Hydra, Troubleshooting, Recovery, Tutorial series]
+apps: []
+durationMinutes: 15
+series: hydra-tutorial
+partNumber: 6
+---
+
+import {Outcomes, Outcome, Prerequisites, PrerequisiteItem, NextSteps, NextStep, HexCard, Troubleshooting, TroubleshootingItem, ContactCta} from '@conduction/docusaurus-preset/components';
+import Details from '@theme/Details';
+
+In deel 5 stond de pijplijn. Nu het laatste deel: **wat doe je als hij niet groen wordt?** Dit deel geeft je de keuzeboom — geordend van goedkoopste interventie naar duurste — en de patronen waarmee je `needs-input`-issues weer in beweging krijgt.
+
+{/* truncate */}
+
+<Outcomes title="Wat je leert in dit deel">
+  <Outcome>De drie typische oorzaken van een vastgelopen pijplijn: stale dependencies, terechte review-findings, en fundamenteel verkeerde build-aanpak.</Outcome>
+  <Outcome>De interventie-ladder: development-merge → review-labels resetten → <code>retry:queued</code> → <code>rebuild:queued</code> → handmatige fix.</Outcome>
+  <Outcome>Waarom <code>needs-input</code> NIET hetzelfde is als "Hydra is kapot".</Outcome>
+  <Outcome>Waar je de retrospectives vindt en hoe je terugkerende patronen herkent.</Outcome>
+</Outcomes>
+
+<Prerequisites title="Wat je nodig hebt">
+  <PrerequisiteItem>Deel 1 t/m 5 doorgenomen.</PrerequisiteItem>
+  <PrerequisiteItem>Een mentaal model van het label-state-machine (uit deel 2).</PrerequisiteItem>
+</Prerequisites>
+
+## Wat betekent `needs-input`?
+
+`needs-input` is **geen failure-state in de zin van "Hydra heeft gefaald"**. Het is een expliciete escalatie: Hydra heeft gedaan wat hij kon, één run, en is tot een terminaal punt gekomen waar hij niet zelf verder kan zonder een menselijke beslissing.
+
+Mogelijke oorzaken:
+
+- Beide reviewers `pass` maar de quality-recheck na hun fixes is rood (een fix introduceerde een nieuwe overtreding).
+- Eén van beide reviews `:fail`.
+- Applier Axel Pliér `:fail`.
+- Build crashed mid-stage (container OOM, rate-limit op alle accounts, …).
+- Agent-maxed-out: een persona heeft zijn turn-budget opgemaakt.
+
+Je rol als mens: bepaal welke van de vier opties hieronder het meest passend is en pas die toe. **Niet** een nieuwe `retry:queued` blind plakken in de hoop dat het deze keer wel werkt.
+
+## De interventie-ladder
+
+| # | Situatie | Interventie | Kosten | Wat behoud je |
+|---|---|---|---|---|
+| 1 | Development is doorgegroeid, PR staat stale (nieuwe lint-rules, ADRs, fixtures op development) | <code>gh pr update-branch &lt;N&gt;</code> (of de cron pakt het op) | Gratis | Alle build/review/applier-werk. Alleen dependencies vernieuwen. |
+| 2 | Review-contracten zijn aangepast en je wilt reviewers opnieuw laten oordelen zonder rebuild | Reviewer-labels resetten: stage-labels strippen, <code>code-review:queued</code> opnieuw zetten. PR blijft. | 2× reviewer + applier | De builder-output. Alleen het review-deel rewindt. |
+| 3 | Reviewers/applier flagden concrete findings en de builder hoeft alleen even bij te schaven | <code>retry:queued</code> op het issue plakken | 1× builder + 2× reviewer + applier | Branch + PR blijven. Orchestrator bouwt <code>feedback.md</code> uit <code>hydra.json</code> (unfixed + applier-blockers + reeds gefixed) en dispatcht builder in <code>HYDRA_MODE=fix</code>. Single-shot — geen loop. |
+| 4 | Builder-output was fundamenteel verkeerd (verkeerde aanpak, stub-implementatie, fundamentele requirements gemist) | <code>rebuild:queued</code> op het issue plakken | Volledige cyclus | Orchestrator sluit de open PR, hard-reset <code>feature/&lt;issue&gt;/*</code> naar development, strip alle cycle-labels, zet <code>build:queued</code>. Volgende cyclus begint van scratch. |
+| 5 | Je hebt zelf de PR al gesloten en stale labels staan nog op het issue | Wachten op <code>reconcile.sh</code> (om de 10 min) | Volgende reconcile-run | <code>check_stage_without_open_pr</code> ziet de inconsistentie en zet automatisch <code>build:queued</code>. Self-healing. |
+| 6 | Pipeline-infra is stuk (container crash, alle tokens op, image niet vindbaar) | Escaleer naar mens (jij of een teamlead), los infra op, en kies pas DAN één van 1-4 hierboven | Tijd | — |
+
+**Volgorde:** altijd 1 → 2 → 3 → 4. Pak het goedkoopste herstel eerst. Reach voor `rebuild:queued` alleen als de build zelf fundamenteel verkeerd was.
+
+### `retry:queued` in detail
+
+1. Jij (of een automated rule) plakt `retry:queued` op het issue. Met label-prefix wordt dat `<prefix>-retry:queued` — `scripts/hydra-label.sh` regelt dat automatisch.
+2. Supervisor pakt het op als reguliere queue-job.
+3. Orchestrator vindt de open PR op `feature/<issue>/*`.
+4. Orchestrator cloned development, kopieert `openspec/changes/<slug>/hydra.json` en draait `scripts/lib/build-feedback-brief.py` → schrijft `feedback.md` met (a) applier-blockers, (b) unfixed reviewer-findings, (c) reeds-gefixed items, (d) Scope-lijst van alle geflagde files.
+5. Orchestrator flipped `retry:queued` → `retry:running`, dispatcht de builder met `HYDRA_MODE=fix` en `feedback.md` gemount op `/workspace/feedback.md`.
+6. Builder leest de brief, fixed álle bevindingen in één pass, beperkt zich tot Scope-files (plus nieuwe files die expliciet door een blocker geëist worden), commit met `fix (retry):` messages, pusht.
+7. Succes: orchestrator strip alle review/applier-labels + `retry:running` + `needs-input`, zet `code-review:queued`. Reviewers draaien opnieuw tegen de gefixede code.
+8. Faal: `retry:running` → `needs-input`, comment op het issue legt uit waarom en wijst naar `rebuild:queued` als de volgende hefboom.
+
+**Geen loop.** Eén `retry:queued` = één iteratie. Als de fix-builder pusht en de volgende review weer faalt, kun je opnieuw `retry:queued` aanvragen — maar dat is dan een **nieuwe** single-shot, niet een auto-retry.
+
+## Wanneer is het de gate, en wanneer is het de builder?
+
+Een terugkerende valkuil uit eigen retrospectives: het issue gaat 3 keer naar `needs-input` om dezelfde reden — typisch `spdx-headers: fail` of een gelijksoortige mechanische gate. Iedere `retry:queued` reproduceert hetzelfde patroon.
+
+In dat geval is een vierde retry **niet** de juiste move. Wees discplineerd:
+
+1. **Sanity-check de gate zelf.** Is dit een fout-positief? (Zie deel 3.) Een klassieker: een grep zonder word-boundary die meer matcht dan bedoeld. Fix in dat geval `scripts/run-quality.sh` of de gate-skill.
+2. **Hand-fix de mechanische overtreding.** Soms is het sneller om zelf de SPDX-headers toe te voegen, te committen op de feature branch en de reviewers opnieuw aan te roepen via label-reset (situatie 2 hierboven). Tijd: minuten.
+3. **Overweeg een sterkere agent.** Als hetzelfde klasse-fout op meerdere repos dezelfde "blind spot" vertoont, is dat een signaal dat de huidige builder-prompt of de mechanische gate niet voldoende is. Open een issue in `hydra/` om de gate aan te scherpen of een "housekeeping"-agent te bouwen.
+
+## Watch-list patronen
+
+Patronen die we al hebben gezien en die het waard zijn om eerst tegen je situatie te leggen:
+
+<HexCard title="spdx-headers + forbidden-patterns loop (2026-04-19)">
+  Op decidesk <a href="https://github.com/ConductionNL/decidesk/issues/44">#44</a>/<a href="https://github.com/ConductionNL/decidesk/issues/71">#71</a>/<a href="https://github.com/ConductionNL/decidesk/issues/72">#72</a> hetzelfde patroon: builder mist EUPL-1.2 header op nieuwe PHP-files, reviewer claimt 0 fixes nodig, recheck slaat rood. Forbidden-patterns bleek deels fout-positief (grep zonder word-boundary). Fix: handmatig SPDX toegevoegd + grep aangescherpt.
+</HexCard>
+
+<HexCard title="decidesk #44/#45 — gate-7 stub-method exploit (2026-04-23)">
+  Vijf onderscheiden pipeline-bugs in één retrospectief. Builder leverde op decidesk <a href="https://github.com/ConductionNL/decidesk/issues/44">#44</a>/<a href="https://github.com/ConductionNL/decidesk/issues/45">#45</a> een methode op met <code>return null;</code> + TODO; PHPCS slikte het; geen test; productie-bug. Resulteerde in <code>hydra-gate-stub-scan</code> + ADR-021 (bounded-fix scope op shape, niet op lijntelling). Volledige lessen in <a href="https://github.com/ConductionNL/hydra/blob/main/docs/retrospectives/decidesk-44-45-phase-g.md">decidesk-44-45-phase-g.md</a>.
+</HexCard>
+
+<HexCard title="134 duplicate needs-input comments overnight (2026-04-23)">
+  Completion-handler in een tight loop poste elke tick een nieuwe escalation-comment op een al-terminaal issue. Fix: terminal-state guard vóór alle side-effects (zie CLAUDE.md sectie "Terminal-state guards"). Als jij een issue ziet met &gt;3 identieke needs-input comments: open een infra-bug, niet een retry.
+</HexCard>
+
+## Diagnostics: waar kijk je?
+
+Snelle checklist als een issue naar `needs-input` gaat:
+
+```bash
+# 1. Welke labels staan er nu?
+gh issue view <N> --repo ConductionNL/<app> --json labels --jq '[.labels[].name]'
+
+# 2. Wat zegt hydra.json (mits aanwezig op de feature branch)?
+gh api repos/ConductionNL/<app>/contents/openspec/changes/<slug>/hydra.json?ref=feature/<N>/<slug> \
+    --jq '.content' | base64 -d | jq '.cycles[-1] | {outcome, outcome_reason, pattern_tags}'
+
+# 3. De supervisor-log van de relevante tijdspanne
+grep "issue/<N>" logs/supervisor.log | tail -50
+
+# 4. Pipeline-logs (per stage) op de feature branch
+gh api repos/ConductionNL/<app>/contents/openspec/changes/<slug>/pipeline-logs?ref=feature/<N>/<slug>
+```
+
+`hydra.json` is je belangrijkste bron. De `outcome_reason` en `pattern_tags` van de laatste cycle leggen meestal in één regel uit wat er misging.
+
+## Wanneer is "menselijk overnemen" gewoon goed?
+
+Niet elk `needs-input`-issue verdient een geautomatiseerd fix-pad. Soms is de meest pragmatische actie: **mens neemt over, los het op in een eigen commit op de feature branch, push, mark resolved**.
+
+Voorbeelden:
+
+- Een kleine semantische beslissing die de Builder niet kan maken zonder context buiten de change (bijv. "moet dit veld optional of required zijn?").
+- Een interactie met een externe partij (open ticket bij een leverancier).
+- Een gate die fout-positief is en een fix in `hydra/` zelf vereist (waarover je niet binnen één retry-cyclus uit bent).
+
+Hydra is een fabriek, geen ideologie. Pak de menselijke shortcut als die billijker is.
+
+## Test jezelf
+
+Vier korte vragen om te checken of je dit deel begrepen hebt. Vastgelopen? Klik **Hint**. Curieus naar het antwoord? Klik **Antwoord**.
+
+<div className="tutorial-quiz">
+
+**1. In welke volgorde probeer je de interventies in de ladder, en waarom?**
+
+<Details summary="Hint">
+
+Eén dimensie: kosten. De andere: hoeveel reeds-gedaan werk je verliest.
+
+</Details>
+
+<Details summary="Antwoord">
+
+Van **goedkoop naar duur**, met als doel zo veel mogelijk reeds-gedaan werk te behouden:
+
+1. **`gh pr update-branch`** — gratis. Alle build/review/applier-werk blijft staan, alleen dependencies vernieuwen.
+2. **Reviewer-labels resetten** — kost 2× reviewer + applier. Builder-output blijft.
+3. **`retry:queued`** — kost 1× builder + 2× reviewer + applier. Branch + PR blijven; builder fixed gescoped via `feedback.md`.
+4. **`rebuild:queued`** — volledige cyclus. PR sluit, branch reset, vanaf scratch.
+5. **Handmatige fix** — als de loop op een fout-positieve gate hangt of een mens een semantische beslissing moet maken.
+
+Reach voor `rebuild:queued` alleen als de oorspronkelijke build fundamenteel verkeerd was; anders verspil je goed werk.
+
+</Details>
+
+</div>
+
+<div className="tutorial-quiz">
+
+**2. Wat is het verschil tussen "Reviewer-labels resetten" en `retry:queued`?**
+
+<Details summary="Hint">
+
+De vraag is: **wordt de builder opnieuw aangeroepen, ja of nee?**
+
+</Details>
+
+<Details summary="Antwoord">
+
+- **Reviewer-labels resetten** (stage-labels strippen + `code-review:queued` opnieuw zetten): **de builder wordt NIET opnieuw aangeroepen**. PR + builder-output blijven exact zoals ze waren; alleen Juan en Clyde draaien opnieuw. Geschikt als de **review-contracten** zijn aangepast (nieuwe ADR, nieuwe gate-skill) en je wilt herbeoordelen zonder de code te veranderen.
+- **`retry:queued`**: **builder wordt wél opnieuw aangeroepen**, in `HYDRA_MODE=fix`, met `feedback.md` (uit `hydra.json`) als input. Hij maakt nieuwe commits, dan draaien reviewers opnieuw. Geschikt als reviewers **terechte findings** hadden en de builder alleen even moet bijschaven.
+
+</Details>
+
+</div>
+
+<div className="tutorial-quiz">
+
+**3. Wanneer is het zinvoller om met de hand de fix te maken in plaats van opnieuw `retry:queued`?**
+
+<Details summary="Hint">
+
+Als hetzelfde patroon zich herhaalt op dezelfde mechanische gate is meer geld erin gooien niet de oplossing.
+
+</Details>
+
+<Details summary="Antwoord">
+
+Als hetzelfde issue **3 keer of vaker** naar `needs-input` is gegaan om dezelfde reden — typisch een mechanische gate zoals `spdx-headers: fail`. Iedere `retry:queued` reproduceert hetzelfde patroon: builder maakt dezelfde fout, reviewer ziet het als boilerplate, recheck slaat rood.
+
+In dat geval:
+
+- Check eerst of het een **fout-positieve gate** is (zie deel 3). Zo ja: gate-detectie aanscherpen.
+- Zo nee: **fix het met de hand** (bijv. zelf SPDX-headers committen op de feature branch) en gebruik label-reset om de reviewers opnieuw te laten oordelen.
+
+Tijd: minuten. Goedkoper dan nog een Sonnet-cyclus verspillen aan iets wat steeds opnieuw fout gaat.
+
+</Details>
+
+</div>
+
+<div className="tutorial-quiz">
+
+**4. Wat doe je als je 3+ identieke `needs-input`-comments ziet binnen korte tijd?**
+
+<Details summary="Hint">
+
+Dit zegt iets over de pijplijn-zélf, niet over één issue. Welk soort fix is dat?
+
+</Details>
+
+<Details summary="Antwoord">
+
+**Dit is een infra-bug, geen retry-vraag.** Ergens in de completion-handler ontbreekt een terminal-state guard, waardoor een tight loop elke tick een nieuwe escalation-comment plaatst op een al-terminaal issue. Voorbeeld: 134 duplicate comments overnight op 23 april 2026 — fix was een terminal-state guard vóór alle side-effects (zie CLAUDE.md sectie "Terminal-state guards").
+
+**Wat doe je:** open een **infra-issue** in `hydra/`, niet een nieuwe `retry:queued`. Een retry doet niets met de comment-storm en kan zelfs meer chaos toevoegen.
+
+</Details>
+
+</div>
+
+<NextSteps title="Klaar — wat nu?" lede="Je hebt de hele leerlijn doorlopen. Wat is verstandig daarna?">
+  <NextStep
+    title="Vorige stap — Een Hydra-run starten"
+    href="/nl/academy/hydra-tutorial-5-een-hydra-run-starten"
+    description="Voor de praktische config en HYDRA_LABEL_PREFIX-uitleg."
+  />
+  <NextStep
+    title="OpenSpec-leerlijn"
+    href="/nl/academy/openspec-tutorial-1-wat-is-openspec"
+    description="De spec-first basis waar Hydra op draait. Nuttig als je nog niet helemaal vlot bent met proposal, change en spec-delta — termen die in elke retrospectief terugkomen."
+  />
+  <NextStep
+    title="Claude Skills-leerlijn"
+    href="/nl/academy/claude-skills-tutorial-1-wat-zijn-claude-skills"
+    description="Wil je een eigen skill toevoegen aan de Hydra-loop (een nieuwe quality gate, een team-skill voor je eigen app)? Hier leer je hoe."
+  />
+  <NextStep
+    title="Retrospectives"
+    href="https://github.com/ConductionNL/hydra/tree/main/docs/retrospectives"
+    description="Pak een retrospectief — bijvoorbeeld decidesk-44-45-phase-g — en herken de patronen die we hier behandelden."
+  />
+  <NextStep
+    title="Doe een peer review"
+    href="mailto:wilco@conduction.nl?subject=Hydra%20leerlijn%20-%20peer%20review"
+    description="Laat iemand uit het Hydra-team door je eerste eigen run lopen. Verplichte stap volgens het oorspronkelijke issue."
+  />
+</NextSteps>
+
+<ContactCta
+  title="Je hebt de Hydra-leerlijn afgerond"
+  body="Vragen, feedback, of suggesties voor uitbreiding? Laat het weten — deze leerlijn evolueert met ons begrip van de pijplijn."
+  cta={{ label: "Stuur feedback", href: "mailto:wilco@conduction.nl?subject=Hydra%20leerlijn%20feedback" }}
+/>

--- a/i18n/nl/docusaurus-plugin-content-blog/2026-05-12-openspec-tutorial-1-wat-is-openspec/index.mdx
+++ b/i18n/nl/docusaurus-plugin-content-blog/2026-05-12-openspec-tutorial-1-wat-is-openspec/index.mdx
@@ -1,0 +1,363 @@
+---
+slug: openspec-tutorial-1-wat-is-openspec
+title: "OpenSpec leerlijn — Deel 1: Wat is OpenSpec?"
+contentType: tutorial
+authors: [conduction]
+date: 2026-05-12
+summary: Een korte introductie op OpenSpec, het spec-first framework dat onder vrijwel al onze projecten draait. Wat een spec is, wat een change is, en waarom we dingen eerst opschrijven voor we ze bouwen. Eerste van twee korte modules.
+tags: [OpenSpec, Spec-first, Tutorial series, Documentation]
+apps: []
+durationMinutes: 12
+series: openspec-tutorial
+partNumber: 1
+---
+
+import {Outcomes, Outcome, Prerequisites, PrerequisiteItem, NextSteps, NextStep, HexCard, ContactCta} from '@conduction/docusaurus-preset/components';
+import Details from '@theme/Details';
+
+[OpenSpec](https://openspec.dev) is een lichtgewicht framework voor **spec-driven development**: eerst opschrijven wat een feature moet doen, dan pas code schrijven. In deze module van twaalf minuten leer je wat OpenSpec is, welke begrippen erin zitten, en waarom we het bij Conduction onder vrijwel elk project gebruiken. Aan het eind sta je klaar voor deel 2, waarin je je eerste change daadwerkelijk schrijft.
+
+{/* truncate */}
+
+<Outcomes title="Wat je leert in dit deel">
+  <Outcome>Wat OpenSpec is in één zin, en wat het verschil is met een losse README of een ticket.</Outcome>
+  <Outcome>De vier kernbegrippen: <strong>spec</strong>, <strong>requirement</strong>, <strong>scenario</strong> en <strong>change</strong> — en hoe ze samenhangen.</Outcome>
+  <Outcome>Waarom we spec-first werken, en wanneer dat zichzelf terugverdient.</Outcome>
+  <Outcome>Hoe een OpenSpec-project op schijf is opgebouwd, zodat je weet waar je moet kijken.</Outcome>
+</Outcomes>
+
+<Prerequisites title="Wat je nodig hebt">
+  <PrerequisiteItem>Basiskennis Git en Markdown. We schrijven specs in <code>.md</code>-bestanden die in je repo leven.</PrerequisiteItem>
+  <PrerequisiteItem>Een werkende ontwikkelmachine. Heb je die nog niet? Volg eerst <a href="/nl/academy/nextcloud-lokaal-draaien">Nextcloud lokaal draaien met Docker</a>.</PrerequisiteItem>
+  <PrerequisiteItem>Toegang tot een Conduction-project waarin je rondkijken kan — een willekeurige app zoals <a href="https://github.com/ConductionNL/openregister">openregister</a> of <a href="https://github.com/ConductionNL/opencatalogi">opencatalogi</a> volstaat.</PrerequisiteItem>
+</Prerequisites>
+
+## In één zin
+
+OpenSpec is een **lichtgewicht conventie voor het bijhouden van requirements naast je code**. De spec leeft in je repo, in Markdown, en evolueert per change in een nette spec-delta — net zoals je code evolueert per commit.
+
+Geen Confluence-pagina die uit sync raakt met de code. Geen Jira-ticket dat alleen jij begrijpt. Geen losse README waarin de echte regels verstopt zitten tussen voorbeelden. Eén plek voor het *wat*, één plek voor het *hoe*.
+
+## Waarom spec-first?
+
+In de praktijk gaat code schrijven sneller dan een spec bedenken. Dus waarom eerst die extra stap?
+
+1. **Aannames vroeg blootleggen.** Wat lijkt op één feature blijkt vaak vier features tegelijk. Door eerst de scenario's op te schrijven, ontdek je gaten en tegenstrijdigheden vóór de code geschreven is — niet erna in een PR-review.
+2. **AI-agenten productief maken.** Onze [Hydra-pipeline](/nl/academy/hydra-tutorial-1-wat-is-hydra) bouwt code uit specs. Hoe scherper de spec, hoe minder bijsturen achteraf. Dezelfde wet geldt voor je menselijke teamleden in een handover.
+3. **Een audit-trail die niet jokt.** Elke change zit in een eigen mapje met een proposal, een spec-delta, een design en een takenlijst. Een halfjaar later weet je nog precies wat er besloten is en waarom.
+4. **Reviewers één bron.** Reviewer ziet de spec-delta en de code naast elkaar. Klopt de code met de spec? Niet "wat had de ontwikkelaar bedoeld", maar "wat staat er".
+
+## De vier kernbegrippen
+
+OpenSpec rust op vier woorden die je terug zult zien in elk project. Een halfuur investeren in deze begrippen scheelt later veel verwarring.
+
+<HexCard title="Spec (capability)">
+  De stabiele beschrijving van een capability — een coherent stuk gedrag dat de app aanbiedt. Eén spec per capability. Lange leefduur.
+</HexCard>
+
+<HexCard title="Requirement">
+  Eén regel binnen een spec. Geschreven met <strong>MUST / SHOULD / MAY</strong> (RFC 2119). Genummerd als <code>REQ-001</code>, <code>REQ-002</code>, enzovoort.
+</HexCard>
+
+<HexCard title="Scenario">
+  Concreet voorbeeld bij een requirement, in <strong>GIVEN / WHEN / THEN</strong>-vorm. Toetsbaar, niet beschrijvend. Per requirement minstens één.
+</HexCard>
+
+<HexCard title="Change">
+  Eén verandering aan een of meer specs. Tijdelijk: begint als voorstel, eindigt gearchiveerd. Bevat een proposal, een spec-delta en een takenlijst.
+</HexCard>
+
+### Hoe ze samenhangen
+
+```
+openspec/
+├── specs/                          ← stabiel — capabilities
+│   └── publications/spec.md        ← bevat REQ-001, REQ-002, … en scenarios
+└── changes/                        ← tijdelijk — wijzigingen in flight
+    └── add-publication-search/
+        ├── proposal.md             ← waarom en wat
+        ├── specs/publications/     ← ADDED / MODIFIED / REMOVED requirements
+        │   └── spec.md
+        ├── design.md               ← hoe (technisch)
+        └── tasks.md                ← implementatie-checklist
+```
+
+Een **change** voegt requirements toe aan, wijzigt of verwijdert requirements uit een **spec**. Zolang de change open staat, leeft de delta in `changes/`. Bij archivering verhuist de delta naar de hoofd-spec en gaat het hele mapje naar `changes/archive/YYYY-MM-DD-<name>/`. Daarmee houd je een complete geschiedenis.
+
+## Een requirement in het wild
+
+Even concreet. Dit is een echte requirement zoals je ze in onze repos tegenkomt:
+
+```markdown
+### REQ-001: Volledige tekstzoekfunctie
+Het systeem MOET full-text zoeken ondersteunen over publicatie-titels
+en -inhoud met behulp van PostgreSQL's tsvector.
+
+#### Scenario: Zoekopdracht levert overeenkomende publicaties op
+- GIVEN publicaties met titels "Klimaatrapport 2026" en "Begrotingsoverzicht"
+- WHEN een gebruiker zoekt op "klimaat"
+- THEN MOETEN de resultaten "Klimaatrapport 2026" bevatten
+- AND MOGEN de resultaten "Begrotingsoverzicht" NIET bevatten
+- AND MOETEN de resultaten op relevantiescore gesorteerd zijn
+```
+
+Drie dingen om te zien:
+
+- **MOET** is geen stijlkeuze. RFC 2119 maakt onderscheid tussen MUST (absoluut), SHOULD (sterk aanbevolen, uitzonderingen mogelijk) en MAY (optioneel). Een reviewer leest dat woord en weet wat de bedoeling is.
+- Het **scenario** is concreet genoeg om een test uit te schrijven. Iemand anders zou hetzelfde gedrag moeten kunnen bouwen zonder met je te overleggen.
+- **Implementatie-vrij.** Geen klassennamen, geen controllers, geen tabelnamen. Die horen in `design.md`, niet hier. De spec beschrijft *gedrag*, niet *implementatie*.
+
+## Spec versus README versus issue
+
+Een veel gestelde vraag bij nieuwe mensen: "wat schrijf ik dan nog in de README, en wat in een issue?" Eenvoudige vuistregel:
+
+| Document | Bevat | Lezer | Updatefrequentie |
+| --- | --- | --- | --- |
+| **`openspec/specs/`** | Het *wat* — requirements en scenario's. Stabiel gedrag van de app. | Reviewers, AI-agenten, latere developers | Per change |
+| **`openspec/changes/`** | Een *verandering* — voorstel, delta, design en tasks van één in-flight change. | Reviewers tijdens de PR | Eénmalig per change |
+| **`README.md`** | Hoe zet je de app op. Hoe draai je hem. Hoe lever je iets aan. | Nieuwe developers, eerste sessie | Bij doorbroken setup-stap |
+| **GitHub Issue** | Eén concrete taak — gekoppeld aan een change. Status, blocker, discussie. | Wie de taak oppakt | Continu tijdens het werk |
+
+De gulden regel: **gedrag van de app hoort in de spec**. Als je merkt dat je hetzelfde uitlegt in een ticket, een Slack-bericht en de PR-beschrijving, mis je vermoedelijk een spec.
+
+## Wanneer geen OpenSpec?
+
+Spec-first is geen religie. Twee situaties waarin we het overslaan:
+
+- **Een eenmalige tweak** — typo's, één rij toevoegen aan een vertaalbestand, een dependency bumpen. Spec-overhead is hier groter dan de tweak zelf.
+- **Een exploratief prototype** — als je nog niet weet of het idee überhaupt werkt. Toets je aannames eerst met een wegwerp-prototype; schrijf pas daarna de spec voor de versie die wél in productie gaat.
+
+Voor alles daartussen — een nieuwe feature, een breaking change, een refactor met gevolgen voor consumers — loont OpenSpec zich.
+
+## Hoe ziet een Conduction-repo eruit?
+
+Onze projecten hebben allemaal dezelfde OpenSpec-mappenstructuur. Eén keer kijken in [openregister/openspec](https://github.com/ConductionNL/openregister/tree/development/openspec) geeft je een goed beeld:
+
+- `openspec/specs/` — de capabilities van deze app, één map per domein
+- `openspec/changes/` — de in-flight changes (vaak één per open PR)
+- `openspec/changes/archive/` — afgeronde changes, met datum vooraan, voor de geschiedenis
+- `openspec/architecture/` — **app-specifieke** ADR's (architecturele besluiten die alleen voor deze app gelden)
+- `openspec/config.yaml` — project-config (verwijst naar het gedeelde Conduction-schema)
+- `project.md` — high-level beschrijving van de app, in de **root** van de repo (niet in `openspec/`)
+
+**Bedrijfsbrede** ADR's leven niet in elke app, maar in [hydra/openspec/architecture](https://github.com/ConductionNL/hydra/tree/main/openspec/architecture). Bouw je in een app van Conduction? Dan gelden die ADR's ook voor jou — de Hydra-pipeline laadt ze mee in elke build. Vuistregel: alleen iets wat écht uniek is voor deze app gaat in `openspec/architecture/`; al het andere hoort bedrijfsbreed in `hydra/openspec/architecture/`.
+
+## Wie schrijft de specs?
+
+Twee patronen, naast elkaar:
+
+1. **Handmatig door een developer of architect** — met [`/opsx-new`](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md#opsx-new) om de change-map aan te maken, gevolgd door [`/opsx-ff`](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md#opsx-ff) (alles in één run) of [`/opsx-continue`](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md#opsx-continue) (artefact voor artefact) in Claude Code. Dat is wat je in deel 2 gaat doen.
+2. **Retrofit op een bestaande app** — voor legacy-code die er was vóór OpenSpec. Zie [retrofit.md](https://github.com/ConductionNL/.github/blob/main/docs/claude/retrofit.md). Niet je eerste klus.
+
+Welke route ook gebruikt wordt, het eindresultaat ziet er identiek uit: een nette change in `openspec/changes/` met de vier verwachte artefacten.
+
+## De OpenSpec-pipeline in één oogopslag
+
+Een volledige change loopt door vier stages, met een eigen `/opsx-`-commando per stap. Bron: [spec-driven-development.md](https://github.com/ConductionNL/.github/blob/main/docs/WayOfWork/spec-driven-development.md).
+
+| Stage | Commando | Wat doet het |
+| --- | --- | --- |
+| **Obtain** | [`/opsx-explore`](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md#opsx-explore) | Verken een topic of probleem voor je een change start (optioneel) |
+| **Specify** | [`/opsx-new`](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md#opsx-new) | Lege change met metadata aanmaken |
+| | [`/opsx-ff`](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md#opsx-ff) | Fast-forward: proposal + specs + design + tasks in één run |
+| | [`/opsx-continue`](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md#opsx-continue) | Per-artefact opbouwen i.p.v. alles in één keer |
+| | [`/opsx-plan-to-issues`](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md) | Tasks → tracking-issue + één GitHub-issue per task |
+| **Build** | [`/opsx-apply`](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md#opsx-apply) | Implementeer de tasks, één voor één, tegen de spec |
+| **Validate** | [`/opsx-verify`](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md#opsx-verify) | Check dat de code de spec ook echt levert |
+| **Done** | [`/opsx-archive`](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md#opsx-archive) | Spec-delta → hoofd-spec; change → `archive/` |
+| | [`/opsx-sync`](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md#opsx-sync) | Alleen de delta in de hoofd-spec mergen (zonder archiveren). `/opsx-archive` doet dit ook — sync apart is voor als je de spec eerder wilt bijwerken dan de change afsluiten. |
+
+**De gulden vuistregel uit de Conduction-docs**: *de meeste changes hebben alleen `/opsx-ff` → `/opsx-apply` → `/opsx-verify` nodig*. De rest is opt-in. Volledig automatisch werken kan ook — zie [`/opsx-apply-loop`](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md#opsx-apply-loop) (één change, containerized) en [`/opsx-pipeline`](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md#opsx-pipeline) (meerdere changes parallel).
+
+### Visueel — de pipeline van begin tot eind
+
+```text
+                ┌─────────────────┐
+                │  /opsx-explore  │   (optioneel — verkennen, geen artefacten)
+                └────────┬────────┘
+                         │
+                         ▼
+                ┌─────────────────┐
+                │  /opsx-new      │   start de change (alleen metadata)
+                └────────┬────────┘
+                         │
+                         ▼
+        ┌────────────────────────────────────┐
+        │  /opsx-ff        OF  /opsx-continue│
+        │  (alles in één)       (per stap)   │   artefacten genereren:
+        │                                    │   proposal → specs → design → tasks
+        └────────────────┬───────────────────┘
+                         │
+                         ▼
+                ┌─────────────────────────┐
+                │ openspec validate       │   spec-syntax check (CLI, geen slash)
+                │   --strict              │
+                └────────────┬────────────┘
+                             │
+                             ▼              ── PR voor de spec (review op specs, niet op code) ──
+                             │
+                             ▼
+                ┌─────────────────────────┐
+                │ /opsx-plan-to-issues    │   tasks → GitHub issues + tracking-epic
+                └────────────┬────────────┘
+                             │
+                             ▼
+                ┌─────────────────────────┐
+                │ /opsx-apply             │   implementeren (per task: backend + UI + tests)
+                └────────────┬────────────┘
+                             │
+                             ▼
+                ┌─────────────────────────┐
+                │ /opsx-verify            │   code-vs-spec check (CRITICAL/WARNING/SUGGESTION)
+                └────────────┬────────────┘
+                             │
+                             ▼
+                ┌─────────────────────────┐
+                │ /opsx-archive           │   sync delta → hoofd-spec, change → archive/
+                └─────────────────────────┘
+```
+
+Deel 2 van deze leerlijn loopt door deze pipeline heen, beginnend bij `/opsx-explore` (optioneel) en eindigend bij `/opsx-archive`.
+
+## Test jezelf
+
+Vijf korte vragen om te checken of je dit deel begrepen hebt. Vastgelopen? Klik **Hint**. Curieus naar het antwoord? Klik **Antwoord**.
+
+<div className="tutorial-quiz">
+
+**1. Wat is het kernverschil tussen een spec en een change?**
+
+<Details summary="Hint">
+
+Eén leeft jaren mee, de ander leeft van voorstel tot merge. Waar staat elk in het repo?
+
+</Details>
+
+<Details summary="Antwoord">
+
+- **Spec** beschrijft een stabiele capability — een coherent stuk gedrag van de app. Lange leefduur, één spec per capability. Alle requirements + scenarios staan erin. Leeft in `openspec/specs/<capability>/spec.md`.
+- **Change** is een tijdelijke verandering aan één of meer specs. Bevat een proposal, spec-delta (ADDED/MODIFIED/REMOVED), design en tasks. Leeft in `openspec/changes/<naam>/` zolang hij open staat, en verhuist bij archivering naar `openspec/changes/archive/YYYY-MM-DD-<naam>/`.
+
+Een spec leeft jaren mee; een change leeft van voorstel tot merge en wordt daarna geschiedenis.
+
+</Details>
+
+</div>
+
+<div className="tutorial-quiz">
+
+**2. Waarom schrijven we eerst een spec-delta voordat we code aanpassen?**
+
+<Details summary="Hint">
+
+Denk aan: aannames, AI-agenten, audit-trail, en reviewers. Welke winst pakt elk?
+
+</Details>
+
+<Details summary="Antwoord">
+
+Vier voordelen die in deze module worden genoemd:
+
+- **Aannames vroeg blootleggen.** Wat lijkt op één feature blijkt vaak vier features tegelijk. Scenario's schrijven brengt gaten en tegenstrijdigheden naar boven vóór de code in plaats van erna in een PR-review.
+- **AI-agenten productief maken.** Onze Hydra-pipeline bouwt code uit specs — hoe scherper de spec, hoe minder bijsturen achteraf. Dezelfde wet geldt voor menselijke teamleden in een handover.
+- **Audit-trail die niet jokt.** Per change één mapje met proposal, delta, design, tasks. Een halfjaar later weet je nog precies wat besloten is en waarom.
+- **Reviewers één bron.** De reviewer ziet spec-delta en code naast elkaar — "klopt de code met de spec" in plaats van "wat had de ontwikkelaar bedoeld".
+
+</Details>
+
+</div>
+
+<div className="tutorial-quiz">
+
+**3. Wat zijn de drie bouwstenen waarmee je in OpenSpec gedrag beschrijft, en welke functie heeft een scenario?**
+
+<Details summary="Hint">
+
+Top-down: van capability, naar regel, naar concreet voorbeeld. De laatste maakt de regel _toetsbaar_.
+
+</Details>
+
+<Details summary="Antwoord">
+
+De drie bouwstenen (top-down):
+
+- **Spec** — de stabiele capability-beschrijving, top niveau.
+- **Requirement** — één regel binnen een spec, geschreven met **MUST / SHOULD / MAY** (RFC 2119). Genummerd: `REQ-001`, `REQ-002`, …
+- **Scenario** — concreet **GIVEN / WHEN / THEN**-voorbeeld bij een requirement. Per requirement minstens één.
+
+Het scenario maakt de requirement **toetsbaar**: iemand anders zou hetzelfde gedrag moeten kunnen bouwen of testen zonder met je te overleggen. Geen beschrijving, maar een toets.
+
+</Details>
+
+</div>
+
+<div className="tutorial-quiz">
+
+**4. Waar staan de in-flight changes in een Conduction-project, en wat gebeurt er met een change als hij klaar is?**
+
+<Details summary="Hint">
+
+Twee mappen: één voor lopend werk, één voor afgeronde geschiedenis. En wat verhuist er waarheen?
+
+</Details>
+
+<Details summary="Antwoord">
+
+- **In-flight changes** staan in `openspec/changes/<naam>/` — proposal, spec-delta in `specs/`, design en tasks.
+- **Bij archivering** (na implementatie + merge naar `development`) gebeurt drie dingen:
+  1. De spec-delta wordt gesynct naar de hoofd-spec in `openspec/specs/`.
+  2. Het hele change-mapje verhuist naar `openspec/changes/archive/YYYY-MM-DD-<naam>/`.
+  3. De geschiedenis blijft compleet — je kunt teruglezen welke change wélke regel introduceerde.
+
+Stap 1 en 2 doe je niet handmatig — `/opsx-archive` (deel 2) regelt het.
+
+</Details>
+
+</div>
+
+<div className="tutorial-quiz">
+
+**5. Noem een situatie waarin je OpenSpec juist NIET inzet en gewoon direct codeert.**
+
+<Details summary="Hint">
+
+De overhead moet kleiner zijn dan de winst. Bij welke twee situaties is dat duidelijk niet zo?
+
+</Details>
+
+<Details summary="Antwoord">
+
+Twee situaties uit de module:
+
+- **Eenmalige tweak** — typo's, één rij toevoegen aan een vertaalbestand, een dependency bumpen. De spec-overhead is groter dan de tweak zelf.
+- **Exploratief prototype** — als je nog niet weet of het idee überhaupt werkt. Toets je aannames eerst met een wegwerp-prototype; schrijf pas daarna de spec voor de versie die wél in productie gaat.
+
+Voor alles daartussen — een nieuwe feature, een breaking change, een refactor met gevolgen voor consumers — loont OpenSpec zich wel.
+
+</Details>
+
+</div>
+
+<NextSteps title="Volgende stap" lede="Nu je de begrippen kent, schrijven we in deel 2 een echte change van begin tot eind.">
+  <NextStep
+    title="Deel 2 — Je eerste OpenSpec change"
+    href="/nl/academy/openspec-tutorial-2-eerste-change"
+    description="Maak een change met /opsx-new, schrijf een spec-delta met requirements en scenarios, genereer een takenlijst, en valideer het geheel."
+  />
+  <NextStep
+    title="De Hydra-leerlijn"
+    href="/nl/academy/hydra-tutorial-1-wat-is-hydra"
+    description="Wil je zien hoe onze AI-pipeline van een OpenSpec change naar code komt? Lees hoe Hydra die overdracht automatiseert."
+  />
+  <NextStep
+    title="OpenSpec officieel"
+    href="https://openspec.dev"
+    description="De officiële OpenSpec-website met de bron-conventie waar wij op voortbouwen."
+  />
+</NextSteps>
+
+<ContactCta
+  title="Vragen over OpenSpec?"
+  body="Spreek je teamlead of buddy aan, of stel je vraag in #openspec op Slack. Issues op deze tutorial graag op het bijbehorende GitHub-issue."
+  cta={{ label: "Mail ons", href: "mailto:info@conduction.nl?subject=OpenSpec%20leerlijn%20deel%201" }}
+/>

--- a/i18n/nl/docusaurus-plugin-content-blog/2026-05-12-openspec-tutorial-2-eerste-change/index.mdx
+++ b/i18n/nl/docusaurus-plugin-content-blog/2026-05-12-openspec-tutorial-2-eerste-change/index.mdx
@@ -1,0 +1,508 @@
+---
+slug: openspec-tutorial-2-eerste-change
+title: "OpenSpec leerlijn — Deel 2: Je eerste OpenSpec change"
+contentType: tutorial
+authors: [conduction]
+date: 2026-05-12
+summary: Van leeg mapje naar gevalideerde OpenSpec change. We starten met /opsx-new, schrijven een spec-delta met een requirement plus scenario, laten /opsx-ff de rest genereren, en valideren het geheel. Tweede van twee korte modules.
+tags: [OpenSpec, Spec-first, Tutorial series, Workflow, Claude Code]
+apps: []
+durationMinutes: 22
+series: openspec-tutorial
+partNumber: 2
+---
+
+import {Outcomes, Outcome, Prerequisites, PrerequisiteItem, Troubleshooting, TroubleshootingItem, NextSteps, NextStep, ContactCta} from '@conduction/docusaurus-preset/components';
+import Details from '@theme/Details';
+
+Tijd om OpenSpec aan het werk te zien. In dit deel maak je in een Conduction-project je **eerste echte change** — van leeg mapje, via een spec-delta met requirement en scenario, naar een gevalideerd voorstel klaar voor implementatie. We doen dat met de Claude Code-skills [`/opsx-new`](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md) en [`/opsx-ff`](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md).
+
+{/* truncate */}
+
+<Outcomes title="Wat je gaat opleveren">
+  <Outcome>Begrip van waar <code>/opsx-explore</code> in de pipeline zit en wanneer je hem inzet (optionele voorverkenning).</Outcome>
+  <Outcome>Een werkende change in <code>openspec/changes/&lt;naam&gt;/</code>, op een eigen feature-branch.</Outcome>
+  <Outcome>Alle vier de artefacten — proposal, spec-delta, design, tasks — in de juiste afhankelijkheidsvolgorde, handmatig én via <code>/opsx-ff</code>.</Outcome>
+  <Outcome>Een gevalideerde spec-delta die door <code>openspec validate --strict</code> heen komt en klaar is om als PR open te zetten.</Outcome>
+  <Outcome>Een overzicht van wat er na de spec gebeurt: <code>/opsx-plan-to-issues</code>, <code>/opsx-apply</code> (implementeren), <code>/opsx-verify</code> (review) en <code>/opsx-archive</code>.</Outcome>
+</Outcomes>
+
+<Prerequisites title="Wat je nodig hebt">
+  <PrerequisiteItem>Deel 1 doorgelezen — <a href="/nl/academy/openspec-tutorial-1-wat-is-openspec">Wat is OpenSpec?</a> — zodat je weet wat een spec, requirement, scenario en change zijn.</PrerequisiteItem>
+  <PrerequisiteItem>Claude Code geïnstalleerd en werkend in je projectmap. Heb je dat nog niet, volg dan eerst <a href="/nl/academy/build-an-app">Build an App</a>.</PrerequisiteItem>
+  <PrerequisiteItem>Een ge-checkoute Conduction-repo waarin je rondkijken kan — bijvoorbeeld <a href="https://github.com/ConductionNL/openregister">openregister</a>. We werken in een nieuwe branch, dus je raakt niets bestaands kwijt.</PrerequisiteItem>
+  <PrerequisiteItem>Basiskennis Git: branch aanmaken, committen, pushen.</PrerequisiteItem>
+</Prerequisites>
+
+## Het voorbeeld waar we mee werken
+
+Om het concreet te houden voegen we één feature toe aan een denkbeeldig publicatie-register: **een full-text zoekfunctie over publicatie-titels en -inhoud**. Klein genoeg om in één tutorial te doen, groot genoeg om alle artefacten te raken.
+
+Werk je in een eigen repo? Vervang dan in elke stap "publication-search" door je eigen change-naam. De stappen veranderen niet.
+
+## Stap 0: verkennen met `/opsx-explore` (optioneel)
+
+Weet je al precies wat je wil bouwen? Sla deze stap over en ga direct naar Stap 1. Twijfel je over scope, aanpak of of de feature überhaupt thuishoort in deze app? Dan begin je met:
+
+```
+/opsx-explore
+```
+
+`/opsx-explore` is de **Pre-spec-fase** uit de [commando-referentie](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md#opsx-explore): het maakt **geen artefacten aan**, het denkt met je mee. Claude verkent de codebase, stelt vragen over je intentie, weegt alternatieve aanpakken tegen elkaar af, en geeft aan welke onbekenden er nog liggen. Het is een gesprek — geen bestand op schijf.
+
+Goede momenten om `/opsx-explore` te gebruiken:
+
+- *"Past dit in deze app, of is het een aparte capability?"*
+- *"Welke bestaande spec raakt dit?"*
+- *"Wat is de eenvoudigste manier om dit te bouwen?"*
+
+Niet voor `/opsx-explore`: een feature die je al twee keer eerder hebt gebouwd in een andere app. Dan kun je direct door naar `/opsx-new`.
+
+> **Voor de tutorial.** Het voorbeeld `add-publication-search` is bewust simpel — we slaan `/opsx-explore` over. Onthoud hem voor je eigen, complexere changes.
+
+## Stap 1: een eigen branch
+
+Een change zit altijd op zijn eigen feature-branch. Niet werken op `development` direct:
+
+```bash
+cd /pad/naar/openregister
+git checkout development
+git pull
+git checkout -b feature/add-publication-search
+```
+
+De branch-naam volgt het patroon `feature/<change-name>` — handig voor reviewers om te zien waar de spec bij hoort. In de volledig geautomatiseerde [Hydra-flow](https://github.com/ConductionNL/.github/blob/main/docs/hydra/README.md) wordt dat `feature/<issue-number>/<change-name>` zodra `/opsx-plan-to-issues` (Stap 10) een tracking-issue heeft aangemaakt. Voor deze tutorial pakken we het korte patroon.
+
+## Stap 2: een lege change met `/opsx-new`
+
+Open Claude Code in de repo-map en draai:
+
+```
+/opsx-new add-publication-search
+```
+
+Dat maakt het skelet aan:
+
+```
+openspec/changes/add-publication-search/
+└── .openspec.yaml
+```
+
+`.openspec.yaml` bevat de metadata (schema-versie, aanmaakdatum). Verder is het mapje leeg — dat vullen we hierna.
+
+> **Naamgevingsregel.** Gebruik kebab-case (`add-publication-search`, niet `AddPublicationSearch` of `add_publication_search`). De change-naam wordt een GitHub-issue label, dus houd hem leesbaar en kort.
+
+## Stap 3: de twee routes — `/opsx-ff` versus handmatig
+
+Vanaf hier zijn er twee manieren om de change te vullen:
+
+| Route | Wanneer | Wat doet het |
+| --- | --- | --- |
+| **Geautomatiseerd** — `/opsx-ff` | Je weet wat je wil bouwen en wil snel een complete eerste versie. | Genereert in één run proposal, specs, design en tasks — in deze afhankelijkheidsvolgorde. Daarna lees je terug en stuur je bij. |
+| **Stapsgewijs** — handmatig of `/opsx-continue` | Je wil per artefact even nadenken voor je verder gaat. | Je schrijft (of laat genereren) eerst de proposal, dan de spec-delta, dan design, en pas dan de tasks. |
+
+In productie pak je vaak `/opsx-ff` voor een ruwe schets en stuur je daarna bij — dat is **het canonical pad** uit de Conduction-docs (`/opsx-ff` → `/opsx-apply` → `/opsx-verify`). In deze tutorial doen we het stap-voor-stap handmatig — dat geeft het meeste begrip van wat elk artefact eigenlijk is. Bij stap 7 laten we zien wat `/opsx-ff` in één keer voor je zou doen.
+
+> **Afhankelijkheidsvolgorde uit de [commando-referentie](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md#opsx-continue):** `proposal` (root) → `specs` + `design` (beide hangen af van proposal) → `tasks` (hangt af van specs én design). We volgen die volgorde hieronder.
+
+## Stap 4: `proposal.md` — het waarom en wat
+
+Het eerste artefact is het **proposal**: waarom doe je deze change, en wat verandert er op hoog niveau? In mensentaal, voor reviewers die de feature nog niet kennen.
+
+Maak `openspec/changes/add-publication-search/proposal.md`:
+
+```markdown
+# Proposal: add-publication-search
+
+## Why
+Gebruikers van het publicatie-register kunnen vandaag alleen op exacte
+publicatie-ID zoeken. Een zoekfunctie over titels en inhoud is de
+meest gevraagde feature in support-tickets van de afgelopen maand.
+
+## What
+- Full-text zoekfunctie via PostgreSQL `tsvector`
+- Eén nieuw API-endpoint: `GET /api/publications/search?q=...`
+- Resultaten gesorteerd op relevantiescore
+
+## Out of scope
+- Filters (per organisatie, periode, status)
+- Suggesties / autocomplete
+- Geavanceerde queries (AND/OR, wildcards)
+```
+
+Het proposal staat aan de top van de afhankelijkheidsketen — alle andere artefacten verwijzen er impliciet naar terug. Houd hem daarom kort en helder; details horen in `design.md` (stap 6), niet hier.
+
+## Stap 5: de spec-delta — het hart van de change
+
+De **spec-delta** is het centrale artefact. Het is geen volledige spec; het is alleen wat er verandert ten opzichte van de hoofd-spec. Drie soorten wijzigingen:
+
+- **ADDED** — nieuwe requirements
+- **MODIFIED** — bestaande requirements die anders worden
+- **REMOVED** — requirements die vervallen
+
+We voegen een requirement toe aan de hypothetische `publications`-capability. Maak het bestand aan:
+
+```
+openspec/changes/add-publication-search/specs/publications/spec.md
+```
+
+En vul met:
+
+```markdown
+# publications — Delta
+
+## ADDED Requirements
+
+### REQ-001: Volledige tekstzoekfunctie
+Het systeem MOET full-text zoeken ondersteunen over publicatie-titels en
+publicatie-inhoud met behulp van PostgreSQL's `tsvector`.
+
+#### Scenario: Zoekopdracht levert overeenkomende publicaties op
+- GIVEN publicaties met titels "Klimaatrapport 2026" en "Begrotingsoverzicht 2026"
+- WHEN een gebruiker zoekt op "klimaat"
+- THEN MOETEN de resultaten "Klimaatrapport 2026" bevatten
+- AND MOGEN de resultaten "Begrotingsoverzicht 2026" NIET bevatten
+- AND MOETEN de resultaten op relevantiescore gesorteerd zijn
+
+#### Scenario: Lege zoekopdracht geeft een nette fout
+- GIVEN een gebruiker op de zoekpagina
+- WHEN de zoekopdracht leeg is
+- THEN MOET het systeem HTTP 400 retourneren
+- AND MOET het antwoord de fout `query parameter required` bevatten
+```
+
+Drie dingen die hier mis kunnen gaan:
+
+- **Vier hashtags voor een scenario.** `#### Scenario:` (vier), niet `###` (drie). De parser herkent `###` niet als scenario — geen foutmelding, gewoon stilzwijgend overgeslagen.
+- **MOET / MAG / KAN.** Gebruik [RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119)-woorden bewust. Een reviewer leest "MAG" en weet dat het optioneel is.
+- **Geen implementatie noemen.** Geen klassen, controllers of tabel-namen. Die horen in `design.md` (stap 6). De spec beschrijft *gedrag*.
+
+## Stap 6: `design.md` en `tasks.md`
+
+Met proposal en spec-delta op orde zijn de laatste twee artefacten kort werk.
+
+**`design.md`** — het *hoe*, technisch. Hier wél klassen, tabellen en controllers — alles wat in de spec niet thuishoort:
+
+````markdown
+# Design: add-publication-search
+
+## Approach
+We gebruiken PostgreSQL's native `tsvector` en `tsquery`, geen
+externe zoekmachine. Volstaat voor de huidige hoeveelheid publicaties
+(< 100k rijen) en houdt de stack simpel.
+
+## Schema-wijziging
+Een gegenereerde kolom `search_vector` op tabel `publications`:
+
+```sql
+ALTER TABLE publications
+  ADD COLUMN search_vector tsvector
+  GENERATED ALWAYS AS (
+    setweight(to_tsvector('dutch', coalesce(title, '')), 'A') ||
+    setweight(to_tsvector('dutch', coalesce(content, '')), 'B')
+  ) STORED;
+
+CREATE INDEX idx_publications_search ON publications USING GIN (search_vector);
+```
+
+## Endpoint
+Nieuw: `GET /api/publications/search`
+- Query parameter: `q` (verplicht, niet leeg)
+- Antwoord: gepagineerde lijst, gesorteerd op `ts_rank`
+````
+
+**`tasks.md`** — de implementatie-checklist. Komt als laatste want hangt af van zowel de spec als het design:
+
+```markdown
+# Tasks: add-publication-search
+
+- [ ] Task 1 — Migratie: `search_vector` kolom + GIN-index op `publications`
+- [ ] Task 2 — Backend: nieuwe `SearchController::search()` met `tsquery`-vertaling
+- [ ] Task 3 — Backend: 400 bij lege of ontbrekende `q`
+- [ ] Task 4 — Tests: PHPUnit voor beide scenario's uit REQ-001
+- [ ] Task 5 — API-documentatie: endpoint opgenomen in OpenAPI-spec
+- [ ] Task 6 — README-update: vermelden in feature-lijst
+```
+
+Tasks zijn klein en concreet — 15-30 minuten werk per task. Te grote tasks zijn een teken dat je ze nog moet opsplitsen. Goede taskbreakdown bepaalt direct hoe soepel `/opsx-apply` (stap 10) straks door je change loopt.
+
+> **Optionele extra artefacten.** Naast de vier vaste artefacten heeft OpenSpec een paar optionele: `discovery.md` (open vragen die je tijdens onderzoek aantrof), `contract.md` (cross-project API-contracten), `migration.md` (data-migratie tussen schema-versies), en `test-plan.md` (test-classificatie voor `/opsx-apply-loop`). Voor een eerste change heb je ze meestal niet nodig — zie de [commando-referentie](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md#opsx-continue) voor de volledige dependency-chain.
+
+## Stap 7: of in één klap met `/opsx-ff`
+
+Voor wie liever met één commando begint: nadat je `/opsx-new add-publication-search` hebt gedraaid, kun je ook gewoon zeggen:
+
+```
+/opsx-ff
+```
+
+Claude Code stelt eerst een paar vragen ("wat moet de change doen?", "welk model wil je gebruiken?") en genereert dan in één run de proposal, de specs/, de design en de tasks — in **diezelfde afhankelijkheidsvolgorde** die we hierboven handmatig hebben afgelopen. Snel, en in onze ervaring goed genoeg om vanaf daar bij te sturen.
+
+Wanneer wel `/opsx-ff`: voor changes waarvan je het beeld al helder hebt en je vooral typewerk wil uitsparen. Per [`spec-driven-development.md`](https://github.com/ConductionNL/.github/blob/main/docs/WayOfWork/spec-driven-development.md) is **`/opsx-ff` → `/opsx-apply` → `/opsx-verify`** het canonical pad voor de meeste changes.
+
+Wanneer juist niet: bij architecturale keuzes waar je per stap wil mee-denken — dan loont [`/opsx-continue`](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md#opsx-continue) zich (genereert telkens het volgende artefact na review en eventuele aanpassing). Of, voor de brainstorm vooraf, [`/opsx-explore`](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md#opsx-explore) (zie Stap 0) — die maakt nog niets aan, maar denkt mee.
+
+## Stap 8: valideren
+
+Op spec-niveau draai je de OpenSpec-CLI:
+
+```bash
+openspec validate --strict
+```
+
+Dat is een **terminal-commando**, geen slash-command (zie de [commando-referentie](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md#openspec-cli-commands)). Met `--strict` worden waarschuwingen als fouten gezien. De validator checkt onder andere:
+
+- Scenario's gebruiken **vier** hashtags (`####`), niet drie — de meest voorkomende OpenSpec-fout, en wordt anders stilzwijgend door de parser overgeslagen.
+- Requirements gebruiken RFC 2119-keywords (MOET / MAG / KAN).
+- ADDED / MODIFIED / REMOVED-secties zijn correct gevormd.
+- Geen lege of incomplete artefacten.
+
+Komt validate groen door, dan is je spec-delta klaar voor commit + PR. Komt-ie rood, dan staan de bevindingen klip en klaar — bijna altijd een vergeten hashtag of een typo in een keyword.
+
+## Stap 9: commit en PR
+
+```bash
+git add openspec/changes/add-publication-search/
+git commit -m "spec: add-publication-search proposal + delta"
+git push -u origin feature/add-publication-search
+
+gh pr create --base development \
+  --title "spec: add-publication-search" \
+  --body "Eerste OpenSpec change — alleen specs, geen implementatie."
+```
+
+In een spec-eerste workflow merge je deze spec-PR apart vóór implementatie; de review focust dan op of de spec klopt — niet of de code werkt, want er is nog geen code. Daarna komen de volgende fases — zie Stap 10 (implementeren) en Stap 11 (verifiëren en archiveren).
+
+> **Spec + implementatie in één PR?** Ook prima — vooral voor kleine, duidelijke changes. Het spec-only-eerst patroon hierboven loont vooral wanneer reviewers de spec willen tekenen voordat er code is.
+
+## Stap 10: implementeren
+
+Met de spec gemerged is de spec klaar — nu de code. Twee skills nemen je daarbij bij de hand, in volgorde:
+
+### `/opsx-plan-to-issues` — tasks worden GitHub-issues
+
+```
+/opsx-plan-to-issues
+```
+
+Dit leest `tasks.md` en maakt:
+
+- Een **tracking-issue** (de "epic") met een complete checkboxlijst.
+- **Eén GitHub-issue per task**, met acceptance-criteria, een `spec_ref` naar de relevante spec-sectie, en bestanden-die-waarschijnlijk-aangeraakt-worden.
+- Een `plan.json` in de change-map met alle issue-nummers gekoppeld.
+
+Vanaf nu staat de change op het projectbord — zichtbaar voor het team. Optioneel `--trigger-label <label>` (bv. `--trigger-label wilco-ready-to-build`) zet meteen het Hydra-bouwlabel op elk issue.
+
+### `/opsx-apply` — bouwen tegen de spec
+
+```
+/opsx-apply
+```
+
+`/opsx-apply` draait de **Build-fase**: pakt de volgende open task uit `plan.json`, leest **alleen** de bijbehorende spec-sectie (via `spec_ref` — minimale context, geen "AI-amnesie"), implementeert backend + UI + tests, draait die tests, vinkt de task af in `tasks.md` én op het GitHub-issue, en herhaalt tot alles staat.
+
+De skill laadt automatisch alle bedrijfsbrede ADR's uit [`hydra/openspec/architecture/`](https://github.com/ConductionNL/hydra/tree/main/openspec/architecture) mee — harde constraints op de implementatie (data-laag, API-patronen, frontend-conventies, security, i18n).
+
+Per [`spec-driven-development.md`](https://github.com/ConductionNL/.github/blob/main/docs/WayOfWork/spec-driven-development.md) is dit het canonical pad: **de meeste changes hebben alleen `/opsx-ff` → `/opsx-apply` → `/opsx-verify` nodig**.
+
+**Hands-off alternatief.** [`/opsx-apply-loop`](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md#opsx-apply-loop) draait `apply` → `verify` in een isolated Docker-container (max 5 iteraties), optioneel met tests, en archiveert daarna. Of gebruik Hydra zelf: label het tracking-issue met `ready-to-build`, dan pikt [Hydra](https://github.com/ConductionNL/.github/blob/main/docs/hydra/README.md) hem op via de container-pipeline en levert een draft-PR.
+
+## Stap 11: verifiëren en archiveren
+
+Nadat de implementatie staat — alle taken in `tasks.md` afgevinkt en de code in `development` — draai je `/opsx-verify`:
+
+```
+/opsx-verify
+```
+
+Dit is de **Review-fase**. Waar `openspec validate` (Stap 8) checkte of de **spec** syntactisch klopt, checkt `/opsx-verify` of de **code** ook levert wat de spec belooft. Vijf controles:
+
+- **Completeness** — alle tasks afgevinkt en elke requirement geïmplementeerd.
+- **Correctness** — de implementatie matcht de spec-intentie.
+- **Coherence** — design-beslissingen zijn terug te zien in de code.
+- **Test-dekking** — nieuwe PHP-services/controllers hebben een testbestand; nieuwe Vue-components idem.
+- **Documentatie** — nieuwe features en endpoints staan in README of `docs/`.
+
+Bevindingen komen in drie smaken: **CRITICAL** (moet vóór archive opgelost), **WARNING** (zou opgelost moeten worden) en **SUGGESTION** (mooi-om-te-doen). Verify biedt ook aan om gevonden issues meteen te fixen en daarna opnieuw te draaien.
+
+Pas als verify groen is, draai je:
+
+```
+/opsx-archive
+```
+
+`/opsx-archive` doet vijf dingen:
+
+1. Controleert opnieuw artefact- en task-completeness.
+2. Syncht de delta naar de hoofd-spec via [`/opsx-sync`](https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md#opsx-sync) (als dat nog niet is gebeurd).
+3. Verhuist het mapje naar `openspec/changes/archive/YYYY-MM-DD-<naam>/`.
+4. Werkt `CHANGELOG.md` bij (completed tasks worden versie-entries).
+5. Maakt of update `docs/features/<change-name>.md` en het feature-overzicht in `docs/features/README.md`.
+
+Daarna is je change geschiedenis.
+
+> **`/opsx-sync` apart draaien? Meestal niet nodig.** `/opsx-archive` regelt de sync zelf — dat is stap 2 hierboven. De toegevoegde waarde van `/opsx-sync` standalone zit in **timing**: je wilt de hoofd-spec al bijwerken vóórdat je archiveert. Bijvoorbeeld om de gewijzigde regels alvast met een ander team te delen, een tussentijdse spec-review te doen, of de spec bij te werken terwijl de implementatie nog loopt. De skill mergt de ADDED / MODIFIED / REMOVED / RENAMED-secties slim in de hoofd-spec (alleen wat in de delta staat verandert — bestaande scenarios blijven staan). Daarna kun je later alsnog `/opsx-archive` draaien; die slaat stap 2 dan over.
+
+<Troubleshooting title="Probleemoplossing">
+  <TroubleshootingItem symptom="openspec validate meldt 'geen scenarios gevonden' voor een requirement">
+    Tellen tot vier: <code>#### Scenario:</code> — geen <code>###</code>, geen vetdruk. De parser slaat scenarios met drie hashtags stilzwijgend over, dus <code>openspec validate</code> ziet alleen het symptoom (een requirement zonder scenarios). Meest voorkomende OpenSpec-fout.
+  </TroubleshootingItem>
+  <TroubleshootingItem symptom="Mijn change-mapje heeft geen .openspec.yaml">
+    Je hebt vermoedelijk handmatig een map gemaakt in plaats van <code>/opsx-new</code> te gebruiken. Verwijder de map en draai <code>/opsx-new &lt;naam&gt;</code> opnieuw — de tooling maakt het skelet aan inclusief de metadata.
+  </TroubleshootingItem>
+  <TroubleshootingItem symptom="Reviewer zegt: deze requirement is te implementatie-specifiek">
+    Lees terug: noem je controllers, klassen of tabelnamen in <code>specs/</code>? Verplaats die naar <code>design.md</code>. De spec beschrijft alleen <em>extern waarneembaar gedrag</em>.
+  </TroubleshootingItem>
+  <TroubleshootingItem symptom="Ik wil iets wijzigen aan een bestaande spec, maar weet niet hoe">
+    Gebruik een <strong>MODIFIED Requirements</strong>-sectie in je spec-delta. Vermeld erbij wat het vorige gedrag was — bijvoorbeeld <em>(Voorheen: sessies verliepen na 30 minuten.)</em>. Zo kunnen reviewers de wijziging volgen.
+  </TroubleshootingItem>
+</Troubleshooting>
+
+## Test jezelf
+
+Vijf korte vragen om te checken of je dit deel begrepen hebt. Vastgelopen? Klik **Hint**. Curieus naar het antwoord? Klik **Antwoord**.
+
+<div className="tutorial-quiz">
+
+**1. Welk commando gebruik je om een nieuwe lege change te starten, en wat staat er direct in het mapje na die stap?**
+
+<Details summary="Hint">
+
+Eén commando, één naam in kebab-case. Direct daarna is het mapje vrijwel leeg op één metadata-bestandje na.
+
+</Details>
+
+<Details summary="Antwoord">
+
+**`/opsx-new <naam>`** met de change-naam in kebab-case (bijv. `add-publication-search` — niet `AddPublicationSearch` of `add_publication_search`). De change-naam wordt ook een GitHub-issue-label, dus kort en leesbaar.
+
+Direct na de stap staat in het mapje:
+
+```
+openspec/changes/<naam>/
+└── .openspec.yaml
+```
+
+Eén bestand — `.openspec.yaml` met metadata (schema-versie, aanmaakdatum). Verder leeg; proposal, delta, design en tasks komen pas daarna.
+
+</Details>
+
+</div>
+
+<div className="tutorial-quiz">
+
+**2. Wat is het verschil tussen `/opsx-ff` en handmatig artefacten schrijven, en wanneer kies je welke?**
+
+<Details summary="Hint">
+
+Snelheid vs. controle. De ene levert in één run alles op, de andere laat je per artefact terugkijken en bijsturen.
+
+</Details>
+
+<Details summary="Antwoord">
+
+- **`/opsx-ff`** ("fast-forward") — genereert proposal, specs, design en tasks in één run na een paar setup-vragen. Kies hem als je het beeld al helder hebt en typewerk wil besparen.
+- **Handmatig of `/opsx-continue`** — je schrijft (of genereert) per artefact, leest terug, scherpt aan, en gaat dan pas verder. Kies dit bij architecturale keuzes waar je per stap wil meedenken. `/opsx-explore` zit nog een stap eerder: die maakt nog niets aan, maar denkt mee bij de brainstorm.
+
+In de praktijk: vaak `/opsx-ff` voor een ruwe schets en daarna handmatig bijsturen.
+
+</Details>
+
+</div>
+
+<div className="tutorial-quiz">
+
+**3. Welke drie soorten delta-secties kun je in een spec-delta schrijven, en wat doe je in elke?**
+
+<Details summary="Hint">
+
+Drie hoofdletter-woorden, alledrie een werkwoord voor wat ze met requirements doen.
+
+</Details>
+
+<Details summary="Antwoord">
+
+- **ADDED Requirements** — nieuwe requirements die nog niet in de hoofd-spec staan.
+- **MODIFIED Requirements** — bestaande requirements die anders worden. Vermeld erbij wat het vorige gedrag was — bijvoorbeeld *(Voorheen: sessies verliepen na 30 minuten.)* — zodat reviewers de wijziging kunnen volgen.
+- **REMOVED Requirements** — requirements die vervallen.
+
+Bij archivering gaan ADDED-regels naar de hoofd-spec, MODIFIED overschrijven hun voorganger, en REMOVED-regels verdwijnen.
+
+</Details>
+
+</div>
+
+<div className="tutorial-quiz">
+
+**4. Met welk commando check je je spec voordat je commit, en met welk commando check je later of de implementatie de spec ook echt levert?**
+
+<Details summary="Hint">
+
+Twee verschillende rollen — één is een OpenSpec-CLI die naar **spec-syntax** kijkt, één is een Claude Code-skill die naar **code-vs-spec** kijkt.
+
+</Details>
+
+<Details summary="Antwoord">
+
+- **Vóór commit**: `openspec validate --strict`. De OpenSpec-CLI (terminal-commando, geen slash). Checkt of de delta syntactisch klopt — vier hashtags voor scenarios, RFC 2119-keywords, ADDED/MODIFIED/REMOVED-vorm, geen lege artefacten. Met `--strict` worden waarschuwingen ook als fouten gezien.
+- **Na implementatie**: `/opsx-verify`. Een Claude Code-skill die de **Review**-fase draait — alle taken afgevinkt, code in `development` — en checkt of de code ook levert wat de spec belooft. Vijf controles: **completeness**, **correctness**, **coherence**, **test-dekking** en **documentatie**. Bevindingen komen in **CRITICAL** / **WARNING** / **SUGGESTION**.
+
+Het ene checkt of de spec **correct opgeschreven** is, het andere of de code de spec **echt levert**. De meest voorkomende spec-syntaxfout — drie i.p.v. vier hashtags bij een scenario — wordt door de parser stilzwijgend overgeslagen, dus `openspec validate` ziet alleen het symptoom (requirement zonder scenarios). "Tellen tot vier" blijft de eerste reflex.
+
+</Details>
+
+</div>
+
+<div className="tutorial-quiz">
+
+**5. Wanneer is een change klaar om gearchiveerd te worden, en welk commando draai je dan?**
+
+<Details summary="Hint">
+
+Vier voorwaarden: tasks, code in development, delta in hoofd-spec, en mapje verhuisd. Het laatste hoef je niet zelf te doen.
+
+</Details>
+
+<Details summary="Antwoord">
+
+Een change is klaar om gearchiveerd te worden als:
+
+1. Alle taken in `tasks.md` afgevinkt zijn.
+2. De implementatie in `development` zit (PR gemerged).
+3. De spec-delta is gesynct naar de hoofd-spec in `openspec/specs/`.
+4. Het mapje is verplaatst naar `openspec/changes/archive/YYYY-MM-DD-<naam>/`.
+
+Stap 3 en 4 doe je niet handmatig — draai **`/opsx-archive`**. Die controleert of alle taken klaar zijn, syncht de delta via `/opsx-sync`, en verhuist het mapje met datum vooraan. Daarna is je change geschiedenis.
+
+</Details>
+
+</div>
+
+<NextSteps title="Volgende stap" lede="Je eerste change staat. Een paar logische vervolgstappen:">
+  <NextStep
+    title="Deel 1 — Wat is OpenSpec?"
+    href="/nl/academy/openspec-tutorial-1-wat-is-openspec"
+    description="Even teruglezen wat een spec versus een change is — handig als je een collega meeneemt in deze workflow."
+  />
+  <NextStep
+    title="Hydra-leerlijn — van spec naar code"
+    href="/nl/academy/hydra-tutorial-1-wat-is-hydra"
+    description="Hoe gaat een OpenSpec change vanzelf door naar een PR met code? Onze AI-pipeline doet dat werk."
+  />
+  <NextStep
+    title="De officiële OpenSpec-conventie"
+    href="https://openspec.dev"
+    description="De bron-conventie waar wij op voortbouwen, met de volledige naamgeving en regels."
+  />
+  <NextStep
+    title="OpenSpec-commando's compleet"
+    href="https://github.com/ConductionNL/.github/blob/main/docs/claude/commands-openspec.md"
+    description="Alle /opsx-*-commando's op één rij: new, ff, continue, explore, apply, verify, sync, archive."
+  />
+</NextSteps>
+
+<ContactCta
+  title="Vragen of feedback?"
+  body="Spreek je teamlead of buddy aan, of stel je vraag in #openspec op Slack. Issues op deze tutorial graag op het bijbehorende GitHub-issue."
+  cta={{ label: "Mail ons", href: "mailto:info@conduction.nl?subject=OpenSpec%20leerlijn%20deel%202" }}
+/>

--- a/i18n/nl/docusaurus-plugin-content-blog/2026-05-13-deskdesk-tutorial-2-schemas-manifest/index.mdx
+++ b/i18n/nl/docusaurus-plugin-content-blog/2026-05-13-deskdesk-tutorial-2-schemas-manifest/index.mdx
@@ -287,7 +287,7 @@ Dit is de schema-gedreven discipline waarover [nextcloud-vue.conduction.nl](http
 <NextSteps>
   <NextStep
     title="Deel 3 — Schema-gedreven integraties (NC Agenda)"
-    href="/academy/deskdesk-tutorial-3-calendar"
+    href="/nl/academy/deskdesk-tutorial-3-calendar"
     description="Eén calendarProvider-blok op het booking-schema. Bookings verschijnen in de Nextcloud-agenda van de gebruiker. Geen controller, geen listener, geen lijmcode."
   />
   <NextStep

--- a/i18n/nl/docusaurus-plugin-content-blog/2026-05-15-claude-skills-tutorial-1-wat-zijn-claude-skills/index.mdx
+++ b/i18n/nl/docusaurus-plugin-content-blog/2026-05-15-claude-skills-tutorial-1-wat-zijn-claude-skills/index.mdx
@@ -1,0 +1,325 @@
+---
+slug: claude-skills-tutorial-1-wat-zijn-claude-skills
+title: "Claude Skills leerlijn — Deel 1: Wat zijn Claude Skills?"
+contentType: tutorial
+authors: [conduction]
+date: 2026-05-15
+summary: Wat is een Claude Skill, wanneer schrijf je er een (en wanneer juist een prompt of command), welke velden staan in de frontmatter en hoe weet Claude wanneer hij hem moet triggeren. Eerste van vier korte modules.
+tags: [Claude, Claude Code, Skills, AI, Tutorial series]
+apps: []
+durationMinutes: 12
+series: claude-skills-tutorial
+partNumber: 1
+---
+
+import {Outcomes, Outcome, Prerequisites, PrerequisiteItem, NextSteps, NextStep, HexCard, ContactCta} from '@conduction/docusaurus-preset/components';
+import Details from '@theme/Details';
+
+Claude Skills zijn het mechanisme waarmee je Claude Code uitbreidt met herbruikbare, gespecialiseerde gedragingen. Denk aan Conductions eigen `/review-pr`, `/opsx-new` of de hele `hydra-gate-*` familie: stuk voor stuk skills. Dit eerste deel legt in tien minuten uit wát een skill is, hoe hij geactiveerd wordt, en wanneer je beter géén skill maakt. Het is deel 1 van een leerlijn van vier; aan het eind sta je klaar om er in deel 2 zelf een te schrijven — en in deel 3 introduceren we het **7-level maturity-framework** waarmee je een skill van "voelt goed" naar "gemeten goed" brengt (deel 4 gaat door op L6 en L7).
+
+{/* truncate */}
+
+<Outcomes title="Wat je leert in dit deel">
+  <Outcome>Wat een Claude Skill is — een mapje met een <code>SKILL.md</code> dat Claude on-demand laadt.</Outcome>
+  <Outcome>De twee manieren waarop een skill geactiveerd kan worden: handmatig via <code>/</code> en automatisch door Claude zelf.</Outcome>
+  <Outcome>Welke velden de frontmatter heeft, en waarom de <code>description</code> verreweg het belangrijkste veld is.</Outcome>
+  <Outcome>Wanneer een skill de juiste keuze is — en wanneer een gewone prompt, een command of een agent beter past.</Outcome>
+</Outcomes>
+
+<Prerequisites title="Wat je nodig hebt">
+  <PrerequisiteItem>Een werkende installatie van <a href="https://docs.claude.com/en/docs/claude-code/overview">Claude Code</a> op je laptop. Zo niet, doe eerst de <a href="https://github.com/ConductionNL/.github/blob/main/docs/claude/workstation-setup.md">Workstation Setup</a>.</PrerequisiteItem>
+  <PrerequisiteItem>Basiskennis Git en GitHub — een skill is uiteindelijk gewoon een bestand dat je commit.</PrerequisiteItem>
+  <PrerequisiteItem>Een paar uur ervaring met Claude Code in de praktijk. Je hoeft geen power-user te zijn, maar je moet wel weten wat <code>/help</code> doet en hoe je een prompt naar Claude stuurt.</PrerequisiteItem>
+</Prerequisites>
+
+## In één zin
+
+Een **Claude Skill** is een mapje onder `.claude/skills/<naam>/` met daarin een `SKILL.md` (en optioneel scripts, voorbeelden, referentiebestanden). De frontmatter van die `SKILL.md` vertelt Claude wanneer de skill relevant is; de inhoud is de instructie die Claude volgt zodra de skill geladen wordt.
+
+Praktisch: een skill is een **bundel-eenheid van gedrag**. In plaats van duizend regels prompt-tekst in `CLAUDE.md` te plakken, of telkens dezelfde instructies opnieuw te typen, schrijf je het één keer als skill. Hergebruikbaar, testbaar, en deelbaar met je team.
+
+```
+.claude/skills/
+└── review-pr/
+    ├── SKILL.md          ← verplicht: de skill-logica
+    ├── templates/        ← optioneel: bestanden met placeholders
+    ├── references/       ← optioneel: standaarden en achtergrond
+    ├── examples/         ← optioneel: voorbeelden van gewenste output
+    └── scripts/          ← optioneel: shell- of Python-scripts
+```
+
+## Hoe een skill wordt aangeroepen
+
+Eén skill kan op **twee manieren** in actie komen:
+
+1. **Handmatig** — je typt `/review-pr` in een Claude-sessie. Direct, voorspelbaar, en de skill draait precies wanneer jij dat wilt.
+2. **Automatisch** — Claude leest de `description` van alle beschikbare skills mee en kiest er zelf eentje wanneer de huidige situatie matcht. Vraag bijvoorbeeld "kun je deze PR reviewen?" en Claude triggert vanzelf `review-pr` als die voorhanden is.
+
+Welke mode is toegestaan, regel je in de frontmatter van de skill zelf:
+
+- `disable-model-invocation: true` — alleen jij kunt 'm aanroepen via `/<naam>`. Gebruik dit voor skills met side-effects (`/opsx-apply` past code aan, `/create-pr` opent een PR). Claude mag dit niet zomaar uit zichzelf doen.
+- `user-invocable: false` — alleen Claude zelf mag 'm laden. Gebruik dit voor achtergrondkennis die niet als actie zinvol is (bijvoorbeeld een `legacy-system-context` die alleen informeert).
+- Geen van beide gezet → beide mogen. Default voor de meeste skills.
+
+In een Hydra-pipeline draaien skills meestal **automatisch**: containers hebben geen toetsenbord en leunen op auto-activatie. Achter je eigen toetsenbord typ je vaker expliciet `/` voor controle.
+
+## De frontmatter, veld voor veld
+
+Een minimale `SKILL.md` ziet er zo uit:
+
+```markdown
+---
+name: review-pr
+description: Review a Pull Request — runs local checks, summarises the diff, and posts inline comments
+metadata:
+  category: Workflow
+  tags: [github, review]
+---
+
+# Review PR
+
+Korte uitleg van wat de skill doet.
+
+**Input**: hoe je de skill aanroept en welke argumenten hij accepteert.
+
+**Steps**
+
+1. **Stap-naam**
+   Instructies...
+
+2. **Stap-naam**
+   Instructies...
+
+**Guardrails**
+- Wat de skill nooit mag doen
+- Wat hij moet checken voor destructieve acties
+```
+
+Drie velden vragen extra aandacht:
+
+| Veld | Functie |
+|---|---|
+| `name` | Moet **exact gelijk** zijn aan de mapnaam. Folder heet `review-pr` → `name: review-pr`. Wijkt het af, dan kun je de skill niet via `/<naam>` triggeren. |
+| `description` | Het belangrijkste veld van de hele skill. Hierop beslist Claude of de skill relevant is. Action-oriented, derde persoon, met concrete trigger-woorden. |
+| `metadata.tags` / `metadata.category` | Vrij in te vullen, handig voor filteren en groeperen — geen invloed op triggering. |
+
+### Waarom de description zoveel belangrijker is dan je denkt
+
+Claude laadt skills in drie lagen:
+
+| Laag | Wat | Wanneer geladen |
+|---|---|---|
+| **Metadata** | `name` + `description` | **Altijd** — zit standaard in de system prompt |
+| **SKILL.md body** | Steps, guardrails, instructies | Pas wanneer de skill triggert |
+| **Reference files** | `references/`, `templates/`, `examples/` | On-demand tijdens uitvoering |
+
+Dat betekent: alleen je `description` staat altijd "aan". Is hij vaag, dan vuurt je skill nooit automatisch. Schrijf 'm in derde persoon, start met een werkwoord, en plak de meest specifieke trigger-woorden vooraan (alleen de eerste ~250 tekens zijn zichtbaar in skill-listings).
+
+```
+# Slecht — vaag, passief, geen trigger-woorden
+description: A skill that helps with various document-related tasks
+
+# Goed — specifiek, derde persoon, action-werkwoord vooraan
+description: Create a Pull Request from the current branch — runs local checks, picks target branch, and opens the PR on GitHub
+```
+
+### Verdiepende frontmatter-velden
+
+Naast `name`, `description` en `metadata` zijn er een paar optionele velden die het gedrag van een skill subtiel sturen. Je hebt ze niet altijd nodig, maar weten dát ze bestaan helpt later:
+
+| Veld | Functie | Wanneer gebruiken |
+|---|---|---|
+| `allowed-tools` | Beperkt welke tools de skill mag aanroepen | Read-only audit-skills die nooit mogen schrijven |
+| `context: fork` | Runt de skill in een geïsoleerde sub-context | Zware skills die je hoofdgesprek niet willen vervuilen |
+| `paths` | Auto-trigger alleen bij werk in deze paden | Skills die alleen relevant zijn in bv. `openspec/**` |
+| `disable-model-invocation` | Schakelt auto-trigger volledig uit | Skills met side-effects die strikt slash-only moeten zijn |
+| `user-invocable: false` | Schakelt handmatige `/`-invocatie uit | Pure achtergrondkennis voor Claude zelf |
+
+Begin met de drie verplichte/basis-velden. Voeg de bovenstaande pas toe als je een concrete reden hebt — anders maak je je skill stiller of strikter dan nodig.
+
+### Naming convention: `namespace-action`
+
+Skills heten standaard `<namespace>-<action>` met alleen kleine letters, cijfers en koppeltekens. Conduction gebruikt onder meer:
+
+| Namespace | Dekt |
+|---|---|
+| `opsx-` | OpenSpec-workflow (`opsx-new`, `opsx-apply`, `opsx-archive`) |
+| `app-` | Nextcloud app-lifecycle (`app-design`, `app-create`) |
+| `test-` | Testen (`test-counsel`, `test-persona-henk`) |
+| `team-` | Scrum team-rollen (`team-backend`, `team-qa`) |
+| `hydra-gate-` | Quality- en security-gates binnen Hydra |
+
+De mapnaam, het `name`-veld én de manier waarop je 'm typt (`/<naam>`) moeten allemaal exact gelijk zijn.
+
+## Skill vs. prompt vs. agent
+
+Een veelgehoorde vraag: wanneer is een skill de juiste keuze, en wanneer iets anders? Drie categorieën, kort:
+
+<HexCard title="Gewone prompt">
+  Eenmalig, of iets wat je sneller schrijft dan op te zoeken. Geen herhaalbaar patroon. Voorbeeld: <em>"refactor deze functie naar early-return-stijl"</em>.
+</HexCard>
+
+<HexCard title="Skill">
+  Herhaalbaar gedrag, mechanisch te beschrijven, met side-effects of een vast stappenplan. Voorbeelden: <code>/review-pr</code>, <code>/opsx-new</code>, <code>/create-pr</code>.
+</HexCard>
+
+<HexCard title="Subagent">
+  Een aparte uitvoeringscontext met eigen tools en eigen tokenbudget. Gebruik je wanneer je werk wilt isoleren (zware exploratie, parallelle reviews). Een skill kan een subagent oproepen, maar is er niet hetzelfde als.
+</HexCard>
+
+De pragmatische test: schrijf een skill als…
+
+1. **Het gedrag is herhaalbaar** — meer dan eens nodig, op meer dan één plek.
+2. **Het is mechanisch beschrijfbaar** — je kunt het in 1-3 alinea's instrueren, zonder dat het ontaardt in "het hangt van de context af".
+3. **Je teamgenoot zou hetzelfde willen doen** — anders is het een persoonlijke macro, geen team-skill.
+
+Voor één-keer-werk: gewoon prompten. Voor herhaalbaar werk: skill. Voor zware isolatie van een sub-werkstroom: subagent.
+
+## Waar skills "wonen"
+
+Skills kunnen op drie niveaus liggen:
+
+| Niveau | Pad | Wie zie ze |
+|---|---|---|
+| **Globaal** | `~/.claude/skills/<naam>/` | Jij, in elke Claude-sessie op deze laptop |
+| **Per project** | `<repo>/.claude/skills/<naam>/` | Iedereen die in deze repo werkt — gecommit in Git |
+| **Vendored** | `<repo>/vendor/skills/<naam>/` | Idem, maar afkomstig van een externe partij (bv. Anthropic of Trail of Bits) |
+
+In Conduction-repo's leeft het overgrote deel als **project-skills** in `<repo>/.claude/skills/`. Dat zorgt dat het hele team — en Hydra's Docker-personas — exact dezelfde skills hebben.
+
+## Test jezelf
+
+Vier korte vragen om te checken of je dit deel begrepen hebt. Vastgelopen? Klik **Hint**. Curieus naar het antwoord? Klik **Antwoord**.
+
+<div className="tutorial-quiz">
+
+**1. Wanneer kies je voor een skill, en wanneer voor een gewone prompt of een subagent?**
+
+<Details summary="Hint">
+
+Denk aan herhaalbaarheid, mechanische beschrijfbaarheid, en isolatie. Bij welke combinaties valt de keuze welke kant op?
+
+</Details>
+
+<Details summary="Antwoord">
+
+- **Gewone prompt** — eenmalig, of iets wat je sneller schrijft dan op te zoeken. Geen herhaalbaar patroon. Bijvoorbeeld: *"refactor deze functie naar early-return-stijl"*.
+- **Skill** — herhaalbaar gedrag, mechanisch te beschrijven, met side-effects of een vast stappenplan. Voorbeelden: `/review-pr`, `/opsx-new`, `/create-pr`. Je teamgenoot zou ook willen dat dit consistent gebeurt.
+- **Subagent** — een aparte uitvoeringscontext met eigen tools en tokenbudget. Voor isolatie: zware exploratie, parallelle reviews. Een skill kan een subagent oproepen, maar is niet hetzelfde.
+
+Vuistregel: één-keer-werk → prompt. Herhaalbaar werk → skill. Zware isolatie van een sub-werkstroom → subagent.
+
+</Details>
+
+</div>
+
+<div className="tutorial-quiz">
+
+**2. Welke velden zijn verplicht in de frontmatter van een skill, en wat doen ze?**
+
+<Details summary="Hint">
+
+Twee velden zijn écht verplicht. Eén ervan beslist over de mapnaam, de ander beslist of Claude de skill ooit oppikt.
+
+</Details>
+
+<Details summary="Antwoord">
+
+Verplicht zijn:
+
+- **`name`** — moet exact gelijk zijn aan de mapnaam (folder `review-pr` → `name: review-pr`). Wijkt het af, dan kun je de skill niet via `/<naam>` triggeren.
+- **`description`** — wat Claude leest om te beslissen of de skill relevant is. Action-oriented, derde persoon, concrete trigger-woorden vooraan.
+
+Optioneel, maar veel gebruikt:
+
+- **`metadata.category`** / **`metadata.tags`** — voor filteren/groeperen.
+- **`disable-model-invocation: true`** — alleen handmatig oproepbaar.
+- **`user-invocable: false`** — alleen automatisch laadbaar door Claude.
+- **`allowed-tools`** — beperkt welke tools de skill mag gebruiken.
+
+Verreweg het belangrijkste veld is de `description`: alleen díe staat altijd in de system prompt geladen. De rest van de `SKILL.md` wordt pas gelezen wanneer de skill triggert.
+
+</Details>
+
+</div>
+
+<div className="tutorial-quiz">
+
+**3. Hoe weet Claude wanneer hij een skill moet triggeren — wat staat er in de `description`?**
+
+<Details summary="Hint">
+
+Claude leest een korte tekst en moet vervolgens op basis daarvan beslissen. Wat zou jij willen lezen om die beslissing snel en zeker te kunnen nemen?
+
+</Details>
+
+<Details summary="Antwoord">
+
+Claude vergelijkt de huidige conversatie tegen de `description` van elke beschikbare skill. Een goede description:
+
+1. **Begint met een action-werkwoord** (`Create`, `Review`, `Archive`, `Test`, …) — geen passieve constructies.
+2. **Front-loadt de kern in de eerste ~250 tekens** — daarna kapt het skill-listing af.
+3. **Bevat concrete trigger-woorden** — zelfstandige naamwoorden en werkwoorden die een gebruiker zou typen. ("Pull Request", "review", "GitHub branch" voor `review-pr`).
+4. **Is geschreven in derde persoon** — hij wordt letterlijk in de system prompt geïnjecteerd.
+
+Vermijd vage formuleringen ("helpt met allerlei dingen"), de eerste persoon ("ik help je…"), en marketing-taal ("een handige tool voor…"). Concreet en specifiek wint altijd.
+
+Praktische realiteit: meerdere bronnen rapporteren ~50% auto-activatie zelfs voor goede skills, doordat Claude een vast contextbudget heeft voor skill-descriptions. Bij grote skill-libraries is expliciet `/skill-naam` typen altijd betrouwbaarder dan vertrouwen op auto-trigger.
+
+</Details>
+
+</div>
+
+<div className="tutorial-quiz">
+
+**4. Wanneer is het beter om een gewone prompt te schrijven dan een skill?**
+
+<Details summary="Hint">
+
+Vraag jezelf: ga ik dit nog een keer doen? En zou een collega dit ook willen?
+
+</Details>
+
+<Details summary="Antwoord">
+
+Schrijf een gewone prompt als…
+
+- Het werk is **eenmalig**: een specifieke refactor, een onderzoeksvraag, een ad-hoc analyse.
+- Het is **persoonlijk**: alleen jij hebt het ooit nodig, niemand anders in het team — dan blijft het een eigen macro/snippet, geen team-skill.
+- Het is **moeilijk mechanisch beschrijfbaar**: "het hangt sterk van de context af", veel uitzonderingen, veel oordeel. Skills zijn voor herhaalbare patronen, niet voor situatie-specifieke beslissingen.
+- Je hebt **nog geen 3 keer hetzelfde gedaan**. Schrijf een skill pas wanneer je het patroon écht ziet — anders bouw je een abstractie op één voorbeeld.
+
+Vuistregel ("rule of three"): één keer is toeval, twee keer ook nog, drie keer is een patroon dat een skill verdient.
+
+</Details>
+
+</div>
+
+<NextSteps title="Volgende stap" lede="Nu je weet wat een skill is, gaan we er in deel 2 zelf eentje schrijven — met /skill-creator als startpunt.">
+  <NextStep
+    title="Deel 2 — Je eerste skill schrijven"
+    href="/nl/academy/claude-skills-tutorial-2-je-eerste-skill"
+    description="Van mapje naar werkende skill: scaffolden met /skill-creator, een goede description schrijven, lokaal testen, en opnemen in de skill-registry."
+  />
+  <NextStep
+    title="Hydra-leerlijn — Deel 4: Skills in de praktijk"
+    href="/nl/academy/hydra-tutorial-4-skills"
+    description="Wil je vooraf al een gevoel krijgen waar skills in een echte agentic loop landen? Hydra's deel 4 laat de skill-families zien die de fabriek draaiende houden (opsx-*, hydra-gate-*, team-*, test-*)."
+  />
+  <NextStep
+    title="Anthropic — Skill authoring best practices"
+    href="https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices"
+    description="De officiële Anthropic-documentatie over skill-structuur, descriptions en progressive disclosure. Goed als achtergrondlectuur."
+  />
+  <NextStep
+    title="Agent Skills Open Standard"
+    href="https://agentskills.io/specification"
+    description="De open standaard voor het SKILL.md-formaat, geadopteerd door 20+ tools (OpenAI Codex, Gemini CLI, Cursor, GitHub Copilot)."
+  />
+</NextSteps>
+
+<ContactCta
+  title="Vragen over Claude Skills?"
+  body="Stuur ons gerust een mail of stel je vraag via GitHub Discussions op de .github-repo. We helpen je graag op weg."
+  cta={{ label: "Mail Conduction", href: "mailto:info@conduction.nl?subject=Claude%20Skills%20leerlijn%20deel%201" }}
+/>

--- a/i18n/nl/docusaurus-plugin-content-blog/2026-05-15-claude-skills-tutorial-2-je-eerste-skill/index.mdx
+++ b/i18n/nl/docusaurus-plugin-content-blog/2026-05-15-claude-skills-tutorial-2-je-eerste-skill/index.mdx
@@ -1,0 +1,412 @@
+---
+slug: claude-skills-tutorial-2-je-eerste-skill
+title: "Claude Skills leerlijn — Deel 2: Je eerste skill schrijven"
+contentType: tutorial
+authors: [conduction]
+date: 2026-05-15
+summary: Schrijf van scratch een werkende Claude Skill — een mini-skill die git-statussen samenvat. Met /skill-creator als startpunt, een goede description, lokaal testen, en opnemen in je registry. Tweede van vier korte modules.
+tags: [Claude, Claude Code, Skills, AI, Tutorial series]
+apps: []
+durationMinutes: 18
+series: claude-skills-tutorial
+partNumber: 2
+---
+
+import {Outcomes, Outcome, Prerequisites, PrerequisiteItem, NextSteps, NextStep, HexCard, ContactCta} from '@conduction/docusaurus-preset/components';
+import Details from '@theme/Details';
+
+In deel 1 zag je wát een skill is. In dit deel ga je er zélf eentje schrijven: een werkende `git-status-summary` skill die een leesbare samenvatting maakt van de huidige working tree. Aan het eind staat hij in je `~/.claude/skills/`-folder, kun je hem aanroepen via `/git-status-summary`, en weet je hoe je hem deelt met je team.
+
+{/* truncate */}
+
+<Outcomes title="Wat je leert in dit deel">
+  <Outcome>Een complete skill scaffolden met <code>/skill-creator</code> in plaats van zelf folders aanleggen.</Outcome>
+  <Outcome>Een goede <code>description</code> schrijven die zowel handmatig (<code>/</code>) als automatisch betrouwbaar triggert.</Outcome>
+  <Outcome>De skill lokaal testen vóór je hem deelt — met een should-trigger / should-not-trigger checklist.</Outcome>
+  <Outcome>Wanneer een skill globaal hoort (<code>~/.claude/skills/</code>) en wanneer in een project (<code>repo/.claude/skills/</code>).</Outcome>
+</Outcomes>
+
+<Prerequisites title="Wat je nodig hebt">
+  <PrerequisiteItem>Deel 1 doorgenomen: <a href="/nl/academy/claude-skills-tutorial-1-wat-zijn-claude-skills">Wat zijn Claude Skills?</a></PrerequisiteItem>
+  <PrerequisiteItem>Claude Code geïnstalleerd, en een werkende sessie in een willekeurige Git-repo. Zelfs een leeg <code>git init</code> mapje is voldoende.</PrerequisiteItem>
+  <PrerequisiteItem>De <code>skill-creator</code> skill geïnstalleerd. Hij komt standaard mee als plugin met Claude Code; als je hem niet hebt: <code>git clone https://github.com/anthropics/skills</code> en kopieer <code>skills/skill-creator/</code> naar je <code>~/.claude/skills/</code>.</PrerequisiteItem>
+</Prerequisites>
+
+## Wat we gaan bouwen
+
+Een mini-skill die je `git status` leesbaar samenvat — met categorieën (staged / unstaged / untracked), bestandsaantallen, en een lijst van wijzigingen per categorie. Eenvoudig genoeg om in dit deel volledig te schrijven, maar concreet genoeg om alle stappen mee te illustreren.
+
+Eindresultaat: typ `/git-status-summary` in je sessie en je krijgt iets zoals:
+
+```
+Working tree status
+
+Staged (3 files):
+  • src/components/Button.vue — modified
+  • src/components/Card.vue — modified
+  • README.md — modified
+
+Unstaged (2 files):
+  • src/App.vue — modified
+  • src/utils/format.ts — modified
+
+Untracked (1 file):
+  • notes.txt
+```
+
+## Stap 1 — Scaffold met `/skill-creator`
+
+De makkelijkste manier om een nieuwe skill te starten is **niet** zelf folders aanleggen, maar `/skill-creator` laten begeleiden. Open een Claude-sessie en typ:
+
+```
+/skill-creator
+```
+
+Claude vraagt je vervolgens wat je wilt maken. Antwoord ongeveer zo:
+
+> Ik wil een skill `git-status-summary` die `git status --porcelain` draait, de output parset, en in drie groepen (staged / unstaged / untracked) presenteert met bestandsnamen en wijzigings-type. Hij hoort op alle Git-repo's te werken.
+
+`/skill-creator` zal vervolgens:
+
+1. Vragen om een korte description — geef hier de zorgvuldig geformuleerde versie van hieronder.
+2. Vragen of de skill side-effects heeft (nee — alleen lezen).
+3. Een mapje aanmaken: `~/.claude/skills/git-status-summary/` met een eerste `SKILL.md`.
+
+:::tip Niet bang zijn om met de hand te starten
+Als `/skill-creator` om wat voor reden dan ook niet werkt, kun je het mapje ook gewoon aanmaken: `mkdir -p ~/.claude/skills/git-status-summary && touch ~/.claude/skills/git-status-summary/SKILL.md`. De skill is een doodgewoon tekstbestand.
+:::
+
+## Stap 2 — De `description` zorgvuldig formuleren
+
+Herinner je uit deel 1: alleen de `description` staat altijd in de system prompt geladen. Hier valt of staat je auto-triggering.
+
+Een goede description voor onze skill:
+
+```
+description: Summarise the current Git working tree — groups changes by staged, unstaged, and untracked, and lists files per group with their change type
+```
+
+Wat zit daarin?
+
+| Stuk | Waarom |
+|---|---|
+| `Summarise` | Action-werkwoord vooraan. Geen "this skill is" of "helps with". |
+| `current Git working tree` | Concrete trigger-woorden: iemand die "git status overview" of "what's changed" typt, raakt hier. |
+| `groups changes by staged, unstaged, and untracked` | Vertelt Claude precies wat hij krijgt — handig bij keuzes tussen meerdere skills. |
+| `lists files per group with their change type` | Sluit af met het waarneembare resultaat, zodat een gebruiker meteen herkent of dit is wat hij zoekt. |
+
+Schrijf 'm in **derde persoon** (de description wordt letterlijk geïnjecteerd in de system prompt) en blijf onder ~250 tekens — daarna kapt skill-listings af.
+
+## Stap 3 — Schrijf de `SKILL.md`
+
+Open `~/.claude/skills/git-status-summary/SKILL.md` en vul hem zo:
+
+````markdown
+---
+name: git-status-summary
+description: Summarise the current Git working tree — groups changes by staged, unstaged, and untracked, and lists files per group with their change type
+metadata:
+  category: Workflow
+  tags: [git, workspace]
+---
+
+# Git Status Summary
+
+Produces a clean, grouped summary of the current Git working tree.
+
+**Input**: no arguments. Always reads `git status --porcelain` from the current
+working directory.
+
+**Steps**
+
+1. **Verify a Git repo**
+
+   Run `git rev-parse --is-inside-work-tree`. If it returns anything other than
+   `true`, abort with: *"Not inside a Git repository — cd into one first."*
+
+2. **Read the porcelain status**
+
+   Run `git status --porcelain=v1` and split the output by line. Each line
+   starts with a two-character XY status code:
+   - `X` = index status, `Y` = working tree status
+   - `M` = modified, `A` = added, `D` = deleted, `R` = renamed, `??` = untracked
+
+3. **Group the lines**
+
+   - **Staged**: lines where `X` is not blank and not `?`
+   - **Unstaged**: lines where `Y` is not blank and the line is not untracked
+   - **Untracked**: lines starting with `??`
+
+   A single file can appear in both Staged and Unstaged (modified in both).
+   Show it in both groups when that happens.
+
+4. **Render the summary**
+
+   Output in this exact shape (preserve formatting):
+
+   ```
+   Working tree status
+
+   Staged (N files):
+     • path/to/file — modified
+
+   Unstaged (N files):
+     • path/to/file — modified
+
+   Untracked (N files):
+     • path/to/file
+   ```
+
+   Omit any group that has zero files. If all three are empty, output:
+   *"Working tree clean — nothing to commit."*
+
+**Guardrails**
+
+- Never run `git add`, `git commit`, `git reset`, or any other write command.
+  This skill is read-only.
+- Never call `git status` without `--porcelain` — the human-readable form is
+  fragile across locales and Git versions.
+- Never pass `--ignored` to `git status`. The "X is not blank and not `?`"
+  staged-check would otherwise also match `!` (ignored) lines and produce
+  a wrong staged group.
+- Do not invent files. Only list what `git status --porcelain` actually returns.
+````
+
+Drie dingen om op te merken:
+
+1. **Genummerde stappen** — geen prozaïsche paragrafen. Eén handeling per stap, met een duidelijke kop.
+2. **Een "Guardrails" sectie** — wat de skill expliciet niet mag. Voor read-only skills is de regel "geen schrijfacties" cruciaal.
+3. **Concreet output-formaat in een code-block** — Claude volgt zichtbare voorbeelden veel betrouwbaarder dan vage instructies.
+
+### Hoe specifiek moet je SKILL.md zijn? — degrees of freedom
+
+Een veelgemaakte fout: alle skills hetzelfde detail-niveau geven. In de praktijk past je specificiteit zich aan de fragiliteit van de taak aan:
+
+| Soort taak | Vrijheid | Skill-stijl |
+|---|:---:|---|
+| Exploratie, brainstorm, code review | **Hoog** | Geef doelen en kaders, laat Claude de aanpak kiezen |
+| Feature-werk, refactor | **Middel** | Geef stappen met beslispunten, laat Claude adapteren |
+| DB-migraties, production-deploys, CI-config | **Laag** | Voorgeschreven commando's, expliciete confirmation-gates |
+
+Onze `git-status-summary` is read-only en mechanisch — middel-tot-laag, met expliciete formattering en harde guardrails. Een hypothetische `/explore-architecture` zou juist hoge vrijheid willen ("denk hardop, vergelijk opties, geen vaste vorm").
+
+### Dynamic content: argumenten en shell-output injecteren
+
+Een laatste stuk syntax dat je verderop tegen gaat komen, maar nog niet nodig hebt voor `git-status-summary`:
+
+| Syntax | Betekenis | Voorbeeld |
+|---|---|---|
+| `$ARGUMENTS` | Alles wat na `/skill-naam` getypt is | `/app-create my-app` → `$ARGUMENTS` = `"my-app"` |
+| `$ARGUMENTS[0]` | Eerste positionele argument | Eerste woord na de skill-naam |
+| `${CLAUDE_SKILL_DIR}` | Absoluut pad naar de skill-folder | Voor verwijzingen naar bundled scripts |
+| `` !`command` `` | Shell-output geïnjecteerd vóór de skill laadt | `` !`git branch --show-current` `` injecteert de huidige branch |
+
+Vooral de `` !`command` ``-syntax is krachtig: hij draait *voordat* de skill in context komt, dus je kunt runtime-informatie (current branch, git-user, datum) als context meegeven aan Claude. Niet nodig voor onze mini-skill, maar goed om te kennen voor wanneer je meer dynamische skills schrijft.
+
+### De gebruiker iets vragen: `AskUserQuestion`
+
+Sommige skills hebben input nodig die je niet uit shell-commando's kunt afleiden — bijvoorbeeld een keuze tussen twee aanpakken, of confirmatie vóór een destructieve actie. Daarvoor is er de **`AskUserQuestion`** tool: een ingebouwde Claude Code-tool waarmee een skill midden in z'n uitvoering een korte multiple-choice vraag aan de gebruiker stelt en op het antwoord wacht.
+
+In je `SKILL.md` instrueer je 'm gewoon in tekst:
+
+```markdown
+3. **Confirm before applying**
+
+   Use the `AskUserQuestion` tool to ask: *"Apply this migration to the
+   production database?"* with options `Yes, apply now` and `No, abort`.
+   Only continue to step 4 if the user picks the first option.
+```
+
+Wanneer gebruiken: bij beslismomenten waar Claude niet zelfstandig mag kiezen (production-deploys, branch-strategie, gevoelige refactors). Wanneer níet: voor info die je uit `git`, `gh` of het bestand zelf kunt halen — dan is `` !`command` `` of een Read-call sneller en minder storend. Voor `git-status-summary` is er geen keuzemoment, dus we gebruiken hem niet — maar onthou hem voor je volgende, zwaardere skill.
+
+## Stap 4 — Lokaal testen
+
+Vóór je de skill deelt: test hem zelf. Drie soorten tests:
+
+### A. Handmatige trigger
+
+Open een Claude-sessie in een Git-repo met wat unstaged wijzigingen en typ:
+
+```
+/git-status-summary
+```
+
+Wat je verwacht: een nette samenvatting in het beloofde formaat. Wat je controleert: klopt de telling? Mist er een bestand? Worden staged + unstaged dubbel getoond bij gemengde wijzigingen?
+
+### B. Auto-trigger checklist
+
+De moeilijkere test: triggert hij automatisch wanneer hij zou moeten, en blijft hij stil wanneer dat niet zou moeten?
+
+| Prompt | Verwacht gedrag |
+|---|---|
+| "Wat is er veranderd in mijn working tree?" | **Should trigger** |
+| "Geef me een overzicht van staged en unstaged" | **Should trigger** |
+| "Show me the diff for src/App.vue" | **Should not trigger** (dat is `git diff`, niet status) |
+| "Commit my changes" | **Should not trigger** (write-actie, niet status) |
+| "Wat doet git rebase?" | **Should not trigger** (informatieve vraag) |
+
+Loopt een prompt mis? Pas de `description` aan en probeer opnieuw. Triggert hij over-eager? Voeg specifiekere woorden toe ("working tree", "staged/unstaged/untracked"). Triggert hij niet vaak genoeg? Haal jargon weg en voeg natuurlijke termen toe ("git status overview", "what's changed").
+
+### C. Edge cases
+
+- **Lege repo** — geen commits, geen wijzigingen. Krijg je de "Working tree clean" boodschap?
+- **Alleen untracked** — `echo "test" > new.txt` zonder add. Wordt alleen de Untracked-groep getoond?
+- **Bestand met spaties** — `touch "my file.txt" && git add "my file.txt"`. Wordt de naam correct gerenderd?
+
+## Stap 5 — Globaal of per project?
+
+Nu de skill werkt, is de vraag: waar laat je hem staan?
+
+<HexCard title="~/.claude/skills/ — globaal">
+  Voor skills die je in <strong>elke repo</strong> bruikbaar vindt. Onze <code>git-status-summary</code> is hier een goede kandidaat — het is een algemeen Git-hulpmiddel. Nadeel: je teamgenoten hebben hem niet automatisch.
+</HexCard>
+
+<HexCard title="repo/.claude/skills/ — per project">
+  Voor skills die <strong>specifiek voor deze repo</strong> zijn (eigen quality-gates, eigen workflow, eigen domein-kennis). Voordeel: je commit hem, je team heeft hem, en CI/Hydra-containers gebruiken dezelfde versie. Bijna alle skills in Conduction-repo's leven hier.
+</HexCard>
+
+<HexCard title="vendor/skills/ — extern">
+  Voor skills die je <strong>van buiten</strong> importeert (Anthropic-community, Trail of Bits, OWASP). Apart houden helpt bij audit-spoor en onderhoud — externe skills muteer je niet, je volgt de bron.
+</HexCard>
+
+Voor `git-status-summary` is globaal prima. Voor een fictieve `conduction-quality-check`-skill die de Conduction-specifieke PHPCS/Psalm/ESLint-config draait, hoort het in `.claude/skills/` van de project-repo zelf.
+
+## Stap 6 — Opnemen in de skill-registry
+
+Binnen Conduction houden we een lijst bij van alle interne skills (zowel persoonlijk relevant als project-niveau). Als je een nieuwe skill schrijft die voor het team waardevol is:
+
+1. **Voeg 'm toe aan de relevante repo** — meestal `<repo>/.claude/skills/<naam>/` met een gewone commit.
+2. **Update de `README.md` van die `.claude/skills/`-folder** als die bestaat — voeg een regel toe met naam, één-zin-omschrijving, en wanneer je hem aanroept.
+3. **Update de Hydra skill-docs in [`ConductionNL/.github`](https://github.com/ConductionNL/.github)** als de skill in een Hydra-pipeline meedraait — de centrale documentatie over welke skills Hydra kent, in welke familie ze horen en wat ze doen, leeft daar. Zonder die update weet de rest van het team (en latere Hydra-runs) niet dat je skill bestaat.
+4. **Open een PR** en laat één teamgenoot de skill triggeren in zijn eigen sessie. Niet de description theoretisch beoordelen — letterlijk een prompt typen die zou moeten triggeren.
+
+Voor globaal-persoonlijke skills (`~/.claude/skills/`) hoeft niets gecommit te worden — het is je eigen workshop.
+
+## Veelgemaakte beginnersfouten
+
+| Symptoom | Oorzaak | Fix |
+|---|---|---|
+| Skill triggert nooit automatisch | `description` is te vaag of mist trigger-woorden | Herschrijf in derde persoon, action-werkwoord vooraan, concrete zelfstandige naamwoorden uit de gebruiker-vraag |
+| Skill triggert te vaak op onverwante prompts | `description` is te breed of overlapt met andere skills | Voeg specifieke afbakening toe ("only for X, not Y") |
+| `/skill-naam` werkt niet | `name`-veld in frontmatter wijkt af van mapnaam | Maak ze identiek (folder `git-status-summary` → `name: git-status-summary`) |
+| Skill doet iets onverwachts destructiefs | Geen guardrails | Voeg een **Guardrails** sectie toe met expliciete "never do X"-regels |
+| Skill werkt op één laptop, niet op een andere | Hardcoded paden of OS-specifieke commando's | Gebruik relatieve paden; check OS-afhankelijke commando's (`grep` vs `ggrep`, etc.) |
+
+## Test jezelf
+
+Vier korte vragen om te checken of je dit deel begrepen hebt. Vastgelopen? Klik **Hint**. Curieus naar het antwoord? Klik **Antwoord**.
+
+<div className="tutorial-quiz">
+
+**1. Hoe test je een skill voordat je hem deelt met het team?**
+
+<Details summary="Hint">
+
+Drie soorten tests: een handmatige, een over auto-triggering, en eentje voor randgevallen. Wat doet elk daarvan?
+
+</Details>
+
+<Details summary="Antwoord">
+
+Drie niveaus:
+
+1. **Handmatige trigger** — typ `/skill-naam` in een sessie waar de skill van toepassing is. Controleer of de output klopt en het formaat strak is.
+2. **Auto-trigger checklist** — verzin 5+ prompts die wél moeten triggeren en 5+ die níet mogen triggeren. Loop ze één voor één door. Triggert hij te weinig? `description` te vaag. Te vaak? `description` te breed.
+3. **Edge cases** — test situaties die voorzienbaar mis kunnen gaan (lege input, speciale tekens, ontbrekende dependencies). Een skill die de happy path doet maar de leeg-geval mist, is niet af.
+
+Pas na alle drie deel je hem — anders ontdek je problemen in een teamgenoot z'n sessie in plaats van je eigen.
+
+</Details>
+
+</div>
+
+<div className="tutorial-quiz">
+
+**2. Waar zou je een skill voor "Conduction-specifieke PR-template invullen" plaatsen — globaal of per project?**
+
+<Details summary="Hint">
+
+De vraag is: voor wie is dit nuttig? Alleen jij, of het hele team?
+
+</Details>
+
+<Details summary="Antwoord">
+
+**Per project**, in `<repo>/.claude/skills/`. Reden: het is Conduction-specifiek (een algemene Claude-gebruiker zou er niets aan hebben) en je wilt dat het hele team — én Hydra's containers — dezelfde versie heeft. Commit hem in Git, zodat hij meekomt met elke fresh checkout.
+
+Globaal (`~/.claude/skills/`) is voor skills die jij over álle repo's heen handig vindt en die niets met de specifieke codebase te maken hebben. Bijvoorbeeld: een persoonlijke `summarise-clipboard` skill.
+
+</Details>
+
+</div>
+
+<div className="tutorial-quiz">
+
+**3. Waarom moet de `name` in de frontmatter exact gelijk zijn aan de mapnaam?**
+
+<Details summary="Hint">
+
+De naam die je achter `/` typt moet ergens vandaan komen. Wat ziet Claude eerst — de map of het frontmatter-veld?
+
+</Details>
+
+<Details summary="Antwoord">
+
+Claude vindt skills door je `~/.claude/skills/` en `.claude/skills/` te scannen op mappen met een `SKILL.md`. Voor de slash-trigger kijkt hij naar het `name`-veld in de frontmatter. Komen die niet overeen, dan zijn er twee mogelijke symptomen:
+
+- **`/foldername` werkt niet** maar `/nameveld` wel — verwarrend, want je teamgenoot kent alleen de mapnaam uit Git.
+- **Auto-trigger werkt onverwacht** — Claude koppelt de description aan het frontmatter-name, niet aan de mapnaam.
+
+Vuistregel: kies één naam, gebruik 'm overal hetzelfde. `skill-creator` zorgt dat dit klopt; bij handmatig scaffolden moet je er zelf op letten.
+
+</Details>
+
+</div>
+
+<div className="tutorial-quiz">
+
+**4. Je hebt een skill die soms over-eager triggert op onverwante prompts. Wat is je eerste actie?**
+
+<Details summary="Hint">
+
+Welk veld bepaalt wanneer Claude een skill oppikt? En welk gereedschap heb je om dat veld te valideren?
+
+</Details>
+
+<Details summary="Antwoord">
+
+Pas de **`description`** aan. Concreet:
+
+1. **Maak hem specifieker** — voeg trigger-woorden toe die alleen bij de bedoelde situatie passen ("for the current Git working tree", niet alleen "for changes").
+2. **Voeg afbakening toe** — een korte zin als "Only for X, not Y" werkt verrassend goed.
+3. **Test opnieuw** met je should-trigger / should-not-trigger checklist (zie vraag 1).
+
+Pas als de description al ijzersterk is en hij nóg over-eager is, overweeg `disable-model-invocation: true` om auto-triggering helemaal uit te zetten en alleen `/<naam>` toe te staan. Dat is een laatste redmiddel — meestal lost een betere description het op.
+
+</Details>
+
+</div>
+
+<NextSteps title="Volgende stap" lede="Je skill werkt nu. In deel 3 leer je hoe je systematisch meet of hij blijft werken — met skill-evals.">
+  <NextStep
+    title="Deel 3 — Skill-evals: meten of je skill werkt"
+    href="/nl/academy/claude-skills-tutorial-3-skill-evals"
+    description="Test-scenario's schrijven, baseline-meting, trigger-tests. Hoe je van een 'voelt goed' skill naar een gemeten skill gaat (Maturity Level 5)."
+  />
+  <NextStep
+    title="Vorige stap — Wat zijn Claude Skills?"
+    href="/nl/academy/claude-skills-tutorial-1-wat-zijn-claude-skills"
+    description="De concept-introductie als je nog wilt teruglezen."
+  />
+  <NextStep
+    title="Anthropic skill-creator op GitHub"
+    href="https://github.com/anthropics/skills/blob/main/skills/skill-creator/SKILL.md"
+    description="De officiële skill-creator skill, met scripts voor scaffolden, eval-runner, en description-optimizer."
+  />
+</NextSteps>
+
+<ContactCta
+  title="Vastgelopen bij je eerste skill?"
+  body="Stuur ons je SKILL.md en de prompts waarmee je test — we kijken even mee en helpen je 'm sneller goed te krijgen."
+  cta={{ label: "Mail Conduction", href: "mailto:info@conduction.nl?subject=Claude%20Skills%20leerlijn%20deel%202" }}
+/>

--- a/i18n/nl/docusaurus-plugin-content-blog/2026-05-15-claude-skills-tutorial-3-skill-evals/index.mdx
+++ b/i18n/nl/docusaurus-plugin-content-blog/2026-05-15-claude-skills-tutorial-3-skill-evals/index.mdx
@@ -1,0 +1,346 @@
+---
+slug: claude-skills-tutorial-3-skill-evals
+title: "Claude Skills leerlijn — Deel 3: Skill-evals — meten of je skill werkt"
+contentType: tutorial
+authors: [conduction]
+date: 2026-05-15
+summary: Van een skill die "goed voelt" naar een skill die gemeten goed werkt. Test-scenario's schrijven, baseline-meting, trigger-tests, en de eval-runner van /skill-creator. Derde van vier korte modules.
+tags: [Claude, Claude Code, Skills, AI, Evals, Tutorial series]
+apps: []
+durationMinutes: 15
+series: claude-skills-tutorial
+partNumber: 3
+---
+
+import {Outcomes, Outcome, Prerequisites, PrerequisiteItem, NextSteps, NextStep, HexCard, ContactCta} from '@conduction/docusaurus-preset/components';
+import Details from '@theme/Details';
+
+Je hebt nu een werkende skill — maar werkt hij ook écht goed? En blijft hij goed werken als Claude zelf een upgrade krijgt of als je de skill aanpast? Dit derde, optionele deel laat zien hoe je een skill systematisch evalueert: test-scenario's, trigger-tests, een baseline-meting, en de eval-runner die `/skill-creator` voor je inricht. Dit is de stap van Maturity Level 4 ("voelt goed") naar Level 5 ("gemeten goed").
+
+{/* truncate */}
+
+<Outcomes title="Wat je leert in dit deel">
+  <Outcome>Waarom skills die alleen "goed voelen" blinde vlekken hebben, en wat een baseline-meting daaraan toevoegt.</Outcome>
+  <Outcome>Het <code>evals/evals.json</code>-formaat schrijven: prompts, expectations, trigger-tests.</Outcome>
+  <Outcome>De eval-runner van <code>/skill-creator</code> draaien en de uitkomst lezen (<code>timing.json</code>, <code>grading.json</code>).</Outcome>
+  <Outcome>Wanneer een skill genoeg evals heeft om Maturity Level 5 te claimen — en wanneer je verder moet naar Level 6.</Outcome>
+</Outcomes>
+
+<Prerequisites title="Wat je nodig hebt">
+  <PrerequisiteItem>Deel 1 en 2 doorgenomen, en idealiter een eigen werkende skill om te evalueren (de <code>git-status-summary</code> uit deel 2 werkt prima als oefenobject).</PrerequisiteItem>
+  <PrerequisiteItem>De <code>skill-creator</code> skill geïnstalleerd — de eval-runner zit daarin verstopt.</PrerequisiteItem>
+  <PrerequisiteItem>Een paar concrete scenario's waarin jouw skill is gebruikt of zou worden gebruikt — anders kun je geen realistische evals schrijven.</PrerequisiteItem>
+</Prerequisites>
+
+## Waarom meten? De 7 maturity-niveaus, kort
+
+Skills doorlopen zeven volwassenheidsniveaus, elk bovenop het vorige. Je hoeft niet alles te bouwen — een eenvoudig hulpmiddel hoeft niet voorbij L3 te komen. Maar voor skills die kritisch zijn (hele pipelines, gates, dagelijkse workflows) wil je verder dan "voelt goed":
+
+| Level | Wat erbij komt | Voor wie |
+|---|---|---|
+| **L1** Anatomy | `SKILL.md` met frontmatter, genummerde stappen, guardrails | Iedereen |
+| **L2** Golden Rule | Optimale `description`, progressive disclosure, &lt;500 regels | Iedereen die wil dat de skill goed triggert |
+| **L3** Foundations | Gebouwd op proven patterns, met `examples/` of `references/` | Skills die meer dan een quick utility zijn |
+| **L4** Personalisation | Bevat business-specifieke kennis (jouw ADRs, standaarden, domein) | Conduction-specifieke skills |
+| **L5** Measurement | Heeft 3+ evals, trigger-tests, en `last_validated` is gezet | **Hier zit dit deel** |
+| **L6** Self-improvement | Houdt `learnings.md` bij, consolideert periodiek | Skills die je intensief gebruikt |
+| **L7** Workforce | Orkestreert sub-agents of zit in een workflow-keten | Hydra-achtige pipelines |
+
+Dit deel brengt je van L4 naar L5. Onderzoek toont aan dat ~80% van community-skills de output *slechter* maakt; de 20% die werkt is gebouwd door domein-experts mét iteratieve evaluatie. Meten is wat het verschil maakt.
+
+## Het probleem: wat je niet meet, weet je niet
+
+Een skill die "goed voelt" maar nooit gemeten is, kan drie verborgen problemen hebben:
+
+1. **Geen baseline** — je weet niet of de skill beter is dan Claude zonder skill. Misschien voegt hij niets toe.
+2. **Onbekende auto-triggering** — je hebt 'm twee keer met succes met `/` aangeroepen, maar Claude pikt 'm in normale gesprekken nooit op. Of juist veel te vaak.
+3. **Regressie na een edit** — je tweakt de `description` om scenario A te fixen en breekt onbedoeld scenario B.
+
+Evals lossen alle drie op.
+
+## De drie soorten meting
+
+| Meting | Antwoordt op de vraag | Output |
+|---|---|---|
+| **Eval scenarios** | Doet de skill wat hij moet doen op realistische prompts? | `grading.json` — pass/fail per scenario |
+| **Trigger tests** | Triggert hij wel/niet automatisch zoals bedoeld? | `should_trigger` / `should_not_trigger` slagings-percentage |
+| **Baseline** | Is de skill beter dan Claude zonder skill? | Een vergelijking naast elkaar |
+
+Je hebt alle drie nodig voor een schone L5-claim.
+
+## Het `evals.json`-formaat
+
+Maak in je skill-folder een subfolder `evals/` aan met daarin `evals.json`:
+
+```json
+{
+  "skill_name": "git-status-summary",
+  "version": "1.0.0",
+  "created": "2026-05-15",
+  "last_validated": null,
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Geef een overzicht van wat er in mijn working tree is veranderd",
+      "expected_output": "Summary grouped by staged / unstaged / untracked with file paths",
+      "files": [],
+      "expectations": [
+        "uses the three-group format from SKILL.md",
+        "calls git status --porcelain, not the plain git status",
+        "shows file path AND change type per line",
+        "omits empty groups"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "What's currently staged for commit?",
+      "expected_output": "Only the Staged group is shown when nothing else has changes",
+      "files": [],
+      "expectations": [
+        "shows Staged group with correct file count",
+        "does not invent files not in git status",
+        "does not run git add or any write commands"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Show me my git status",
+      "expected_output": "Triggers the skill and produces the canonical three-group summary",
+      "files": [],
+      "expectations": [
+        "skill auto-activates on this prompt",
+        "produces full three-group format even if some groups are empty (they should be omitted)"
+      ]
+    }
+  ],
+  "trigger_tests": {
+    "should_trigger": [
+      "Wat is er veranderd in mijn working tree?",
+      "Show me my git status",
+      "Geef me een overzicht van staged en unstaged",
+      "What files are currently modified?",
+      "Summarise my working tree",
+      "Is er nog iets onveranderd dat ik vergeten ben te committen?",
+      "What's the state of my repo right now?",
+      "Welke files staan er klaar voor commit?",
+      "Give me a working tree status overview",
+      "Hoe ziet mijn git-tree er nu uit?"
+    ],
+    "should_not_trigger": [
+      "Show me the diff for src/App.vue",
+      "Commit my changes",
+      "Push to the remote branch",
+      "What does git rebase do?",
+      "Explain the difference between git merge and rebase",
+      "Help me write a commit message",
+      "Run git log for me",
+      "How do I resolve this merge conflict?",
+      "Pull the latest changes from main",
+      "What is a feature branch?"
+    ]
+  }
+}
+```
+
+Drie stukken om op te merken:
+
+1. **3+ evals zijn het minimum** voor L5. Schrijf ze vanuit realistisch gebruik — wat zou een teamgenoot écht intypen?
+2. **10+ should-trigger en 10+ should-not-trigger** prompts. Saaier om te schrijven dan je denkt, maar onmisbaar — dit is waar over-eagerness en blinde vlekken zichtbaar worden.
+3. **`last_validated: null`** — dit veld zet de runner zelf wanneer hij draait. Zolang het `null` is, telt je skill nog niet als gemeten.
+
+## De eval-runner draaien
+
+`/skill-creator` heeft een ingebouwde eval-runner. Open een Claude-sessie in een repo met je skill en typ:
+
+```
+/skill-creator
+```
+
+Zeg in je eerste prompt iets als: *"Ik wil de evals draaien voor mijn `git-status-summary` skill."* `/skill-creator` herkent dat je in de evaluatie-fase zit en doet vier dingen:
+
+1. **Spawnt parallel twee subagents** — eentje met toegang tot je skill, eentje zonder (baseline).
+2. **Draait elke eval-prompt** in beide contexten, registreert tokens en duur in `timing.json`.
+3. **Toetst de output tegen je `expectations`** en schrijft pass/fail naar `grading.json`.
+4. **Opent een lokale benchmark-viewer** waar je beide kanten visueel kunt vergelijken.
+
+Na de run vind je in `evals/`:
+
+```
+evals/
+├── evals.json        ← jouw scenario's
+├── timing.json       ← per scenario: tokens + duur, met- en zonder-skill
+├── grading.json      ← per scenario: assertion pass/fail + bewijs
+└── (eventueel) trigger-results.json
+```
+
+Voor de L5-claim heb je álledrie nodig: `evals.json` (geschreven door jou), `timing.json` (de runner heeft daadwerkelijk gedraaid, geen statische read-only simulatie), én `grading.json` (assertions zijn gescoord). Vergeet ook niet `last_validated` bij te werken in `evals.json` zelf.
+
+## De resultaten lezen
+
+Drie vragen om jezelf te stellen bij elk eval-rapport:
+
+### 1. Slaagt de skill alle expectations?
+
+Open `grading.json` en kijk welke `expectations` `pass: false` opleveren. Elk failed-item is een concreet verbeterpunt: ofwel mist je `SKILL.md` instructie, ofwel zijn de stappen niet specifiek genoeg, ofwel triggert er een edge case die je niet beschreven hebt.
+
+### 2. Is de skill beter dan baseline?
+
+Vergelijk de met-skill output naast de zonder-skill output in de benchmark-viewer. Twee uitkomsten zijn rode vlaggen:
+
+- **Skill = baseline** — beide produceren ongeveer hetzelfde. Je skill voegt niets toe, behalve misschien wat formattering. Overweeg of het de moeite waard is om hem te hebben.
+- **Skill < baseline** — Claude zonder skill is *beter*. Dit gebeurt vaker dan je denkt; de skill kan over-prescriptief zijn, of in conflict met wat Claude al goed kan. Vereenvoudig de skill of trek 'm in.
+
+### 3. Hoe scoren je trigger-tests?
+
+De runner draait elke `should_trigger` en `should_not_trigger` prompt in een verse context en checkt of de skill (auto-)laadt. Streef naar 90%+ op beide kanten. Onder de 80%? Iterate op de description.
+
+> **Realiteitscheck:** meerdere bronnen rapporteren ~50% auto-activatie zelfs voor goede skills, omdat Claude een vast contextbudget heeft voor skill-descriptions. Bij grote skill-libraries is auto-trigger inherent minder betrouwbaar dan expliciet `/<naam>` typen. Een lage score betekent niet altijd "skill is slecht" — soms is "skill is te één van vele". Eval-resultaten lees je in context.
+
+## Iteratie-cyclus
+
+Eén ronde evals draaien is alleen maar het begin. Het patroon:
+
+```
+schrijf evals → run → lees resultaten → identificeer 1 zwakte → fix → re-run
+```
+
+Eén verbetering per ronde — niet vier tegelijk. Anders weet je achteraf niet welke fix welk verschil maakte.
+
+<HexCard title="Vuistregel: 1 fix per cycle">
+  Identificeer één specifieke zwakte uit de benchmark-viewer (één gefaalde expectation, of één trigger-test die de verkeerde kant op ging). Pas de <code>SKILL.md</code> alleen op dát punt aan. Draai opnieuw. Pas dan ga je door naar de volgende zwakte.
+</HexCard>
+
+## Wanneer is een skill "gemeten genoeg"?
+
+Voor L5-claim heb je minimaal:
+
+- ✅ 3+ evals in `evals.json`
+- ✅ 10+ should-trigger + 10+ should-not-trigger prompts
+- ✅ `last_validated` is gevuld (niet `null`)
+- ✅ Zowel `timing.json` als `grading.json` aanwezig (bewijs dat de runner gedraaid heeft, niet alleen een read-only beoordeling)
+- ✅ Een baseline-meting (skill vs. zonder skill)
+- ✅ Minstens één iteratie-cycle doorlopen op basis van eval-resultaten
+
+Klopt dat allemaal? Dan kun je de skill als L5-mature labellen. Wil je verder — en voor skills die je dagelijks gebruikt of die andere skills aansturen wil je dat — dan komt L6 (`learnings.md` met capture-loop) en uiteindelijk L7 (multi-agent orchestratie). [Deel 4 van de leerlijn](/nl/academy/claude-skills-tutorial-4-l6-l7-mature-skills) loopt die laatste twee niveaus door, plus het dashboard waarmee je je hele skill-library tegelijk op maturity bewaakt. Voor ~80% van de skills is L5 het natuurlijke eindpunt; deel 4 is voor de skills die dat niet zijn.
+
+## Test jezelf
+
+Vier korte vragen om te checken of je dit deel begrepen hebt. Vastgelopen? Klik **Hint**. Curieus naar het antwoord? Klik **Antwoord**.
+
+<div className="tutorial-quiz">
+
+**1. Waarom is een baseline-meting belangrijk bij skill-evals?**
+
+<Details summary="Hint">
+
+Een skill kan slagen op al je expectations en tóch geen waarde toevoegen. Wat zou je daarvoor moeten weten?
+
+</Details>
+
+<Details summary="Antwoord">
+
+Omdat een skill die alle expectations haalt, nog steeds **niets kan toevoegen ten opzichte van Claude zonder skill**. Of erger: Claude zonder skill kan beter zijn (over-prescriptieve skills knellen Claude's eigen oordeel).
+
+De baseline draait elke eval-prompt twee keer: eenmaal met toegang tot je skill, eenmaal zonder. Pas dan kun je zeggen "deze skill maakt verschil X". Zonder baseline meet je alleen of de skill consistent is — niet of hij waardevol is.
+
+Drie mogelijke uitkomsten bij baseline-vergelijk:
+
+- **Skill > baseline** → de skill verdient zijn plek.
+- **Skill ≈ baseline** → twijfelgeval. Overweeg of de winst (formattering, consistentie) opweegt tegen de context-cost.
+- **Skill < baseline** → skill weghalen of fundamenteel herzien.
+
+</Details>
+
+</div>
+
+<div className="tutorial-quiz">
+
+**2. Wat is het verschil tussen `evals` en `trigger_tests` in `evals.json`?**
+
+<Details summary="Hint">
+
+Eén meet of de skill goed werk levert. De andere meet of hij überhaupt op het juiste moment opduikt.
+
+</Details>
+
+<Details summary="Antwoord">
+
+- **`evals`** meet **kwaliteit van uitvoering**: gegeven dat de skill is geladen, doet hij wat hij moet doen? Drie expectations per scenario, getoetst tegen de output. Score: hoeveel expectations slagen?
+- **`trigger_tests`** meet **auto-activatie**: pikt Claude de skill automatisch op bij relevante prompts (`should_trigger`), en blijft hij weg bij niet-relevante prompts (`should_not_trigger`)?
+
+Een skill kan perfect scoren op `evals` maar slecht op `trigger_tests` — dan werkt hij goed *als* je `/<naam>` typt, maar pikt Claude hem nooit zelf op. Andersom: een skill kan altijd triggeren maar slechte output leveren — dan trekt hij ongevraagd aan tafel zonder waarde toe te voegen.
+
+Je hebt beide nodig voor L5.
+
+</Details>
+
+</div>
+
+<div className="tutorial-quiz">
+
+**3. Welke twee bestanden bewijzen dat de eval-runner echt gedraaid heeft, en waarom allebei?**
+
+<Details summary="Hint">
+
+Een statische beoordeling van je `evals.json` is niet voldoende — je hebt bewijs nodig dat er code is uitgevoerd én dat er resultaten zijn gescoord.
+
+</Details>
+
+<Details summary="Antwoord">
+
+- **`timing.json`** bewijst **uitvoering**: per scenario staat hierin hoeveel tokens er zijn gebruikt en hoe lang de run duurde. Dat kan alleen na werkelijke executie — een read-only simulatie kan dit veld niet vullen.
+- **`grading.json`** bewijst **beoordeling**: pass/fail per expectation, met bewijs. Dit is de daadwerkelijke score van je skill.
+
+`grading.json` alleen is niet genoeg — die zou je theoretisch kunnen genereren door een statische read van `SKILL.md` en `evals.json`. Pas met `timing.json` erbij heb je hard bewijs dat de runner ook echt heeft gedraaid.
+
+In de Conduction-skill-check is dit precies waar het script L5 op valideert: beide bestanden moeten bestaan, plus `last_validated` mag niet `null` zijn.
+
+</Details>
+
+</div>
+
+<div className="tutorial-quiz">
+
+**4. Je hebt evals gedraaid en één expectation faalt consistent. Wat is je volgende stap — en wat juist niet?**
+
+<Details summary="Hint">
+
+Niet hagelschot fixen. Wat is de meest leerzame manier om te iteren?
+
+</Details>
+
+<Details summary="Antwoord">
+
+**Wel doen:** identificeer die ene gefaalde expectation, lees in de benchmark-viewer wat de skill in plaats daarvan deed, en pas één specifiek stuk van `SKILL.md` aan (een stap, een guardrail, of een output-voorbeeld). Draai daarna opnieuw — pas dan ga je verder met de volgende zwakte.
+
+**Niet doen:** vier tegelijk fixen, of meteen de `description` overhoop halen omdat "er iets niet goed gaat". Bij meerdere wijzigingen tegelijk weet je niet welke iets bijdroeg. Bij een description-herziening verschuif je auto-triggering en je executie-gedrag tegelijkertijd — onmogelijk om uit elkaar te halen.
+
+Vuistregel: één eval-cyclus = één hypothese = één fix. Saai? Misschien. Maar je leert er sneller van dan van "alles ineens" pogingen.
+
+</Details>
+
+</div>
+
+<NextSteps title="Volgende stap" lede="Dit was deel 3 — je weet nu hoe je een skill systematisch meet en verbetert. Voor de skills die je écht intensief gebruikt is er nog een vervolg.">
+  <NextStep
+    title="Deel 4 — Van gemeten naar lerend en orkestrerend (L6 → L7)"
+    href="/nl/academy/claude-skills-tutorial-4-l6-l7-mature-skills"
+    description="L6 (learnings-loop) en L7 (sub-agent orkestratie), plus het skill-level-overview dashboard waarmee je je hele library tegelijk bewaakt."
+  />
+  <NextStep
+    title="Vorige stap — Je eerste skill schrijven"
+    href="/nl/academy/claude-skills-tutorial-2-je-eerste-skill"
+    description="De praktische module met /skill-creator, frontmatter en lokaal testen."
+  />
+  <NextStep
+    title="Conduction-docs over skill-evals"
+    href="https://github.com/ConductionNL/.github/blob/main/docs/claude/skill-evals.md"
+    description="Verdiepende referentie met het volledige evals.json-schema en de runner-protocol-details."
+  />
+</NextSteps>
+
+<ContactCta
+  title="Klaar om een skill voor je team te schrijven?"
+  body="Of wil je weten of een use-case skill-waardig is? We sparren graag mee. Stuur ons een mail met je voorgestelde use-case en we geven een eerste reactie."
+  cta={{ label: "Mail Conduction", href: "mailto:info@conduction.nl?subject=Claude%20Skills%20leerlijn%20deel%203" }}
+/>

--- a/i18n/nl/docusaurus-plugin-content-blog/2026-05-15-claude-skills-tutorial-4-l6-l7-mature-skills/index.mdx
+++ b/i18n/nl/docusaurus-plugin-content-blog/2026-05-15-claude-skills-tutorial-4-l6-l7-mature-skills/index.mdx
@@ -1,0 +1,346 @@
+---
+slug: claude-skills-tutorial-4-l6-l7-mature-skills
+title: "Claude Skills leerlijn — Deel 4: Van gemeten naar lerend en orkestrerend (L6 → L7)"
+contentType: tutorial
+authors: [conduction]
+date: 2026-05-15
+summary: Hoe ga je voorbij L5? L6 zet een learnings-loop op je skill, L7 maakt er een orkestrator van die sub-agents aanstuurt. Plus een blik op het skill-level-overview dashboard waarmee je je hele skill-library in één oogopslag op maturity kunt scannen. Vierde van vier korte modules.
+tags: [Claude, Claude Code, Skills, AI, Maturity, Tutorial series]
+apps: []
+durationMinutes: 18
+series: claude-skills-tutorial
+partNumber: 4
+---
+
+import {Outcomes, Outcome, Prerequisites, PrerequisiteItem, NextSteps, NextStep, HexCard, ContactCta} from '@conduction/docusaurus-preset/components';
+import Details from '@theme/Details';
+
+In deel 3 bracht je een skill van "voelt goed" naar "gemeten goed" — Maturity Level 5. Voor de meeste skills is dat genoeg. Maar voor een handvol skills die je dagelijks gebruikt of die andere skills aansturen, wil je verder: een skill die **leert van zijn eigen executies** (L6), en een skill die **andere agents aanstuurt** in een grotere workflow (L7). Dit vierde deel laat zien hoe je daar komt — én hoe je met het Hydra-dashboard je hele skill-library tegelijk op maturity bewaakt.
+
+{/* truncate */}
+
+<Outcomes title="Wat je leert in dit deel">
+  <Outcome>Wat een learnings-loop is, en hoe een <code>learnings.md</code> + capture-stap je skill iedere executie iets slimmer maakt (L6).</Outcome>
+  <Outcome>De two-stage buffer (<code>learning-candidates.md</code> → <code>learnings.md</code> → <code>SKILL.md</code>) en wanneer je consolideert.</Outcome>
+  <Outcome>Hoe een skill een orkestrator wordt: sub-agents spawnen, workflow-chains, hand-off, fan-out/fan-in patronen (L7).</Outcome>
+  <Outcome>Het verschil tussen <em>structureel</em> L7 en <em>mature</em> L7 — en waarom je beide nodig hebt.</Outcome>
+  <Outcome>Het <code>skill-level-overview.html</code> dashboard en het <code>update-skill-overview.sh</code> script die je hele skill-library live op maturity tonen.</Outcome>
+</Outcomes>
+
+<Prerequisites title="Wat je nodig hebt">
+  <PrerequisiteItem>Deel 1, 2 en 3 doorgenomen — vooral deel 3, want L6 en L7 bouwen direct op L5 metingen.</PrerequisiteItem>
+  <PrerequisiteItem>Een skill die je minstens een paar weken intensief hebt gebruikt. L6 zonder echte execution-historie is een lege schil.</PrerequisiteItem>
+  <PrerequisiteItem>Voor L7: een use-case waarin je werk parallel kunt verdelen of die zich in een keten van skills laat ontleden.</PrerequisiteItem>
+</Prerequisites>
+
+## Recap: de 7 niveaus, en waar we nu zijn
+
+| Level | Wat erbij komt |
+|---|---|
+| L1–L4 | Anatomy, golden rule, foundations, business-context |
+| **L5** | 3+ evals, trigger-tests, baseline — *deel 3* |
+| **L6** | `learnings.md` + capture-stap, periodieke consolidatie — *dit deel* |
+| **L7** | Orkestreert sub-agents of zit in een workflow-keten — *dit deel* |
+
+Belangrijk: niveaus zijn **cumulatief in criteria** maar niet altijd in praktijk. Een skill kan een L7-architectuur hebben (spawnt acht parallele agents) zonder L5-evals te hebben — dat heet *structureel L7, maturity L4*. De architectuur is er, de zelfkennis nog niet. Voor échte L7 moet je L1 t/m L6 erbij hebben.
+
+## Niveau 6: Self-Improvement — skills die leren van hun executies
+
+Een L5-skill is gemeten, maar statisch. Elke executie verloopt los van de vorige; wat je vorige week leerde, vergeet de skill morgen. **L6 lost dat op met een learnings-loop**:
+
+```
+Executie  →  observaties vastleggen  →  learnings.md  →  consolidatie  →  SKILL.md-regels
+                                          ↑                              │
+                                          └──────────────────────────────┘
+```
+
+### De ingrediënten
+
+Drie dingen maken een skill L6-mature:
+
+1. Een **`learnings.md`** in de skill-folder.
+2. Een **"Capture Learnings"-stap** aan het einde van `SKILL.md` — Claude wordt aan het einde van elke executie expliciet gevraagd of er iets in de uitvoering opviel dat een toekomstige run kan helpen.
+3. Een **consolidatie-ritme** — typisch bij 80–100 entries kijk je terug, verwijder je verouderde regels, voeg je duplicaten samen, en promoveer je gevalideerde principes naar guardrails in `SKILL.md` zelf.
+
+### Het formaat van `learnings.md`
+
+Elke entry is **gedateerd en atomair** (één inzicht per bullet). De file kent vijf vaste secties:
+
+```markdown
+# Learnings — create-pr
+
+## Patterns That Work
+- 2026-03-15: Branch protection op `main` vraagt status checks — altijd eerst verifiëren dat ze bestaan.
+- 2026-03-20: GitHub issue-nummer in PR-titel verbetert traceability.
+
+## Mistakes to Avoid
+- 2026-03-18: NIET een PR maken met uncommitted changes — onduidelijk wat er meegaat.
+- 2026-03-22: composer.lock-conflict → lokaal `composer update` draaien, niet één kant accepteren.
+
+## Domain Knowledge
+- 2026-03-19: Conduction-repos gebruiken `development` als primaire integratie-branch, niet `main`.
+
+## Open Questions
+- Moeten PRs reviewers auto-assignen via CODEOWNERS?
+
+## Consolidated Principles
+- (gepromoot na 3+ bevestigingen)
+- Draai altijd `composer check:strict` vóór PR-aanmaak — vangt 90% van review-feedback af.
+```
+
+### De "Capture Learnings"-stap in `SKILL.md`
+
+`learnings.md` vult zichzelf niet — Claude doet dat alleen als je hem er expliciet om vraagt. De manier waarop is een vaste stap, helemaal onderaan in `SKILL.md`, na alle uitvoeringsstappen en vóór de guardrails. Hieronder een voorbeeld zoals het in Conductions `create-pr`-skill staat — kort, met de vijf rubrieken vooropgesteld zodat Claude ze niet vergeet:
+
+```markdown
+## Capture Learnings
+
+After execution, review what happened and append new observations to
+[learnings.md](learnings.md) under the appropriate section:
+
+- **Patterns That Work** — approaches that produced good results
+- **Mistakes to Avoid** — errors encountered and how they were resolved
+- **Domain Knowledge** — facts discovered during this run
+- **Open Questions** — unresolved items for future investigation
+
+Each entry must include today's date. One insight per bullet.
+**Skip if nothing new was learned** — do NOT invent learnings to fill the section.
+```
+
+Drie dingen om op te merken:
+
+1. **Het is een stap, geen suggestie.** Door hem als `## Capture Learnings`-sectie te formatteren staat hij in dezelfde "doe-dit"-modus als de andere genummerde stappen. Een vrijblijvende zin als "denk eraan om eventueel iets op te schrijven" wordt door Claude vaak overgeslagen.
+2. **"Skip if nothing new was learned"** is cruciaal. Zonder die regel produceert Claude *altíjd* iets — pseudo-inzichten zoals "de skill werd succesvol uitgevoerd". Dat is precies het soort ruis dat `learnings.md` snel vervuilt en bij elke run je context-budget opslokt.
+3. **Per sectie expliciet de bedoeling vermelden** — niet alleen de naam. "Patterns That Work" alléén triggert generieke inhoud; "approaches that produced good results" stuurt Claude naar gericht observerend gedrag.
+
+Variant voor skills met een container/headless-modus: voeg een tabel toe boven aan `SKILL.md` die expliciet zegt dat de Capture Learnings-stap in headless-mode wordt overgeslagen (een container-filesystem is wegwerp — schrijven naar `learnings.md` is verspilling). De `opsx-apply`-skill doet dat zo:
+
+```markdown
+| Stap | Interactive mode | Headless mode (CI) |
+|---|---|---|
+| Capture Learnings | Append to `learnings.md` | **Skip** — container filesystem is disposable |
+```
+
+### De two-stage buffer (sterk aanbevolen)
+
+Het naïeve patroon — élke observatie direct in `learnings.md` schrijven — vult het bestand snel met ruis. Een teamgenoot meldde iets dat "vreemd voelde" maar bij nader inzien een toevallige fluctuatie was; nu staat het er, en bij elke run leest Claude het mee.
+
+De fix is een **two-stage buffer**:
+
+```
+learning-candidates.md  →  (promotie-criteria gehaald?)  →  learnings.md  →  SKILL.md-regels
+        ↓ (nee)
+   verwijderd na 30 dagen
+```
+
+Promotie-criteria zijn bewust streng:
+- Observatie minstens **3 keer bevestigd** in losse executies, **óf**
+- Observatie lost een **gemeten eval-failure** op uit deel 3.
+
+Zo blijft `learnings.md` schoon en wordt context-budget niet verspeeld aan eenmalige toevalligheden.
+
+### Wanneer consolideer je?
+
+Bij ~80–100 entries wordt `learnings.md` zelf een context-last. Trigger op dat moment een consolidatie-ronde:
+
+1. **Verouderd?** — verwijderen (de bug is gepatcht, de regel niet meer relevant).
+2. **Duplicaten?** — samenvoegen tot één scherpere bullet.
+3. **Cross-cutting patroon?** — promoveer naar de "Consolidated Principles"-sectie.
+4. **Gevalideerd principe?** — schrijf het als guardrail of stap rechtstreeks in `SKILL.md`, en haal de losse observaties die ernaar leidden uit `learnings.md`.
+
+<HexCard title="L6 in één regel">
+  Een L6-skill heeft een <code>learnings.md</code> met gedateerde, atomaire entries; <code>SKILL.md</code> eindigt met een "Capture Learnings"-stap; en je consolideert periodiek zodat principes in regels veranderen.
+</HexCard>
+
+## Niveau 7: AI Workforce — skills die andere agents aansturen
+
+L7 is geen "betere skill" — het is een **andere soort skill**. Een L7-skill levert geen output zelf, maar **coördineert** een team van sub-agents of zit zelf in een keten van skills die naar elkaar handoffen.
+
+### Criteria (boven op L6)
+
+- **Spawnt sub-agents** (parallelle workers) **óf** wordt zelf aangeroepen door een parent-skill.
+- Zit in een **gedefinieerde workflow-chain** met expliciete hand-off-punten:
+  ```
+  opsx-new → opsx-ff → opsx-plan-to-issues → opsx-apply → opsx-verify → opsx-archive
+  ```
+- **Geeft context door** aan de volgende skill (toont "Next step: run `/opsx-verify`").
+- Gebruikt **geïsoleerde execution-contexten** waar nodig (git worktrees, Docker, sandbox).
+- Heeft **autonomy** binnen een gedefinieerde scope — niet alles vraagt om bevestiging.
+- Doet **parallel werk** (acht agents tegelijk, fan-out/fan-in).
+
+### Orkestratie-patronen in Hydra
+
+| Patroon | Voorbeeld in Hydra | Beschrijving |
+|---|---|---|
+| **Pipeline** | `opsx-pipeline` | Volledige lifecycle voor 1+ changes parallel via subagents |
+| **Fan-out/Fan-in** | `test-counsel`, `feature-counsel` | N agents parallel spawnen, daarna één synthese |
+| **Sequential Chain** | `opsx-new → … → opsx-archive` | Elke skill handoft naar de volgende |
+| **Autonomous Loop** | `opsx-apply-loop` | Draait apply→verify-cycle met retry, auto-archive |
+| **Multi-perspective** | `test-app` | Zes gespecialiseerde test-agents simultaan |
+
+### Structureel L7 ≠ mature L7
+
+Het is verleidelijk om een orkestrator op te tuigen en je werk klaar te verklaren. Maar als die orkestrator geen evals heeft (L5) en geen learnings-loop (L6), heb je een **complexe machine zonder zelfkennis**. Hij dóét veel; je weet niet hoe goed.
+
+Dat heet *structureel L7, maturity L4*. Het probleem: zodra hij faalt, weet niemand wáár in de keten het misging, en de fout herhaalt zich morgen weer. Voor échte L7 moet je de L5- en L6-gaten dichten — meet de keten als geheel én op handoff-punten, en laat de orkestrator zelf observaties capturen.
+
+<HexCard title="L7 in één regel">
+  Een L7-skill orkestreert anderen — maar pas als hij óók is gemeten (L5) en leert (L6) is hij ook écht mature; daarvoor is het architectuur zonder zelfreflectie.
+</HexCard>
+
+## De hele library bewaken: het skill-level-overview-dashboard
+
+Eén skill op L6 of L7 brengen is overzichtelijk. Maar zodra je een library van tien, twintig of (zoals in Hydra) ~70 skills hebt, wil je in één oogopslag zien welke skill op welk niveau zit — en welke achteruit kachelen.
+
+Daarvoor zitten er in de Conduction-skill-toolchain twee bestanden onder `.claude/skills/`:
+
+- **`skill-level-overview.html`** — een lokaal, statisch HTML-dashboard. Eén tabel met per skill: huidige maturity (groene dots), target maturity (badge), regelaantal van `SKILL.md` (gekleurd: groen ≤200, geel rond 450, rood >500), en oranje rings voor "structureel aanwezig maar nog niet mature". Sorteerbaar per kolom. Je opent 'm lokaal — `xdg-open` op Linux, `open` op macOS, of dubbelklik in de file-explorer.
+- **`update-skill-overview.sh`** — een bash-script dat over alle skill-folders heen scant, structurele markers detecteert (frontmatter aanwezig, guardrails, evals met genoeg trigger-tests, dated learnings, agent-spawns), en de HTML up-to-date schrijft. Eén `./update-skill-overview.sh` en je dashboard klopt weer.
+
+### Wat het script automatisch doet
+
+Het script detecteert:
+
+| Niveau | Wat het script meet |
+|---|---|
+| **L1** | Frontmatter aanwezig, genummerde stappen, guardrail-secties of directieven, `name:` matcht foldernaam |
+| **L2** | `SKILL.md` ≤500 regels en `description:` is gevuld |
+| **L3** | Proven patterns + `examples/` of `references/` of `templates/` aanwezig |
+| **L4** | **NOOIT automatisch** — moet je handmatig bevestigen (domein-kennis is mensenwerk) |
+| **L5** | `evals/evals.json` met 3+ scenario's, 10+ should-trigger, 10+ should-not-trigger, `last_validated` gevuld, plus `grading.json` én `timing.json` |
+| **L6** | `learnings.md` met gedateerde entries + "Capture Learnings"-stap in `SKILL.md` |
+| **L7** | Verwijzingen naar `Agent tool`, `subagent` of `Task agents` in `SKILL.md` |
+
+Belangrijke ontwerpkeuze: **L4 wordt nooit automatisch gezet**. Domein-kennis is niet detecteerbaar uit bestandsstructuur — alleen jij kunt zeggen of een skill jouw business écht kent. Het script roept luidruchtig om aandacht als L1–L3 staan maar L4 nog niet bevestigd is.
+
+### Hoe je dit voor je eigen project opzet
+
+De canonieke `skill-level-overview.html` + `update-skill-overview.sh` zitten in Conductions interne skill-toolchain. Twee paden om er zelf mee aan de slag te gaan:
+
+- **Vraag de bestanden op** — mail ons via de CTA onderaan deze pagina; we delen de huidige versie graag met klanten en partners als startpunt. Daarna is het `cp` naar `<jouw-repo>/.claude/skills/` en `bash .claude/skills/update-skill-overview.sh` draaien.
+- **Bouw zelf** — de meet-regels uit de tabel hierboven zijn alles wat je nodig hebt. Een paar uur bash + een simpele HTML-tabel-template levert al een werkende v1.
+
+Een natuurlijke plek om het script te draaien: vóór een release-tag, in een pre-commit hook op de skills-folder, of als wekelijkse cron. Zo zie je drift (een skill die naar 520 regels groeit en dus L2 verliest) meteen.
+
+<HexCard title="Vuistregel: weekly scan + per-skill consolidatie">
+  Draai <code>update-skill-overview.sh</code> wekelijks; consolideer <code>learnings.md</code> per skill ad-hoc bij ~80 entries. Het dashboard vertelt je welke skill aan de beurt is.
+</HexCard>
+
+## Test jezelf
+
+Vier korte vragen om te checken of je dit deel begrepen hebt. Vastgelopen? Klik **Hint**. Curieus naar het antwoord? Klik **Antwoord**.
+
+<div className="tutorial-quiz">
+
+**1. Waarom een two-stage buffer in plaats van direct in `learnings.md` schrijven?**
+
+<Details summary="Hint">
+
+Wat gebeurt er als élke vluchtige observatie meteen permanent wordt opgeslagen?
+
+</Details>
+
+<Details summary="Antwoord">
+
+Omdat directe schrijfacties `learnings.md` snel verontreinigen met eenmalige toevalligheden, foutdiagnoses die later anders bleken te zijn, of observaties die alleen voor één specifieke context relevant waren. Elk daarvan blijft daarna in elke executie meegelezen worden, en eet van je context-budget.
+
+De two-stage buffer (`learning-candidates.md` → `learnings.md`) plaatst een filter ertussen: alleen observaties die minstens 3 keer bevestigd zijn, of die een gemeten eval-failure oplossen, promoveren. De rest valt na 30 dagen vanzelf weg. Het resultaat: `learnings.md` blijft hoogwaardige signalen bevatten, en bij consolidatie heb je echte patronen om te promoten naar `SKILL.md`-guardrails.
+
+</Details>
+
+</div>
+
+<div className="tutorial-quiz">
+
+**2. Wat is het verschil tussen "structureel L7" en "mature L7", en waarom is dat verschil belangrijk?**
+
+<Details summary="Hint">
+
+Een skill kan architecturaal complex zijn zonder ooit gemeten of geleerd te hebben.
+
+</Details>
+
+<Details summary="Antwoord">
+
+- **Structureel L7** betekent dat de skill *de architectuur* van orkestratie heeft: spawnt subagents, zit in een keten, doet hand-offs, draait parallel.
+- **Mature L7** betekent dat die architectuur óók is gemeten (L5) en zichzelf verbetert (L6).
+
+Een "structureel L7, maturity L4" skill is een complexe machine zonder zelfkennis. Hij dóét veel — je weet niet hoe goed. Zodra hij faalt is onduidelijk wáár in de keten het misging, en de fout herhaalt zich morgen.
+
+Het verschil is belangrijk omdat orkestrators groot blast-radius hebben: ze starten meerdere agents, doen meerdere acties, raken meerdere bestanden. Als je daarbij geen evals (L5) en geen learnings (L6) hebt, schaal je fouten net zo hard mee als successen.
+
+</Details>
+
+</div>
+
+<div className="tutorial-quiz">
+
+**3. Waarom zet `update-skill-overview.sh` L4 nooit automatisch?**
+
+<Details summary="Hint">
+
+Wat onderscheidt L4 van L1, L2, L3, L5, L6 en L7 in termen van wat detecteerbaar is?
+
+</Details>
+
+<Details summary="Antwoord">
+
+Omdat L4 — "Personalization / Domain Knowledge" — betekent dat de skill jouw bedrijfsspecifieke kennis bevat (ADRs, naming conventions, business-rules, "wij gebruiken `development` als primaire branch"). Dat is niet detecteerbaar uit bestandsstructuur, regelaantallen of frontmatter-velden.
+
+L1 t/m L3 zijn structureel (frontmatter, guardrails, voorbeelden — een script kan ze zien). L5 t/m L7 zijn structureel óf gedrags-gerelateerd op manieren die in bestanden zichtbaar zijn (evals-json, learnings.md, agent-calls).
+
+Maar L4 vereist een mens die zegt: "ja, deze skill kent ónze codebase, niet alleen generieke best-practices." Daarom roept het script luid om jouw input zodra L1–L3 zijn behaald maar L4 nog niet bevestigd. Tot dat moment blijft de skill op M3 hangen, ook al zijn er structureel al hogere niveaus aanwezig.
+
+</Details>
+
+</div>
+
+<div className="tutorial-quiz">
+
+**4. Een teamgenoot heeft een skill die parallel zes test-agents spawnt, maar geen evals en geen `learnings.md` heeft. Wat zou jij voorstellen — eerst meer orkestratie toevoegen, of eerst iets anders?**
+
+<Details summary="Hint">
+
+Denk aan het verschil tussen architectuur en zelfkennis.
+
+</Details>
+
+<Details summary="Antwoord">
+
+Eerst **niet meer orkestratie**. Deze skill is structureel L7, maturity L4 — de architectuur staat er, maar er is geen meting (L5) en geen lerend gedrag (L6). Meer parallellisme of meer chain-skills toevoegen vergroot alleen de blast-radius.
+
+De juiste volgorde:
+
+1. **L5 eerst** — schrijf 3+ eval-scenario's voor de hele keten en voor de hand-off-punten. Pas dan weet je of de zes parallele agents elkaar niet tegenwerken of dubbel werk doen.
+2. **L6 daarna** — voeg een `learnings.md` toe waarin de orkestrator vastlegt welke patronen tussen agents wel/niet werken (bv. "wanneer agent A en B beide hetzelfde bestand aanraken, ontstaat conflict X").
+3. **Pas dan L7-uitbreiding** — als de keten gemeten en lerend is, kun je hem veilig uitbreiden (meer agents, langere chain, autonome loop).
+
+Vuistregel: orkestratie zonder meting is ongeoorloofd schaalwerk. Eerst weten of de keten werkt, dan groter maken.
+
+</Details>
+
+</div>
+
+<NextSteps title="Volgende stap" lede="Je hebt nu het complete spectrum gezien: van anatomy tot orkestratie, plus het dashboard om je hele library te bewaken. Dit zijn goede volgende stappen.">
+  <NextStep
+    title="Hydra leerlijn — Deel 4: Skills in de Hydra-pipeline"
+    href="/nl/academy/hydra-tutorial-4-skills"
+    description="Zien hoe ~70 skills samen draaien in vier families binnen een echte agentic CI/CD-pipeline. Interne leerlijn voor Conduction-collega's."
+  />
+  <NextStep
+    title="Vorige stap — Skill-evals (L5)"
+    href="/nl/academy/claude-skills-tutorial-3-skill-evals"
+    description="Terug naar de meet-fundering — handig om nog eens door te lezen vóór je L6 op een skill aanzet."
+  />
+  <NextStep
+    title="Conduction-docs — Writing Skills (volledige referentie)"
+    href="https://github.com/ConductionNL/.github/blob/main/docs/claude/writing-skills.md"
+    description="De canonieke 7-level maturity framework-doc waar deze leerlijn op gebaseerd is."
+  />
+</NextSteps>
+
+<ContactCta
+  title="Een orkestrator opzetten voor jouw team?"
+  body="L7-skills zijn waar Hydra zelf op draait. Wil je sparren over of jouw use-case een orkestrator verdient, of hoe je een learnings-loop in je bestaande skill inbouwt? Stuur ons een mail."
+  cta={{ label: "Mail Conduction", href: "mailto:info@conduction.nl?subject=Claude%20Skills%20leerlijn%20deel%204" }}
+/>

--- a/i18n/nl/docusaurus-plugin-content-blog/2026-05-15-deskdesk-tutorial-3-calendar/index.mdx
+++ b/i18n/nl/docusaurus-plugin-content-blog/2026-05-15-deskdesk-tutorial-3-calendar/index.mdx
@@ -168,7 +168,7 @@ Je hebt DeskDesk effectief geïntegreerd in vier Nextcloud-apps met één JSON-b
 <NextSteps>
   <NextStep
     title="Deel 4: Externe kennis + ship"
-    href="/academy/deskdesk-tutorial-4-knowledge-and-ship"
+    href="/nl/academy/deskdesk-tutorial-4-knowledge-and-ship"
     description="Schrijf de desk-zone-kennisartikelen in xWiki, bedraad OpenConnector om ze per bureau te tonen in CnObjectSidebar, package de app, publiceer naar apps.conduction.nl."
   />
   <NextStep

--- a/i18n/nl/docusaurus-plugin-content-blog/2026-05-17-deskdesk-tutorial-4-knowledge-and-ship/index.mdx
+++ b/i18n/nl/docusaurus-plugin-content-blog/2026-05-17-deskdesk-tutorial-4-knowledge-and-ship/index.mdx
@@ -38,7 +38,7 @@ Externe kennis integreren is dé canonieke case voor OpenConnector: data ophalen
 
 <Prerequisites title="Waar je moet staan">
   <PrerequisiteItem>Delen 1 tot en met 3 af: DeskDesk-shell, schema's + manifest, agenda-integratie werken allemaal.</PrerequisiteItem>
-  <PrerequisiteItem>Een lokale Nextcloud + OpenRegister-stack waar je in kunt <code>docker exec</code>'en. De referentie-stack op <a href="/academy/nextcloud-lokaal-draaien">Nextcloud lokaal draaien met Docker</a> is wat we tegen testen; die levert al de xWiki-service die we in Stap 0 starten.</PrerequisiteItem>
+  <PrerequisiteItem>Een lokale Nextcloud + OpenRegister-stack waar je in kunt <code>docker exec</code>'en. De referentie-stack op <a href="/nl/academy/nextcloud-lokaal-draaien">Nextcloud lokaal draaien met Docker</a> is wat we tegen testen; die levert al de xWiki-service die we in Stap 0 starten.</PrerequisiteItem>
   <PrerequisiteItem><strong>OpenConnector</strong> geïnstalleerd en ingeschakeld, voor wanneer je later in de tutorial van seed-data naar een live xWiki-sync overschakelt.</PrerequisiteItem>
 </Prerequisites>
 
@@ -427,12 +427,12 @@ Die verhouding — JSON beschrijft wat je wil, het framework rendert het — is 
 <NextSteps lede="Deel 5 en Deel 6 staan naast elkaar — ze breiden de uitgeleverde app uit in twee onafhankelijke richtingen. Pak ze in willekeurige volgorde, of kies degene die je volgende app het eerst nodig heeft. Deel 5 verdiept het manifest-vlak; Deel 6 verbreedt naar andere systemen. Geen van beide verwijst naar de ander voor inhoud.">
   <NextStep
     title="Deel 5 — Geavanceerde manifest-features"
-    href="/academy/deskdesk-tutorial-5-advanced-manifest"
+    href="/nl/academy/deskdesk-tutorial-5-advanced-manifest"
     description="Voorbij de schema-gedreven CRUD-basis: actionToggles, fieldWidgets, public-mode pagina's en zeven extra page-types. De v2.7.0 manifest-features die Deel 1–4 bewust oversloegen."
   />
   <NextStep
     title="Deel 6 — Integreren"
-    href="/academy/deskdesk-tutorial-6-integrate"
+    href="/nl/academy/deskdesk-tutorial-6-integrate"
     description="Koppel de uitgeleverde app aan de rest van de workspace. Cross-register-reads, OpenConnector-sources, en een tweerichtings-webhook-sync — drie integratiepatronen, gelaagd van minst naar meest ingrijpend."
   />
   <NextStep

--- a/i18n/nl/docusaurus-plugin-content-blog/2026-05-19-openwoo-community-meetings/index.mdx
+++ b/i18n/nl/docusaurus-plugin-content-blog/2026-05-19-openwoo-community-meetings/index.mdx
@@ -1,0 +1,71 @@
+---
+slug: openwoo-community-meetings
+title: OpenWoo-community — twee jaar maandelijkse meetings
+contentType: webinar
+authors: [conduction]
+date: 2026-05-19
+summary: Opnames van elke publieke OpenWoo community meeting sinds 2023 — leveranciers, gemeenten, KOOP en uitvoeringsorganisaties die samen de Wet open overheid uitrollen op Common Ground-leest.
+tags: [OpenWoo, Woo, Community, Video, Common Ground]
+apps: [openwoo, opencatalogi, openregister, openconnector]
+durationMinutes: 60
+---
+
+import {ContactCta} from '@conduction/docusaurus-preset/components';
+
+De OpenWoo-community komt elke tweede dinsdag van de maand samen. Leveranciers (Conduction, Xxllnc, OpenGemeenten, SHIFT2, Acato, Notubiz, iO), gemeenten in productie of acceptatie, en KOOP delen voortgang, blokkeerders, en het volgende stuk van de roadmap. Onder staan alle opgenomen sessies sinds eind 2023.
+
+{/* truncate */}
+
+## Hoe de community werkt
+
+Eén Slack-kanaal in [samenorganiseren.slack.com](https://samenorganiseren.slack.com/archives/C067Q3UE9F0) voor vragen tussen meetings door. Elke meeting heeft een korte demo, een agenda-issue, en wordt opgenomen voor wie het live niet redt. Toetreden tot de community is open — geen contract, geen commitment, mail [info@conduction.nl](mailto:info@conduction.nl) als je wilt aanhaken.
+
+## Opgenomen sessies
+
+### 2026 — Common Ground OpenWoo community meetings
+
+| Datum | Sessie | Opname |
+|---|---|---|
+| 13-05-2026 | Community Meeting | [YouTube](https://www.youtube.com/watch?v=gaOft31cXic) |
+| 08-04-2026 | Community Meeting | [YouTube](https://youtu.be/Czrd3FdhoGU) |
+| 11-03-2026 | Community Meeting | [YouTube](https://youtu.be/lUFjD-oWTa8) |
+| 11-02-2026 | Community Meeting | [YouTube](https://youtu.be/D-5Y-r7Yqfo) |
+| 14-01-2026 | Community Meeting | [YouTube](https://youtu.be/DnsTPHM80SQ?si=gMBGYsf9EvuM6_lg) |
+
+### 2025
+
+| Datum | Sessie | Opname |
+|---|---|---|
+| 10-12-2025 | Community Meeting | [YouTube](https://youtu.be/jjS1DnILE1o?si=FqvAvUTtdxScehPa) |
+| 12-11-2025 | Community Meeting | [YouTube](https://youtu.be/Jh2Ap_Cuya8) |
+| 10-07-2025 | Community Meeting | [YouTube](https://youtu.be/FMP7HNBD3DQ) |
+| 11-06-2025 | Community Meeting | [YouTube](https://youtu.be/132V-PRl-m8?si=AC55H5cDrBdWSlLO) |
+| 14-05-2025 | Community Meeting | [YouTube](https://youtu.be/sNKKI-nJpTc?si=XR16iXqWXswM6ZFp) |
+| 09-04-2025 | Community Meeting | [YouTube](https://www.youtube.com/watch?v=dIc9XSkXdRQ) |
+| 12-03-2025 | Community Meeting | [YouTube](https://youtu.be/M9xOWcUOK2s) |
+| 15-01-2025 | Community Meeting | [YouTube](https://youtu.be/uV-hQwdz2Bo) |
+
+### 2024 — externe webinars en demo's
+
+| Datum | Sessie | Spreker | Opname |
+|---|---|---|---|
+| 25-03-2024 | SHIFT2 — Een toekomstbestendige Woo-oplossing | SHIFT2 | [shift2.nl](https://www.shift2.nl/een-toekomstbestendige-woo-oplossing) |
+| 30-01-2024 | OpenGemeenten Woobinar | OpenGemeenten | [Vimeo](https://vimeo.com/909134953) |
+
+### 2023 — eerste demo's en webinars
+
+| Datum | Sessie | Spreker | Opname |
+|---|---|---|---|
+| 19-12-2023 | xxllnc Demo | xxllnc | [YouTube](https://www.youtube.com/watch?v=_FGpUYH1yd0) |
+| 17-11-2023 | xxllnc Woobinar | xxllnc | [YouTube](https://www.youtube.com/watch?v=NCnLDEoPh5A) |
+
+## Verwante content in de Academy
+
+- [Woo-register opzetten in OpenRegister](/nl/academy/woo-register-opzetten) — start hier als je net begint; importeert het canonieke Woo-register met alle TOOI-categorieën in tien minuten.
+- [Woo-bestanden uploaden](/nl/academy/woo-bestanden-uploaden) — vervolgtutorial; voeg PDF-bijlagen toe aan publicaties.
+
+## Volledige technische documentatie
+
+Voor de architectuur, installatie, configuratie en integratie-koppelvlakken: [openwoo.conduction.nl](https://openwoo.conduction.nl/). De solutions-pagina op [conduction.nl/solutions/openwoo](/solutions/openwoo) heeft het commerciële verhaal en de actuele lijst van twaalf gemeenten in productie.
+
+<ContactCta />

--- a/i18n/nl/docusaurus-plugin-content-blog/2026-05-19-the-platform-moment/index.mdx
+++ b/i18n/nl/docusaurus-plugin-content-blog/2026-05-19-the-platform-moment/index.mdx
@@ -1,0 +1,80 @@
+---
+slug: the-platform-moment
+title: Nextcloud is een platform
+contentType: opinion
+authors: [ruben]
+date: 2026-05-19
+summary: Een opiniestuk over waarom Nextcloud bekeken zou moeten worden als een platform, niet als een product. De sovereign-workplace-bundels zijn het begin, niet het einde. Microsoft heeft achttien tot zesendertig maanden. Europa ook.
+tags: [Nextcloud, Platform, Sovereignty, AI]
+durationMinutes: 7
+---
+
+Hetzelfde patroon duikt op elke keer dat een softwarecategorie door zijn platformmoment heen gaat. WordPress in 2011. Salesforce een paar jaar eerder. Atlassian daarna. De iPhone, in de consumentenmarkt, vóór allemaal. Elk van hen begon als product. Elk werd een platform. De bedrijven die de overgang goed managen, bezitten hun categorie twee decennia later. De bedrijven die dat niet deden, zijn voetnoten.
+
+Ik denk dat Nextcloud nu vlak voor die overgang staat, en ik denk dat het veld eromheen het nog niet doorheeft.
+
+{/* truncate */}
+
+## Het patroon
+
+Wat een product tot een platform maakt, is geen feature release. Het is een herframing.
+
+WordPress core bleef bewust klein, terwijl het plugin-ecosysteem uitgroeide tot een miljardenmarkt. De plugin-laag werd het eigenlijke product. WordPress core werd infrastructuur. Tegen 2020 kon je niets anders kiezen voor iets anders dan enterprise-CMS of proprietary SaaS — niet omdat WordPress op features had gewonnen, maar omdat het ecosysteem eromheen had gewonnen.
+
+Salesforce AppExchange verscheen in 2006. Eind jaren tien gebruikte 91% van de Salesforce-klanten minstens één app eruit. Dát is de echte gracht onder het bedrijf. Concurrenten hoeven niet alleen de CRM te verslaan. Ze moeten de CRM plus zesduizend integraties verslaan. De AppExchange-partners verdienen samen een veelvoud van wat Salesforce zelf direct uit de marktplaats verdient. Beide winnen in dezelfde uitkomst.
+
+De iPhone won smartphones niet door een betere telefoon te zijn. Hij won door te worden uitgeroepen tot "het platform dat apps draait" voordat dat technisch waar was. Tegen 2010 kopieerde elk ander platform het App Store-model, of het verdween. De naamgeving liep jaren vooruit op de platformrealiteit. Die naamgeving was dragend.
+
+SharePoint is de waarschuwende casus. Microsoft positioneerde het tien jaar lang als hét platform. Het technische oppervlak ondersteunde dat. Het marketingbudget ondersteunde dat. De architectuur en de economie deden dat niet. SharePoint heeft nooit een ecosysteem voortgebracht. Het bleef een product. Power Platform verdrong het als Microsofts gepositioneerde platform voor businessapps.
+
+Vijf casussen. Eén patroon. Telkens dezelfde vorm.
+
+## Waarom Nextcloud op deze positie zit
+
+Het substraat voor een werkplek-platform zit vandaag al in Nextcloud Hub. Het wordt alleen niet als substraat geframed.
+
+Bestanden. Agenda. Contacten. Talk. Mail. Een identity-laag die al LDAP, SAML en OIDC spreekt. Een permissiemodel dat over al die onderdelen heen werkt. Elke businessapp heeft deze primitieven nodig. Nextcloud levert ze al geïntegreerd, in één product, met één toegangsbeheer-oppervlak. ExApps voegt het tweede stuk toe: een productie-rijp patroon om wat dan ook, in welke taal dan ook, te draaien als geïntegreerde app binnen de werkplek. Twee- tot driehonderdduizend servers. Enkele honderden apps in de store. ISO 27001. Blauer Engel. EU-data-hosting als standaard. Geen van deze beslissingen moet nog genomen worden. Ze zijn al uitgeleverd.
+
+De sovereign-workplace-beweging rond openDesk, Mijn Bureau, La Suite Numérique en het Bechtle-Nextcloud-aanbod gebruikt Nextcloud als kerncomponent. Schleswig-Holstein verhuisde in oktober 2025 40.000 ambtenaren weg van Microsoft, met openDesk als samenwerkingslaag. De Bundeswehr tekende een zevenjarig contract. Het Robert Koch Institut en het Internationaal Strafhof draaien erop. De uitrol is reëel en op schaal.
+
+Wat geen van die bundels (nog) doet, is Nextcloud framen als het platform onder de suite. Ze framen het als een van meerdere componenten in een bundel. Dat frame klopt voor het moment van overstappen van Microsoft. Het zal drie jaar later niet meer kloppen.
+
+## De bundel is niet de werkplek
+
+In jaar één vraagt een koper: "kan ik Microsoft vervangen?". In jaar drie vraagt diezelfde koper: "waar draait mijn organisatie eigenlijk?".
+
+Een bundel beantwoordt de eerste vraag. Niet de tweede. Een bundel levert een vaste set tools, waarbij de integratie ertussen plaatsvindt in het hoofd van de gebruiker of in zijn browsertabs. Een werkplek is iets anders: het uniforme oppervlak waarop mensen werken, met het platform eronder dat al het andere host. Tools, data, AI, en de honderden kleine workflows die elke organisatie draait — te klein om door IT te laten formaliseren, te operationeel om uit te besteden. Verlofaanvragen. Materiaaluitleen. Bezoekersregistratie. Hardware-inventaris. Leveranciers-onboarding. De long tail.
+
+De leverancier die het antwoord op jaar drie geeft, wint de relatie. Nextcloud-als-bundel doet dat niet. Nextcloud-als-platform wel. Die herframing is wat naar mijn idee overdue is.
+
+## AI als substraat, niet als vinkje
+
+AI verandert de rekensom rond lokale data — en niet in de richting die de meeste werkplek-leveranciers willen.
+
+Microsoft Copilot routeert gebruikersdata naar Azure voor inferentie. Google Workspace doet hetzelfde, naar Google Cloud. Beide hebben sovereign-cloud-varianten gebouwd — Bleu in Frankrijk via een joint venture van Capgemini en Orange, Delos in Duitsland via SAP en Telekom, Microsoft Cloud for Sovereignty als overkoepelend programma — en dat zijn serieuze engineering-trajecten. Ze verkleinen het blootstellingsoppervlak. Ze elimineren het niet. De CLOUD Act blijft van toepassing op Microsoft zelf, ook wanneer Europese partners de infrastructuur opereren. Het structurele probleem is jurisdictioneel, niet contractueel.
+
+Voor de meeste marksegmenten is de partiële-soevereiniteit-pitch voldoende. Voor de kopers die specifiek voor openDesk en Mijn Bureau kozen omdat de architectuur ertoe doet, is dat niet zo. Die hebben het suite-pad om een reden gekozen.
+
+Een open werkplek-architectuur draait het probleem om. De data staat al op infrastructuur die de klant zelf beheert. Het AI-substraat komt naar de data toe, niet andersom. Lokale LLM-endpoints. Retrieval-indexering over de hele werkplek heen. Tools die registers blootstellen aan modellen binnen de sessie van de gebruiker, op elke stap audit-gelogd, met de operator die het model kiest. Mistral on-premise. Een self-hosted Llama-variant. Of, waar het beleid het toelaat, een commodity API. De architectuur ondersteunt de beleidskeuzes van de operator, niet die van de leverancier.
+
+De features zijn competitief. De architectuur is structureel anders. Dat structurele verschil komt in elke aanbestedingsevaluatie naar boven waar soevereiniteit serieus telt. Dit is het stuk waarop Nextclouds positie zich versterkt. Microsoft kan niet winnen op soevereiniteit voor de kopers die daar het meest om geven. Microsoft kan absoluut winnen op time-to-value en diepte van het ecosysteem — en dat is precies wat ze vijf jaar lang en met significant kapitaal proberen te doen. De race gaat over welk structureel voordeel zwaarder weegt voor welke koper.
+
+## De Microsoft-klok
+
+Even wat context over de omvang van de andere kant. Power Platform stond in 2023 op 33 miljoen monthly active users. 48 miljoen in 2024. 56 miljoen in 2025. Microsoft heeft 500 miljoen tegen het einde van het decennium genoemd als publiek doel. 97% van de Fortune 500-bedrijven gebruikt Power Platform in enige vorm. De 2026 release wave verenigt Power Apps, Power Automate, Power Pages, Copilot Studio en Dataverse tot één AI-native citizen-developer-verhaal. Intern gebruiken ze de framing "low code is dood": apps beginnen als gesprekken met Copilot en worden stilletjes React.
+
+Europa heeft, naar mijn inschatting, ergens tussen de achttien en zesendertig maanden om een geloofwaardig architectonisch antwoord uit te leveren. Sluit dat venster eenmaal, dan zijn citizen developers in Europese organisaties getraind op de Microsoft-stack, en switching costs worden reëel op een manier die geen sales motion meer oplost. Mindshare is het belangrijkste venster. Het sluit ook het snelst.
+
+## Wat waar moet zijn
+
+Het architectonische antwoord bestaat in stukken. De sovereign-workplace-bundels zijn één stuk. Open-source workflow-tools — Windmill, n8n, OpenProject — zijn een tweede. Open-weight LLM's gehost in Europa zijn een derde. De compositie-laag waarmee een niet-ontwikkelaar in een gemeente in één middag een verlofaanvraag-app live krijgt, is het stuk dat in productie nog grotendeels ontbreekt. Dat is het stuk dat wij bij Conduction bouwen, in de openbaarheid, als [OpenBuilt](/apps/openbuilt). Het is niet het enige stuk dat geleverd moet worden. Het is er één.
+
+Het andere dat waar moet zijn, is naamgeving. Steve Jobs verkocht de iPhone niet als een telefoon met uitbreidbare features. Hij positioneerde hem als het platform dat apps draait, jaren voordat die platformrealiteit volledig was geleverd. De naamgeving was dragend. Dat is ze nog steeds.
+
+Nextcloud-als-platform is vandaag al waar in elke structurele zin die ertoe doet. Wat ontbreekt, is dat het bedrijf, het ecosysteem en de kopers het ook zo gaan uitspreken.
+
+## Een persoonlijke noot
+
+Ik heb vier kwartalen runway van mijn bedrijf gestoken in het bouwen naar deze visie. Het is geen rustige visie. Ik schrijf het op omdat ik denk dat het architectonische argument beslecht is, het competitieve venster open staat, en de volgende zet toebehoort aan mensen die de vorm van het moment helder kunnen zien. Daaronder valt het team van Nextcloud. Daaronder vallen de kopers die Europese sovereign-workplace-migraties draaien. Daaronder vallen collega-bedrijven in de open-source workplace-stack.
+
+Lees je dit en ben je het oneens — dan hoor ik graag waarom. ruben@conduction.nl.

--- a/i18n/nl/docusaurus-plugin-content-blog/2026-05-21-deskdesk-tutorial-5-advanced-manifest/index.mdx
+++ b/i18n/nl/docusaurus-plugin-content-blog/2026-05-21-deskdesk-tutorial-5-advanced-manifest/index.mdx
@@ -1,0 +1,325 @@
+---
+slug: deskdesk-tutorial-5-advanced-manifest
+title: "Bouw een Nextcloud-app op de Conduction-stack, Deel 5: Geavanceerde manifest-features"
+contentType: tutorial
+authors: [conduction]
+date: 2026-05-21
+summary: Voorbij de schema-gedreven CRUD-basis geeft het v2.7.0 manifest-schema je `actionToggles`, `fieldWidgets`, route-param-sentinels, public-mode pagina's, en zeven extra page types (form, wiki, search, roadmap, map, logs, settings). Eén tutorial die ze stuk voor stuk doorloopt, met DeskDesk als doorlopend voorbeeld.
+tags: [App development, Manifest, OpenRegister, nextcloud-vue, Tutorial series, Advanced]
+apps: [openregister]
+durationMinutes: 30
+series: deskdesk-tutorial
+partNumber: 5
+---
+
+import {
+  Outcomes,
+  Outcome,
+  Prerequisites,
+  PrerequisiteItem,
+  NextSteps,
+  NextStep,
+  HexCard,
+} from '@conduction/docusaurus-preset/components';
+
+Dit is **Deel 5** van de DeskDesk-tutorial. Deel 1 tot en met 4 leverden je een werkende app: scaffold, schema's + manifest, schema-gedreven Calendar, en een custom Knowledge-tab. Deel 5 is de "en nu?", de v2.7.0 manifest-features die Deel 1 tot en met 4 bewust oversloegen zodat de leercurve mild bleef. Je hebt er geen van nodig om DeskDesk te leveren, maar op het moment dat je app een publiek formulier, een wiki, een admin-only listing of een markdown-editor binnen een formulier nodig heeft, besparen ze je een nieuwe ronde handgemaakte Vue.
+
+:::tip Deel 5 en 6 lopen parallel
+Dit deel verdiept het *manifest*-oppervlak. [Deel 6, Integreren](/nl/academy/deskdesk-tutorial-6-integrate) verbreedt de app naar *andere systemen* (cross-register-reads, OpenConnector-sources, webhooks). Beide bouwen direct op Deel 4, neem ze in willekeurige volgorde, of pak welke je volgende app als eerste nodig heeft.
+:::
+
+Drie principes lopen door elke feature in dit deel: **schema-gedreven** (geen per-pagina Vue), **type-safe** (het manifest-schema valideert elke vorm voor runtime), en **fleet-portable** (dezelfde JSON werkt in elke Conduction-app en krijgt lib-upgrades gratis).
+
+{/* truncate */}
+
+<Outcomes title="Wat je hebt aan het eind van Deel 5">
+  <Outcome>Een admin-only desks-listing die <code>config.actionToggles</code> gebruikt in plaats van negen broer-en-zus boolean-flags.</Outcome>
+  <Outcome>Een booking-creation-formulier met een markdown notes-veld, gedeclareerd via <code>config.fieldWidgets</code>, geen Vue-bestand geschreven.</Outcome>
+  <Outcome>Een <strong>publieke booking-bevestigingspagina</strong> bereikbaar via een token-URL, met <code>config.mode: 'public'</code> + route-param-sentinels.</Outcome>
+  <Outcome>Een <code>type:'wiki'</code> zone-richtlijnen-oppervlak gevoed door hetzelfde OpenRegister-register dat de rest van de app aandrijft.</Outcome>
+  <Outcome>Een <code>type:'search'</code> faceted cross-schema zoekpagina.</Outcome>
+  <Outcome>Een werkende mentale kaart van elke v2.7.0 manifest-feature, zodat je de volgende keer de juiste vorm kunt kiezen zonder de docs te herlezen.</Outcome>
+</Outcomes>
+
+<Prerequisites title="Voor je begint">
+  <PrerequisiteItem>Je hebt minimaal <a href="/nl/academy/deskdesk-tutorial-2-schemas-manifest">Deel 2</a> afgerond, je hebt een werkend manifest met index- en detailpagina's.</PrerequisiteItem>
+  <PrerequisiteItem><code>@conduction/nextcloud-vue</code> op <code>^1.0.0-beta.65</code> of nieuwer. De features in dit deel leunen op schema 2.7.0 getypeerde vormen.</PrerequisiteItem>
+  <PrerequisiteItem>Je <code>src/manifest.json</code> declareert de v2 schema-URL (<code>app-manifest-v2.schema.json</code>). Deel 2 heeft dit opgezet.</PrerequisiteItem>
+</Prerequisites>
+
+## 1. `config.actionToggles`, read-only listings zonder negen flags
+
+De klassieke vorm, vóór v2.7.0, voor een admin-only of read-only `type:'index'`-pagina betekende negen broer-en-zus booleans:
+
+```json title="Old shape — works but reads poorly"
+"config": {
+  "register": "deskdesk", "schema": "desk", "columns": [...],
+  "showAdd": false, "showEdit": false, "showCopy": false, "showDelete": false,
+  "showMassImport": false, "showMassCopy": false, "showMassDelete": false,
+  "selectable": false, "showFormDialog": false
+}
+```
+
+`config.actionToggles` klapt alle negen in één object. De renderer vlakt het bij dispatch terug uit naar de onderliggende props, expliciete `config.<key>` wint nog steeds als je beide zet, dus je kunt één flag overrulen zonder het toggle-blok te herschrijven.
+
+```json title="src/manifest.json — admin-only desks read-out"
+{"id": "desks-admin-readout",
+ "route": "/admin/desks",
+ "type": "index",
+ "title": "deskdesk.admin.desks",
+ "permission": "admin",
+ "config": {
+   "register": "deskdesk", "schema": "desk",
+   "columns": ["label","floor","zone","equipment","capacity"],
+   "actionToggles": {
+     "showAdd": false, "showEdit": false, "showCopy": false,
+     "showDelete": false, "showMassImport": false, "showMassCopy": false,
+     "showMassDelete": false, "selectable": false, "showFormDialog": false
+   }
+ }}
+```
+
+Er is een shorthand voor het all-off-geval: `config.readOnly: true` ontvouwt naar dezelfde negen flags. Gebruik het voor echt read-only views, audit logs, gearchiveerde snapshots, alles wat de gebruiker moet kunnen lezen maar niet aanraken.
+
+```json
+"config": {"register": "deskdesk", "schema": "desk", "readOnly": true}
+```
+
+## 2. `config.fieldWidgets`, lib-widgets binnen een formulier, geen Vue-bestand
+
+De booking-dialoog van DeskDesk heeft een vrije-tekst-notitieveld. De schema-gegenereerde input geeft je een `<textarea>`, prima, maar niet geweldig. Je wilt een markdown-editor met een preview-paneel, syntax highlighting, en de standaard toolbar. Vóór v2.7.0 betekende dat een eigen Vue-component schrijven, registreren, en het veld overrulen met een `#field-notes`-slot.
+
+Schema 2.7.0 typeerde de `fieldWidgets[]`-slot op `type:'form'`- en `type:'detail'`-pagina's: elke entry mount een lib-`Cn*`-component voor één veld op id.
+
+```json title="src/manifest.json — booking creation form"
+{"id": "bookings-create",
+ "route": "/bookings/new",
+ "type": "form",
+ "title": "deskdesk.bookings.createTitle",
+ "config": {
+   "register": "deskdesk", "schema": "booking",
+   "submitEndpoint": "/index.php/apps/openregister/api/objects/deskdesk/booking",
+   "submitMethod": "POST",
+   "mode": "create",
+   "fieldWidgets": [
+     {"id": "notes", "component": "CnMarkdownEditor"}
+   ]
+ }}
+```
+
+Een paar regels:
+
+- **De `component`-waarde moet matchen met het lib-`Cn*`-patroon** (`^Cn[A-Z]\w+$`). Host-app SFC's gaan op `type:'custom'`-pagina's, niet in `fieldWidgets[]`.
+- **`id` matcht een schema-property-naam.** De widget vervangt de auto-gegenereerde input van dat veld; al het andere in het formulier blijft schema-gedreven.
+- **`props` is optioneel**, een serialiseerbaar object dat bij mount-tijd aan de lib-component wordt meegegeven (bijv. `{"id": "preview", "component": "CnCodeViewer", "props": {"language": "yaml"}}`).
+- **Meerdere `fieldWidgets[]`-entries zijn toegestaan.** Gebruik ze voor welke velden ook rijkere editing nodig hebben; de rest van het formulier behoudt zijn schema-gedreven inputs.
+
+## 3. Route-param-sentinels, bind URL-params aan config
+
+Het manifest kan een route met `:`-placeholders declareren (`/bookings/:id`) en de params bereiken automatisch de gedispatchte component. v2.7.0 laat het manifest die params ook *gebruiken* binnen `config`, door `@route.<paramName>` te schrijven als een string-sentinel die de renderer bij dispatch resolved:
+
+```json title="A detail page that filters by route param"
+{"id": "desk-bookings",
+ "route": "/desks/:deskId/bookings",
+ "type": "index",
+ "title": "deskdesk.desks.bookings",
+ "config": {
+   "register": "deskdesk", "schema": "booking",
+   "filter": {"desk": "@route.deskId"},
+   "columns": ["bookedBy","start","end","status"]
+ }}
+```
+
+Wanneer de gebruiker `/desks/abc-123/bookings` bezoekt, resolved de renderer `"@route.deskId"` → `"abc-123"` en `CnIndexPage` ontvangt `filter: {desk: "abc-123"}`, de listing toont alleen boekingen op dat bureau. Geen Vue, geen `mounted()`-hook, geen `watch` op `$route.params`.
+
+Onopgeloste sentinels worden `null` (met een eenmalige `console.warn` voor de pagina-id), ze crashen de pagina niet, ze produceren gewoon geen filter. Nuttig tijdens incrementele migraties waar de route nog niet is gedeclareerd.
+
+## 4. `config.mode: 'public'`, token-scoped unauthenticated pagina's
+
+Publieke booking-bevestiging. De gebruiker klikt een link in een e-mail, landt op een pagina die hun boeking bevestigt, ziet een klein formulier om optioneel een notitie toe te voegen, geen Nextcloud-login vereist. De pagina is bereikbaar via een eenmalig token, iedereen met het token ziet hem, niemand zonder.
+
+```json title="src/manifest.json — public booking confirmation"
+{"id": "booking-confirm",
+ "route": "/public/bookings/:token",
+ "type": "detail",
+ "title": "deskdesk.bookings.confirmTitle",
+ "config": {
+   "register": "deskdesk", "schema": "booking",
+   "mode": "public",
+   "objectId": "@route.token",
+   "sidebar": false,
+   "fieldWidgets": [
+     {"id": "guestNote", "component": "CnMarkdownEditor"}
+   ]
+ }}
+```
+
+Wat je krijgt:
+
+- **`mode: "public"`** signaleert aan de renderer en de achterliggende API dat deze pagina unauthenticated is. Het OR-endpoint dat hem serveert moet de token-query accepteren, dat is bedraad in je `appinfo/routes.php` en een kleine public-mode-handler in `lib/Controller/`.
+- **`objectId: "@route.token"`** gebruikt de route-sentinel om het token in de object-lookup van de pagina te voeden. Het token is de externe identifier van het object in deze flow.
+- **`sidebar: false`** zet de audit/files/notes-sidebar expliciet uit, publieke kijkers horen het interne spoor niet te zien.
+- **`fieldWidgets[]`** werkt hetzelfde als op geauthenticeerde formulieren.
+
+Dezelfde vorm werkt voor `type:'form'` (een publiek inzendingsformulier), de `submitEndpoint` van het formulier resolved ook een token-sentinel.
+
+## 5. Andere page types, `wiki`, `search`, `roadmap`, `map`, `logs`, `settings`
+
+Deel 2 tot en met 4 gebruikten `index`, `detail`, `dashboard` en `custom`. De 13-type enum van v2.7.0 geeft je nog meerdere getypeerde oppervlakken die alleen via het manifest erbij komen.
+
+### `type: 'wiki'`
+
+Voor markdown-artikel-oppervlakken gevoed vanuit een OR-register. Handig voor zone-richtlijnen, kennisbankartikelen, interne policies, alles wat "een artikel gerenderd vanuit een opgeslagen markdown-blob" is.
+
+```json
+{"id": "zone-guides",
+ "route": "/zones/guides/:id",
+ "type": "wiki",
+ "title": "deskdesk.zones.guideTitle",
+ "config": {
+   "register": "deskdesk", "schema": "zoneGuide",
+   "contentField": "body",
+   "titleField": "title",
+   "idParam": "id",
+   "sidebarSchema": "zoneGuide",
+   "treeField": "children"
+ }}
+```
+
+De `contentField` is de markdown-property op het artikel-record. `sidebarSchema` (optioneel) zet een in-pagina tree-sidebar aan gevoed vanuit hetzelfde register, perfect wanneer de wiki een hiërarchie heeft.
+
+### `type: 'search'`
+
+Een faceted cross-schema zoekpagina. Eén config-blok declareert welke registers + schema's te bevragen en welke velden facets zijn. `CnSearchPage` doet de rest.
+
+```json
+{"id": "global-search",
+ "route": "/search",
+ "type": "search",
+ "title": "deskdesk.search.title",
+ "config": {
+   "scopes": [
+     {"register": "deskdesk", "schema": "desk"},
+     {"register": "deskdesk", "schema": "booking"},
+     {"register": "deskdesk", "schema": "zoneGuide"}
+   ],
+   "facets": ["floor","zone","schema"]
+ }}
+```
+
+### `type: 'roadmap'`
+
+`CnFeaturesAndRoadmapPage` leest een manifest-gedeclareerde roadmap en haalt live status uit GitHub issues. Valt in voor een `Features & Roadmap`-menuregel in elke app.
+
+```json
+{"id": "features-roadmap",
+ "route": "/roadmap",
+ "type": "roadmap",
+ "title": "deskdesk.roadmap.title",
+ "config": {
+   "repo": "ConductionNL/deskdesk",
+   "milestones": ["1.0", "1.1", "Future"]
+ }}
+```
+
+### `type: 'map'`
+
+`CnMapPage` mount een Leaflet-kaart met marker-layers gevoed vanuit een register, een statische GeoJSON, of een tile-source. Handig voor asset-locaties, geo-getagde objecten, of gewoon "waar op deze plattegrond staat bureau X".
+
+```json
+{"id": "floor-map",
+ "route": "/floors/:floorId/map",
+ "type": "map",
+ "title": "deskdesk.floors.mapTitle",
+ "config": {
+   "center": [52.13, 5.29], "zoom": 18,
+   "layers": [{"type": "tile", "url": "https://tile.openstreetmap.org/{z}/{x}/{y}.png"}],
+   "markers": {"dataSource": {"register": "deskdesk", "schema": "desk"},
+               "latField": "lat", "lngField": "lng", "popupField": "label"}
+ }}
+```
+
+### `type: 'logs'` en `type: 'settings'`
+
+`logs` rendert een audit/event-log-viewer (wijst vaak naar een OR-beheerde `auditEntry`-schema of een externe `source`). `settings` mount `CnSettingsPage` met een sections-of-tabs-config die zijn eigen formulier-rendering meelevert, het hele admin-oppervlak van de app kan één `type:'settings'`-pagina zijn.
+
+```json
+"settings": {
+  "id": "deskdesk-settings",
+  "route": "/settings",
+  "type": "settings",
+  "title": "deskdesk.settings.title",
+  "config": {
+    "sections": [
+      {"id": "register-mapping", "label": "Register mapping",
+       "widgets": [{"type": "register-mapping"}]},
+      {"id": "version", "label": "Version",
+       "widgets": [{"type": "version-info"}]}
+    ]
+  }
+}
+```
+
+`CnSettingsPage` heeft zijn eigen widget-vocabulaire (`version-info`, `register-mapping`, `component` voor een eigen mount) dat dunner is dan de dashboard-`widgetDef`. De referentiepagina in de nc-vue docs heeft de volledige lijst.
+
+## 6. De `_note`-regel op `type:'custom'`, versoepeld
+
+Wanneer je een host-app SFC mount via `type:'custom'`, vraagt het v2.7.0-schema je om in een `_note`-veld te documenteren *waarom* de custom nodig was. Dat staat er om scope creep te bevechten, elke custom is een plek waar het manifest-pad niet paste, en de reden opschrijven dwingt een eerlijk antwoord af.
+
+```json title="A custom that needs _note"
+{"id": "pipeline-board",
+ "route": "/pipeline",
+ "type": "custom",
+ "title": "deskdesk.pipeline.title",
+ "component": "PipelineBoard",
+ "_note": "Bespoke kanban board with drag-drop column reorder + per-card status transitions. No lib analogue."}
+```
+
+2.7.0 *versoepelt* de regel voor één geval: als `component` matcht met het lib-`Cn*`-patroon (`^Cn[A-Z]\w+$`), is `_note` optioneel omdat de componentnaam de keuze al documenteert. Dus:
+
+```json title="Lib Cn* custom — _note no longer required"
+{"id": "federation-status",
+ "route": "/directory",
+ "type": "custom",
+ "title": "deskdesk.directory.title",
+ "component": "CnFederationStatus"}
+```
+
+De regel bijt nog steeds op host-app SFC's (geen `Cn*`-prefix), en daar verdient hij zijn brood.
+
+## 7. Kiezen tussen fieldWidgets, custom pages, en geregistreerde componenten
+
+Wanneer je een eenmalige UI-behoefte hebt, heb je drie opties. De juiste kiezen bespaart je later een refactor.
+
+| Behoefte | Gebruik | Waarom |
+|---|---|---|
+| Eén rich field binnen een verder schema-gedreven formulier | `config.fieldWidgets[]` met een lib-`Cn*`-component | Kleinste scope. Formulier blijft declaratief. |
+| Een hele pagina die niet in een getypeerd type past | `type:'custom'` met `component: 'YourHostSfc'` + `_note` | Eerlijke ontsnappingsklep. De rest van het manifest blijft schoon. |
+| Een herbruikbaar oppervlak (een widget of tab) dat meerdere pagina's willen | Registreer een integration met `OCA.OpenRegister.integrations.register({...})` en gebruik `useRegistry: true` | Cross-app herbruikbaar. Andere Conduction-apps kunnen je registratie oppikken. |
+
+Hoe hoger je `type:'custom'`-aantal klimt, hoe meer het de moeite waard is om te vragen of het onderliggende gat eigenlijk een lib-feature zou moeten zijn. Als je vergelijkbare custom pagina's in twee apps zit te schrijven, open een issue op `nextcloud-vue`, zo zijn features als `CnWikiPage` en de getypeerde `actionToggles`-vorm gepromoveerd van "iedereen schrijft dezelfde custom" naar "first-class lib-oppervlak".
+
+## Waar nu naartoe
+
+<NextSteps>
+  <NextStep
+    title="Deel 6: Integreren"
+    href="/nl/academy/deskdesk-tutorial-6-integrate"
+    description="Het laatste deel: koppel je app aan de rest van de workspace. Cross-register-reads, OpenConnector-sources, en een tweerichtings webhook-sync, drie integratiepatronen gelaagd van minst naar meest ingrijpend."
+  />
+  <NextStep
+    title="Volledige manifest-schema-referentie"
+    href="https://nextcloud-vue.conduction.nl/docs/architecture/manifest/"
+    description="Elk veld, elke constraint, elke $def, de schema-URL waar je manifest.json naar wijst, gerenderd als docs."
+  />
+  <NextStep
+    title="Pluggable integration registry (ADR-019)"
+    href="https://nextcloud-vue.conduction.nl/docs/architecture/integrations/"
+    description="Wanneer je per-app sidebars ontgroeit en cross-app tabs (Calendar, Talk, Files) door wilt laten stromen naar de detailpagina van elke app, is dit de volgende stap omhoog."
+  />
+  <NextStep
+    title="OpenRegister geavanceerde patronen"
+    href="https://openregister.conduction.nl/docs/advanced/"
+    description="GraphQL-endpoints, cross-register-relaties, formule-properties, de OR-features die het beste passen bij manifest-gedreven apps."
+  />
+</NextSteps>

--- a/i18n/nl/docusaurus-plugin-content-blog/2026-05-21-deskdesk-tutorial-6-integrate/index.mdx
+++ b/i18n/nl/docusaurus-plugin-content-blog/2026-05-21-deskdesk-tutorial-6-integrate/index.mdx
@@ -25,7 +25,7 @@ import {
 Het zesde en laatste deel van de DeskDesk-tutorial. Deel 4 packagede de app en zette hem in de Conduction-store; dit deel laat hem praten met de rest van de workspace — drie integratiepatronen, gelaagd van minst naar meest ingrijpend.
 
 :::tip Deel 5 en 6 staan naast elkaar
-Beide bouwen rechtstreeks voort op de uitgeleverde app uit Deel 4. [Deel 5 — Geavanceerde manifest-features](/academy/deskdesk-tutorial-5-advanced-manifest) gaat dieper op het *manifest*-vlak (actionToggles, fieldWidgets, public-mode pagina's). Deel 6 verbreedt naar *andere systemen*. Pak ze in willekeurige volgorde, of kies degene die je volgende app het eerst nodig heeft — geen van beide verwijst naar de ander voor inhoud.
+Beide bouwen rechtstreeks voort op de uitgeleverde app uit Deel 4. [Deel 5 — Geavanceerde manifest-features](/nl/academy/deskdesk-tutorial-5-advanced-manifest) gaat dieper op het *manifest*-vlak (actionToggles, fieldWidgets, public-mode pagina's). Deel 6 verbreedt naar *andere systemen*. Pak ze in willekeurige volgorde, of kies degene die je volgende app het eerst nodig heeft — geen van beide verwijst naar de ander voor inhoud.
 ::: Aan het einde weten je boekingen wie hun klant is, toont elke boeking de juiste help-artikelen uit xWiki, en opent een boeking met status `needs_repair` automatisch een onderhoudspagina in xWiki die de boeking weer op `available` zet zodra de pagina als opgelost is gemarkeerd.
 
 Het gaat niet om de specifieke integraties — het gaat om het patroon. Cross-register-lezen is hoe Conduction-apps data delen zonder aan elkaar te koppelen. Het OpenConnector source-en-synchronisatie-patroon is hoe je data van buiten in je eigen register opneemt. Het webhook-endpoint-patroon is hoe externe systemen state terugduwen. Als je deze drie hebt aangelegd, ken je het integratie-vocabulaire dat de rest van de catalogus gebruikt.
@@ -42,7 +42,7 @@ Het gaat niet om de specifieke integraties — het gaat om het patroon. Cross-re
 
 <Prerequisites title="Waar je moet staan">
   <PrerequisiteItem>Deel 1–4 afgerond: een uitgeleverde DeskDesk-app met floor/desk/booking/knowledge_article-schemas, de agenda-integratie, en de xWiki-kennisbron uit Deel 4 die al synchroniseert.</PrerequisiteItem>
-  <PrerequisiteItem>De referentie-stack uit <a href="/academy/nextcloud-lokaal-draaien">Nextcloud lokaal draaien met Docker</a>, inclusief de xWiki-service die je in Deel 4 hebt opgezet. We hergebruiken dezelfde container, dezelfde admin, dezelfde Postgres.</PrerequisiteItem>
+  <PrerequisiteItem>De referentie-stack uit <a href="/nl/academy/nextcloud-lokaal-draaien">Nextcloud lokaal draaien met Docker</a>, inclusief de xWiki-service die je in Deel 4 hebt opgezet. We hergebruiken dezelfde container, dezelfde admin, dezelfde Postgres.</PrerequisiteItem>
   <PrerequisiteItem><strong>OpenConnector</strong> geïnstalleerd en geactiveerd (dat heb je in Deel 4 gedaan voor de kennis-sync).</PrerequisiteItem>
 </Prerequisites>
 

--- a/i18n/nl/docusaurus-plugin-content-blog/2026-05-22-spec-driven-development/index.mdx
+++ b/i18n/nl/docusaurus-plugin-content-blog/2026-05-22-spec-driven-development/index.mdx
@@ -1,0 +1,306 @@
+---
+slug: spec-driven-development
+title: "Spec-gedreven ontwikkeling met OpenSpec — laat de AI de code schrijven, jij schrijft de context"
+contentType: tutorial
+authors: [conduction]
+date: 2026-05-22
+summary: Met OpenSpec stop je met het zelf schrijven van code en begin je met het schrijven van context. Markdown-specs beschrijven wat een feature moet doen. ADR's op organisatie- en app-niveau bepalen hoe features samenhangen. Een AI-agent (Hydra) leest de spec, past die toe, en een sequentiële kwaliteits- en review-harness valideert het resultaat. Deze tutorial loopt door de workflow, benoemt de skills, en legt uit waarom "configuratie boven code" het natuurlijke eindpunt is.
+tags: [App-ontwikkeling, Spec-gedreven, OpenSpec, Hydra, ADR, AI, n8n, Windmill, OpenBuilt]
+apps: [openregister]
+durationMinutes: 25
+---
+
+import BrowserOnly from '@docusaurus/BrowserOnly';
+import {
+  Outcomes,
+  Outcome,
+  Prerequisites,
+  PrerequisiteItem,
+  SetupSteps,
+  SetupStep,
+  NextSteps,
+  NextStep,
+  HexCard,
+} from '@conduction/docusaurus-preset/components';
+
+Spec-gedreven ontwikkeling draait de gebruikelijke volgorde om. Je schetst niet eerst de feature, schrijft de code, en documenteert daarna misschien wat je hebt gebouwd. Je **schrijft eerst de specificatie** — in Markdown, met RFC 2119-sleutelwoorden en GIVEN/WHEN/THEN-scenario's — en een AI-agent (Hydra) implementeert code die daaraan voldoet. De rol van de mens schuift een niveau omhoog: jij ontwikkelt **context**, geen code.
+
+Dat klinkt idealistisch totdat je het in de praktijk ziet werken. De apps van Conduction worden vandaag in productie op deze manier gebouwd. Deze tutorial loopt door de workflow: wat OpenSpec daadwerkelijk is, hoe ADR's op organisatie- en app-niveau features samenhangend houden, wat de **explore**- en **apply**-skills doen, en hoe de kwaliteits- en gatekeeping-harness het resultaat valideert voordat er ook maar iets in `main` landt.
+
+{/* truncate */}
+
+<Outcomes title="Wat je aan het eind hebt">
+  <Outcome>Een eerlijk mentaal model van hoe OpenSpec werkt in de Hydra-pipeline — proposals, delta's, levende specs, ADR-hiërarchie — en hoe de skills (<code>/opsx-explore</code>, <code>/opsx-ff</code>, <code>/opsx-apply</code>, <code>/opsx-verify</code>) samen een complete workflow vormen.</Outcome>
+  <Outcome>Concreet inzicht in waarom "configuratie boven code" het natuurlijke eindpunt is: declaratieve <code>{'x-openregister-*'}</code> register-patches verzorgen de business logic, <code>n8n</code> en <code>Windmill</code> verzorgen integratie-workflows, en handgeschreven code is de terugvaloptie wanneer declaratieve mogelijkheden tekortschieten.</Outcome>
+  <Outcome>Een helder beeld van de kwaliteits- en gatekeeping-harness die productie beschermt: 13 mechanische gates plus oordeelsreviews door <code>team-reviewer</code> en <code>team-security</code>, sequentieel, label-gestuurd, zonder loops.</Outcome>
+</Outcomes>
+
+<Prerequisites title="Waar je moet staan">
+  <PrerequisiteItem>Goede kennis van <a href="https://nextcloud-vue.conduction.nl/docs/architecture/app-design-principles/">hoe wij Nextcloud-apps ontwerpen</a> — het chassis, de vijf atomen, de gestapelde views.</PrerequisiteItem>
+  <PrerequisiteItem>Basiskennis van het <a href="https://nextcloud-vue.conduction.nl/docs/architecture/manifest/">app-manifest</a> en <a href="https://nextcloud-vue.conduction.nl/docs/architecture/schemas-and-registers/">schemas en registers</a> — de twee declaratieve oppervlakken waarop een spec landt.</PrerequisiteItem>
+  <PrerequisiteItem>Claude, Mistral, Codex, of een andere LLM-tool die je vanuit je editor of terminal kunt aanspreken. De workflow is model-agnostisch; je brengt je eigen agent mee.</PrerequisiteItem>
+  <PrerequisiteItem>De OpenSpec-skills geïnstalleerd — de <code>{'opsx-*'}</code>-familie zit in de <a href="https://github.com/ConductionNL/hydra">ConductionNL/hydra</a>-repository. Clone die (of kopieer de <code>.claude/skills/</code> naar je project) zodat de <code>{'/opsx-*'}</code>-commando's beschikbaar zijn.</PrerequisiteItem>
+</Prerequisites>
+
+## Wat "spec-gedreven" echt betekent
+
+De meeste teams behandelen de specificatie als een oplevering die op de code volgt. Spec-gedreven ontwikkeling behandelt het als **het enige dat mensen schrijven**. De flow draait om:
+
+1. Een mens (jij) beschrijft in een Markdown-spec wat een feature moet doen. RFC 2119-sleutelwoorden (`MUST`, `SHOULD`, `MAY`) voor normatieve uitspraken, GIVEN/WHEN/THEN-scenario's voor gedragsmatige.
+2. Een mens (jij) legt de architectonische randvoorwaarden vooraf vast in een Architecture Decision Record. Per-app voor repo-specifieke keuzes; org-breed voor regels die voor de hele fleet gelden.
+3. Een **AI-agent** (Hydra) leest de spec + de ADR's en schrijft de code. Het implementeert wat gespecificeerd is en is gebonden aan wat besloten is.
+4. Een **kwaliteits- en gatekeeping-harness** valideert dat de code overeenkomt met de spec, voldoet aan elke ADR, en de mechanische- en oordeelsreviews passeert.
+
+De mens schrijft de context. De AI schrijft de code. De harness schrijft het oordeel.
+
+Dit is niet "AI als autocomplete". Het is "AI als implementator, aan een lijn van specs en ADR's." Alles wat goed en fout is aan het resultaat is terug te voeren op of de context helder was. Vage spec → vage code. Ontbrekende ADR → drift over de fleet. Scherpe spec, complete set ADR's → werkende feature op `main`.
+
+## OpenSpec: de mappenstructuur die het laat werken
+
+OpenSpec is de conventie die elke Conduction-repo volgt voor het opslaan van deze context. Het is een directory, een Markdown-dialect, en een kleine CLI in één. De structuur is in elke repo hetzelfde:
+
+```
+openspec/
+├── config.yaml                 # declareert het schema (spec-driven)
+├── project.md                  # canonieke projectcontext, randvoorwaarden, stack
+├── AGENTS.md                   # beheerd instructieblok voor AI-assistenten
+├── architecture/               # ADR's die deze repo binden (adr-NNN-<onderwerp>.md)
+├── specs/<capability>/spec.md  # de LEVENDE spec — wat vandaag waar is
+├── changes/<change-name>/      # actieve delta's onderweg
+│   ├── proposal.md             # waarom + scope + frontmatter (kind, depends_on)
+│   ├── design.md               # hoe — technische aanpak, seed-data, declaratief-vs-imperatief
+│   ├── specs/<cap>/spec.md     # DELTA: ## ADDED / MODIFIED / REMOVED / RENAMED Requirements
+│   └── tasks.md                # hiërarchische checklist gedreven door de apply-skill
+├── changes/archive/            # gemergde delta's, bewaard voor de historie
+└── schemas/conduction/         # het YAML-schema waar de openspec CLI tegen valideert
+```
+
+Een **capability** is één ding dat de app doet — bijv. "beslis-lifecycle," "audit-trail export," "tenant onboarding." Elke capability krijgt precies **één levende spec** in `openspec/specs/<capability>/spec.md`. Wijzigingen op die spec komen binnen als **delta's** in `openspec/changes/<change-name>/specs/<capability>/spec.md`. Wanneer de wijziging gepubliceerd is, voegt `/opsx-archive` de delta samen in de levende spec en verplaatst de change-map naar `changes/archive/`.
+
+Deze scheiding is belangrijk: de levende spec is de *huidige waarheid*. De delta is een *voorstel onderweg*. De twee raken nooit verward, zelfs niet met een dozijn changes tegelijk open.
+
+## ADR's op twee niveaus: organisatie en applicatie
+
+Een specificatie zegt wat *één feature* moet doen. **Architecture Decision Records** zeggen wat *elke feature* moet respecteren. Ze vormen de staande context die een AI-agent leest voordat hij een regel schrijft — het verschil tussen een agent die code produceert volgens jullie conventies en een die ze bij elke wijziging opnieuw uitvindt. Spec-gedreven ontwikkeling heeft beide nodig: specs voor de feature, ADR's voor de samenhang tussen features.
+
+ADR's zitten op twee niveaus, met een schone eigenaarschapssplitsing. Het patroon is algemeen — elke organisatie met meerdere apps kan het overnemen:
+
+- **Organisatie-niveau ADR's** zijn de regels die elke app erft of het nu wil of niet: de datalaag, de beveiligingshouding, het i18n-vereiste, de licentie, de manifest-conventie, de "business logic is declaratief"-regel. Ze leven op één plek, centraal beheerd. App-repo's houden **geen** kopieën — verouderde lokale kopieën drijven af van de bron en zorgen ervoor dat reviewers debatteren tegen een regel die al maanden achterhaald is. Eén canoniek thuis, runtime gekopieerd in build- en review-tooling.
+- **Applicatie-niveau ADR's** leggen de beslissingen vast die alleen één app binden: het domeinmodel, de opslagkeuzes, de UX-patronen. De rest van de fleet is vrij om anders te kiezen.
+
+Wanneer een spec iets voorstelt dat conflicteert met één van beide niveaus, weigert de apply-skill en de reviewer signaleert het. Zo houden de twee lagen tientallen onafhankelijk gebouwde features samenhangend.
+
+In het geval van Conduction zijn de organisatie-niveau ADR's de fleet-brede set die elke Conduction-app erft (datalaag, frontend, beveiliging, i18n, testen, licentie, de app-manifest-conventie, schema-declaratieve business logic, spec-sizing). Voor een concreet, browsebaar voorbeeld van **applicatie-niveau** ADR's vormen die van OpenConnector goede leesvoer — 16 stuks, van [`adr-001-domain-pinia-stores-app-local`](https://github.com/ConductionNL/openconnector/tree/main/openspec/architecture) tot het ontwerp van de encryption-service, elk een echte lokale beslissing die de rest van de fleet niet bindt.
+
+## Eén feature, één spec
+
+De werkeenheid in OpenSpec is een **change** die één capability toevoegt, wijzigt of verwijdert. Elke change leeft in zijn eigen map onder `openspec/changes/<change-name>/` en bevat vier bestanden:
+
+- **`proposal.md`** — waarom deze wijziging, wie erom vroeg, wat in scope is. YAML-frontmatter declareert `kind: config | code | mixed` (per ADR-032; `mixed` is een anti-patroon) en `depends_on: [...]` voor geketende specs.
+- **`design.md`** — hoe de wijziging technisch werkt. De vorm van de seed-data, de schemas die geraakt worden, de declaratief-vs-imperatief afweging die gemaakt is.
+- **`specs/<capability>/spec.md`** — de delta zelf, met sectie-prefixen: `## ADDED Requirements`, `## MODIFIED Requirements`, `## REMOVED Requirements`, `## RENAMED Requirements`. Elke requirement is RFC 2119 met een of meer GIVEN/WHEN/THEN-scenario's.
+- **`tasks.md`** — een hiërarchische checklist (`- [ ]` / `- [x]`) waar de apply-skill doorheen werkt.
+
+Een change volgt één feature. Twee features betekent twee changes. Dit wordt afgedwongen door ADR-032 en door de supervisor — die blokkeert dat afhankelijke specs gebouwd worden voordat hun voorgangers gemerged zijn.
+
+## De workflow, fase voor fase
+
+Elke change doorloopt dezelfde `opsx-*`-fases. Jij stuurt de eerste; de AI-agent stuurt de middelste; de harness stuurt de laatste.
+
+<SetupSteps title={null}>
+  <SetupStep title="Explore — denk het probleem door">
+    <code>/opsx-explore</code>. Een denkende houding, niet een code-schrijvende. Breng een vaag idee mee; de agent onderzoekt de codebase en de ADR's, daagt aannames uit, en brengt risico's aan de oppervlakte. Legt optioneel het resultaat vast als een proposal.
+  </SetupStep>
+  <SetupStep title="Scaffold — maak de change en zijn artifacten aan">
+    <code>/opsx-new</code> (één artefact tegelijk) of <code>/opsx-ff</code> (fast-forward door alle in één keer): proposal, design, delta-specs, en tasks.
+  </SetupStep>
+  <SetupStep title="Plan — zet tasks om in een traceerbare issue">
+    <code>/opsx-plan-to-issues</code>. Zet <code>tasks.md</code> om in een <code>plan.json</code> en een GitHub-issue zodat voortgang zichtbaar is.
+  </SetupStep>
+  <SetupStep title="Apply — implementeer naar de spec">
+    <code>/opsx-apply</code>. De enige fase die code schrijft. Loopt door de takenlijst, landt declaratieve wijzigingen eerst, vinkt elke taak af zodra die klaar is.
+  </SetupStep>
+  <SetupStep title="Verify — controleer of code overeenkomt met de artifacten">
+    <code>/opsx-verify</code>. Bevestigt dat de implementatie aan elke requirement in de spec voldoet voordat er iets gearchiveerd wordt.
+  </SetupStep>
+  <SetupStep title="Archive — voeg de delta in de levende spec">
+    <code>/opsx-archive</code>. De delta vouwt zich in <code>specs/&lt;capability&gt;/spec.md</code> en de change verhuist naar <code>changes/archive/</code>. De levende spec is weer waar.
+  </SetupStep>
+</SetupSteps>
+
+De twee ADR-lagen voeden *elke* fase — explore leest ze om je idee uit te dagen, apply gehoorzaamt ze tijdens het implementeren, verify toetst er tegen. En de fases komen alle samen op dezelfde twee outputs uit: een **manifest**-wijziging en een **schema**-wijziging. Code en workflows zijn de optionele staart, die alleen bereikt wordt wanneer de declaratieve oppervlakken het gedrag niet kunnen uitdrukken.
+
+<BrowserOnly>
+{() => {
+  require('@conduction/docusaurus-preset/diagrams');
+  return (
+  <div style={{ background: 'var(--c-cobalt-50)', borderRadius: '12px', padding: '0.5rem 0', margin: '1.5rem 0' }}>
+    <cn-domain-tree>
+      <cn-hex slot="apex" size="xl">Org + app ADR's</cn-hex>
+      <cn-hex size="md" variant="outline">Explore</cn-hex>
+      <cn-hex size="md" variant="outline">Scaffold</cn-hex>
+      <cn-hex size="md" variant="outline">Apply</cn-hex>
+      <cn-hex size="md" variant="outline">Verify</cn-hex>
+    </cn-domain-tree>
+    <cn-domain-tree compact>
+      <cn-hex slot="apex" size="xl" color="orange">opsx apply</cn-hex>
+      <cn-hex size="md" color="orange">Manifest-wijziging</cn-hex>
+      <cn-hex size="md" color="orange">Schema-wijziging</cn-hex>
+      <cn-hex size="md" color="forest" variant="outline">Code (optioneel)</cn-hex>
+      <cn-hex size="md" color="forest" variant="outline">Workflows (optioneel)</cn-hex>
+
+      <span slot="legend">ADR's (boven) sturen elke opsx-fase</span>
+      <span slot="legend">Apply (oranje) levert eerst configuratie</span>
+      <span slot="legend">Code / workflows (groen) alleen wanneer nodig</span>
+    </cn-domain-tree>
+  </div>
+  );
+}}
+</BrowserOnly>
+
+Of die optionele staart überhaupt bereikbaar is, hangt af van *wie er bouwt*. Een developer die in code werkt kan terugvallen op PHP of een workflow wanneer het declaratieve pad uitgeput raakt. Een citizen developer in de **app builder** ziet die staart helemaal niet — voor hem is manifest + schema + een aangewezen workflow het hele oppervlak.
+
+## De explore-skill: een houding, geen workflow
+
+Voordat je een proposal schrijft, moet je meestal eerst **nadenken**. Daar is `/opsx-explore` voor. Roep het aan met een vaag idee, een halfbakken probleem, een architectuurvergelijking, of helemaal geen onderwerp:
+
+```
+/opsx-explore Moeten we onze bestaande notificatieservice hergebruiken voor de
+              nieuwe SLA-overschrijdingsmeldingen, of iets specifieks bouwen?
+```
+
+`/opsx-explore` is een **houding**, geen workflow — de eigen SKILL.md opent met dat onderscheid. De agent gaat in een denkmodus: laadt stilletjes de projectcontext, de relevante ADR's, de architectuurdocumenten, en eventuele aangrenzende specs; tekent ASCII-diagrammen om de topologie te verhelderen; daagt je aannames uit; brengt risico's aan de oppervlakte; en volgt het gesprek waar het maar heen gaat. Het is expliciet verboden om tijdens verkenning code te schrijven of features te implementeren. Het **mag** OpenSpec-artifacten creëren (een proposal, een design, een spec) wanneer je vraagt om vast te leggen wat jullie samen hebben uitgewerkt.
+
+Wanneer het denken kristalliseert tot "OK, dit is de feature die we moeten bouwen," groeit de explore-houding door naar een van twee volgende skills: `/opsx-ff` fast-forwardt door elk artefact in één pas (proposal + delta-specs + design + tasks), of `/opsx-new` loopt er samen met jou stap voor stap door. Hoe dan ook is de overgang van "denken" naar "scaffolden" expliciet.
+
+Gebruik `/opsx-explore` wanneer de vraag groter is dan het antwoord. Pak het op voordat je een `proposal.md` opent, niet erna. Het uur dat je hier investeert verdient zich tienvoudig terug wanneer de apply-fase niet hoeft over te doen omdat de spec verkeerd was.
+
+## De apply-skill: implementeer naar de spec
+
+Zodra een change een proposal, een design, delta-specs, en een tasks-lijst heeft, doet `/opsx-apply <change-name>` de implementatie:
+
+```
+/opsx-apply add-sla-breach-alerts
+```
+
+De skill laadt de change, loopt `tasks.md` van boven naar beneden door, schrijft code op een feature-branch, vinkt elke taak `[ ] → [x]` af onderweg, houdt de checkboxes in het GitHub-tracking issue gesynchroniseerd, draait aan het eind `composer check:strict` (of `make check-strict` voor Python ExApps), en plaatst een voortgangscommentaar op de issue. Het is de **enige** skill in de familie die code mag schrijven; alles anders is read-only of scaffoldt Markdown.
+
+`/opsx-apply` draait in twee modi die dezelfde SKILL.md delen: interactief vanuit je CLI, of headless binnen Hydra's CI-builder-container. Het headless-modus-contract garandeert identiek gedrag in beide gevallen — wat je lokaal kunt testen is wat productie draait.
+
+### Code alleen wanneer het moet — de ADR-031-hefboom
+
+De "code alleen wanneer het moet"-framing wordt **gecodificeerd door ADR-031**, niet door het app-manifest. Twee oppervlakken regelen verschillende dingen, en beide zijn declaratief:
+
+- **`src/manifest.json`** (ADR-024) declareert de **navigatie, routing, en paginacompositie** van de app — left-nav-items, route-naar-pagina-mappings, per-pagina slot-overrides. CnAppRoot leest het en mount de juiste gestapelde view per route. Voeg een scherm toe door JSON aan te passen.
+- **`lib/Settings/{app}_register.json`** (ADR-031) declareert de **business logic** van de app als `x-openregister-*`-extensies op elk schema: `x-openregister-lifecycle` voor state machines, `x-openregister-aggregations` voor berekende velden, `x-openregister-calculations` voor afgeleide waarden, `x-openregister-notifications` voor uitgaande berichten, `x-openregister-relations` voor cross-schema links, `x-openregister-widgets` voor dashboard-tegels. De apply-skill is verplicht om lifecycle, aggregations, calculations, notifications, declaratieve relaties, en dashboard-widgets uit te drukken als register-patches **in plaats van als nieuwe `lib/Service/*Service.php`-klassen**.
+
+Imperatieve PHP/Vue-code is de terugval wanneer het declaratieve pad het gedrag echt niet kan uitdrukken: integratie met externe API's, documentgeneratie, NLP, lifecycle-guards met niet-triviale preconditions. ADR-031 somt de uitzonderingen op; alles daarbuiten MOET declaratief zijn. De apply-skill dwingt dit af, de reviewer-skill controleert het dubbel, en de harness weigert om overtredingen te mergen.
+
+### Windmill en n8n: het code-loze pad voor business logic
+
+De interessantste consequentie van ADR-031 is dat **niet-triviale business logic helemaal geen PHP hoeft te zijn**. Voor workflows — opeenvolgingen van stappen, conditionele vertakkingen, externe calls, asynchrone overdrachten — exposed OpenRegister een `WorkflowEngineInterface` met adapters voor **n8n** en **Windmill**. Schemas declareren workflow-hooks:
+
+```json
+"x-openregister-hooks": {
+  "afterCreate": {
+    "engine": "n8n",
+    "workflowId": "melding-notificatie",
+    "params": { "channel": "email" }
+  }
+}
+```
+
+Wanneer een object van dat schema wordt aangemaakt, emit OpenRegisters `HookExecutor` een CloudEvent, de `n8n`-adapter ontvangt die, de visuele workflow-editor van n8n verzorgt de orkestratie, en het resultaat rijdt terug in OR. Hetzelfde patroon werkt met Windmill (TypeScript / Python / Go-scripts op een visueel canvas) voor zwaarder rekenwerk.
+
+De spec voor dit fleet-brede consumption-patroon leeft in Hydra in `openspec/changes/consume-or-workflow-engine-fleet-wide/`. De regel die hij codificeert: **apps mogen NIET rechtstreeks n8n, Windmill, of welke andere workflow-engine dan ook aanroepen via HTTP vanuit PHP service-klassen**. Alle workflow-executie MOET getriggerd worden via schema-hooks die gekoppeld zijn aan OpenRegisters `WorkflowEngineInterface`. Apps die workflow-logica nodig hebben voegen een hook-declaratie toe aan het schema-register; ze schrijven nooit `curl`-code tegen n8n.
+
+Dit is wat **OpenBuilt** — Conductions visuele app-builder — mogelijk maakt. Een citizen developer sleept schemas op een canvas, wijst workflow-hooks naar n8n-workflows aan, en levert een werkende app op **zonder ook maar één regel code te schrijven**. De "code alleen wanneer het moet"-belofte wordt letterlijk: er is geen code in de app om te schrijven, omdat het schema-register + de n8n-workflow + het manifest al alles afdekken wat een LLM (of een mens, of OpenBuilt) nodig heeft om een complete app te produceren.
+
+→ [OpenBuilt](https://conduction.nl/apps/openbuilt) — de visuele app-builder. Hetzelfde OpenSpec-contract, hetzelfde schema-register, dezelfde workflow-engine-adapters; alleen geen JSON-editor.
+
+## De kwaliteits- en gatekeeping-harness
+
+Een spec-gedreven workflow zonder handhaving is gewoon een chique manier om je eigen regels te negeren. Hydra's kwaliteits- en gatekeeping-harness maakt de discipline echt. Hij draait in twee lagen, sequentieel, met een hard **no-loop beleid** (ADR-013): elke transitie is one-shot, geen automatische retries, fouten escaleren naar mensen.
+
+### Laag A — mechanische gates
+
+Dertien benoemde gates, gedraaid via één gedeeld script. Elk is klein, snel, deterministisch, en draait tegen de PR-diff (per ADR-020, tenzij een full-repo-scope wordt gevraagd):
+
+1. **`spdx`** — elk PHP-bestand onder `lib/` draagt `SPDX-License-Identifier: EUPL-1.2` + `@copyright`.
+2. **`forbidden-patterns`** — geen `var_dump`, `die`, `error_log`, `print_r`, `dd`, `dump` in productiecode.
+3. **`stub-scan`** — geen "In a complete implementation"-commentaren, geen lege `run()`-bodies, geen hardgecodeerde fetch-stubs.
+4. **`composer-audit`** — `composer audit` rapporteert nul bekende CVE's in `composer.lock`.
+5. **`route-auth`** — elke gerouteerde controller-methode declareert zijn auth-houding (`#[PublicPage]`, `#[NoAdminRequired]`, `#[NoCSRFRequired]`, `#[AuthorizedAdminSetting]`). Zonder de annotatie wordt het endpoint stilletjes onbereikbaar; geobserveerd op decidesk#47.
+6. **`orphan-auth`** — auth/validatie-service-methodes gedefinieerd maar nooit aangeroepen. Equivalent met helemaal geen check (OWASP A01:2021).
+7. **`no-admin-idor`** — `#[NoAdminRequired]`-controllers MOETEN een per-object-guard dragen.
+8. **`unsafe-auth-resolver`** — `catch (\Throwable) { return null; }` op auth-resolvers is verboden (silent-fail-open / CWE-863).
+9. **`semantic-auth`** — de auth-annotatie komt overeen met wat de method-body daadwerkelijk vereist, niet zomaar *een* annotatie.
+10. **`initial-state`** — server-data stroomt via `IInitialState::provideInitialState()` + `loadState()`, nooit via DOM `data-*`-reads.
+11. **`admin-router`** — admin Vue-componenten MOGEN NIET geregistreerd worden in `src/router/index.js`.
+12. **`nc-input-labels`** — elke `<NcSelect>` heeft `inputLabel` / `ariaLabelCombobox` (WCAG 2.1 AA 1.3.1 + 4.1.2).
+13. **`modal-isolation`** — `<NcModal>` leeft in `src/modals/`, `<NcDialog>` in `src/dialogs/`, nooit inline (ADR-004 harde regel).
+
+Plus de per-taal strikte suites: PHP draait `composer check:strict` (PHPCS PSR-12, PHPMD ≥80%, Psalm errorLevel 4, PHPStan level 5, PHPUnit). Frontend draait `npm run lint` + `npm run stylelint`. Python ExApps draaien `make check-strict`. Deze draaien **binnen** de apply-skill aan het einde van de implementatie, en draaien **opnieuw** in de orchestrator als `quality-recheck` *nadat* de reviewers klaar zijn. De recheck bestaat omdat reviewers gezien zijn die gates oversloegen wanneer hun aandacht zich richtte op het diff-narratief — de orchestrator vangt het gat op.
+
+### Laag B — oordeelsreviews
+
+De mechanische gates zijn noodzakelijk maar niet voldoende. Een diff kan elke statische check doorstaan en toch fout zijn. Drie oordeelsslagen volgen, elk een container-persona:
+
+1. **`code-review:queued` → `team-reviewer`** (persona: Juan Claude van Damme, Claude Sonnet). Draait de PHP- en JS-pipelines opnieuw, scoort composite quality (≥90% om te slagen), loopt vervolgens een handmatige checklist van 30+ items af: constructor DI, named-argument-hygiëne, controller-dikte, Pinia boven Vuex, native `fetch` boven axios, EUPL-1.2-headers, NLGov REST-regels, WCAG 2.1 AA, AVG/GDPR, OWASP ASVS Level 2, BIO2 / ISO 27002:2022. Heeft begrensde fix-autoriteit (ADR-021): kan fixes rechtstreeks naar de PR-branch pushen, gescoped op de vorm van de change.
+2. **`security-review:queued` → `team-security`** (persona: Clyde Barcode, Sonnet, fallback Opus). Dezelfde begrensde fix-autoriteit, gescoped op security-findings: threat-model, secret-handling, input-validatie, encryption-at-rest, sessie-hygiëne.
+3. **`applier:queued` → applier-persona** (Axel Pliér, Sonnet, fallback Opus, **geen Write/Edit-tools**). Leest de post-fix-diff en geeft een binair `{pass, blocking[]}`-oordeel. De applier kan geen code schrijven; zijn enige taak is beoordelen of de fixes van de twee voorgaande reviewers daadwerkelijk gelandd zijn.
+
+De label-state-machine is de enkele bron van waarheid voor welke fase een PR in zit: `build:queued → build:running → build:pass → code-review:queued → … → security-review:pass → applier:queued → applier:pass → done`. Als een van beide reviewers faalt, wordt de applier overgeslagen en gaat de PR naar `needs-input` — mensen nemen het over in plaats van dat het systeem in een loop terechtkomt.
+
+### Waarom dit een complete loop is
+
+De mechanische gates vangen de dingen die een reviewer kan missen. De oordeelsreviewers vangen de dingen die een statische check niet kan zien. De applier vangt het geval waarin een reviewer iets signaleerde maar de fix niet daadwerkelijk landde. Quality-recheck vangt het geval waarin een reviewer een gate oversloeg. De label-machine voorkomt dat het geheel stilletjes in een loop draait wanneer er iets misgaat.
+
+Wanneer dit werkt — en het werkt op elke PR die Conduction levert — is de rol van de mens precies die waarmee deze tutorial opende: **schrijf de spec, zet de ADR's, laat de AI implementeren**. De harness doet de rest.
+
+## Van feature-aanvraag tot opgeleverde functionaliteit
+
+Samengevoegd is de hele reis één pipeline. Een feature-aanvraag komt binnen; een explore-sessie zet die om in een spec onder de staande ADR's; apply implementeert het als manifest- + schema-wijzigingen (met code of een workflow alleen wanneer nodig); de kwaliteits- en gatekeeping-harness valideert het; en werkende functionaliteit gaat live. De mens schreef de context aan het begin. Alles na de spec was de agent en de harness.
+
+<BrowserOnly>
+{() => {
+  require('@conduction/docusaurus-preset/diagrams');
+  return (
+  <div style={{ background: 'var(--c-cobalt-50)', borderRadius: '12px', padding: '1rem', margin: '1.5rem 0', overflowX: 'auto' }}>
+    <cn-pipeline>
+      <cn-hex color="lavender">Feature-aanvraag</cn-hex>
+      <cn-hex color="cobalt">Explore → spec</cn-hex>
+      <cn-hex color="cobalt">Apply → manifest + schema</cn-hex>
+      <cn-hex color="forest">Kwaliteit + gatekeeping-harness</cn-hex>
+      <cn-hex color="mint">Functionaliteit opgeleverd</cn-hex>
+      <span slot="caption">ADR's sturen elke fase; code en workflows vormen het optionele midden, alleen bereikt wanneer configuratie het gedrag niet kan uitdrukken.</span>
+    </cn-pipeline>
+  </div>
+  );
+}}
+</BrowserOnly>
+
+## Het eindpunt: configuratie boven code
+
+Spec-gedreven ontwikkeling klapt in de limiet ineen tot een vraag over *waar de context leeft*. Je kunt het manifest met de hand schrijven. Je kunt een LLM vragen om het voor je te schrijven. Je kunt schemas op OpenBuilts canvas slepen. Drie verschillende oppervlakken, één identiek artefact: een schema-register, een app-manifest, en een map met OpenSpec-specs + ADR's. Alle drie zijn ze round-trip; geen van drieën sluit je op.
+
+Dat is wat de bijbehorende architectuurpagina op [nextcloud-vue.conduction.nl/docs/architecture/configuration-over-code](https://nextcloud-vue.conduction.nl/docs/architecture/configuration-over-code/) "de runtime blijft van de library, de sandbox blijft van het platform" noemt. Spec-gedreven ontwikkeling is de **methode**. Configuratie boven code is het **gevolg**. OpenBuilt is het **oppervlak** dat het toegankelijk maakt voor zowel niet-engineers als AI-agents.
+
+De reden dat dit nu telt: een LLM met een schoon manifest-schema, een complete set ADR's, en de apply-skill kan in één keer een werkende Conduction-app produceren. Niet "een startpunt." Een werkende app. Hoe smaller we het contract maken, hoe breder we het auteursoppervlak maken.
+
+## Waar nu naartoe
+
+<NextSteps>
+  <NextStep title="Lees configuration-over-code" href="https://nextcloud-vue.conduction.nl/docs/architecture/configuration-over-code/">
+    De bijbehorende architectuurpagina op nextcloud-vue.conduction.nl. Laat zien hoe de OpenSpec-workflow landt in het manifest- + schema-register-contract op de app-laag.
+  </NextStep>
+  <NextStep title="Open OpenBuilt" href="https://conduction.nl/apps/openbuilt">
+    De visuele app-builder. Dezelfde OpenSpec-artifacten, geen JSON-editor. Ontworpen voor citizen developers en AI-gedreven generatie.
+  </NextStep>
+  <NextStep title="Loop een echte OpenSpec-change door" href="https://github.com/ConductionNL/hydra/tree/main/openspec/changes">
+    De "consume OR workflow engine fleet-wide"-change is een compleet, echt voorbeeld: proposal, design, delta-specs, tasks. Gebruik die als template de volgende keer dat je er een schrijft.
+  </NextStep>
+  <NextStep title="Probeer /opsx-explore in je eigen repo" href="https://github.com/ConductionNL/hydra/blob/main/.claude/skills/opsx-explore/SKILL.md">
+    Lees de skill-prompt, en roep die aan in Claude Code tegen je eigen app. De houding is het makkelijkste deel van de workflow om je eigen te maken.
+  </NextStep>
+</NextSteps>

--- a/i18n/nl/docusaurus-plugin-content-pages/connext.mdx
+++ b/i18n/nl/docusaurus-plugin-content-pages/connext.mdx
@@ -111,19 +111,19 @@ import {totalPartners} from '@site/src/data/partners-catalog';
   />
   <PairRow columns={3}>
     <PairCard
-      href="/academy/nextcloud-lokaal-draaien"
+      href="/nl/academy/nextcloud-lokaal-draaien"
       icon={<svg viewBox="0 0 24 24"><rect x="3" y="4" width="18" height="14" rx="2"/><path d="M3 9h18M8 4v5M16 4v5"/><path d="M8 14h3M8 17h6"/></svg>}
       name="Tutorial 1 · Draai Nextcloud lokaal"
       why="Drie commando's, een kwartier. Zet een schone Nextcloud op localhost op, klaar om tegenaan te ontwikkelen."
     />
     <PairCard
-      href="/academy/deskdesk-tutorial-1-scaffold"
+      href="/nl/academy/deskdesk-tutorial-1-scaffold"
       icon={<svg viewBox="0 0 24 24"><path d="M14.7 6.3a4 4 0 1 0-5.4 5.4l-7 7v3h3l7-7a4 4 0 0 0 5.4-5.4z"/><path d="M5 19l3-3"/></svg>}
       name="Tutorial 2 · Bouw je eerste app"
       why="Een zesdelige walkthrough van een blanco template naar een werkende DeskDesk-app op de volledige Conduction-stack."
     />
     <PairCard
-      href="/academy/deskdesk-tutorial-6-integrate"
+      href="/nl/academy/deskdesk-tutorial-6-integrate"
       icon={<svg viewBox="0 0 24 24"><path d="M10 13a5 5 0 0 0 7 0l3-3a5 5 0 0 0-7-7l-1 1"/><path d="M14 11a5 5 0 0 0-7 0l-3 3a5 5 0 0 0 7 7l1-1"/></svg>}
       name="Tutorial 3 · Integreer met je stack"
       why="Lees over registers heen, neem data uit xWiki op via OpenConnector, en sluit de cirkel met een webhook terug naar OpenRegister."

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@docusaurus/types": "^3.5.0"
       },
       "engines": {
-        "node": ">=18.0"
+        "node": ">=20.0"
       }
     },
     "node_modules/@algolia/abtesting": {
@@ -16050,6 +16050,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/search-insights": {
+      "version": "2.17.3",
+      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.3.tgz",
+      "integrity": "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/section-matter": {
       "version": "1.0.0",


### PR DESCRIPTION
## Summary

Builds out the missing Dutch/English pairs for the academy posts that
were drafted in only one language. Every academy post now has both
`academy/<slug>/` (English) and `i18n/nl/.../<slug>/` (Dutch) with
matching slugs so the locale switcher resolves consistently.

**English translations** (from Dutch sources that were sitting in `academy/`):
- Hydra leerlijn parts 1–6 (parts 2 + 6 expanded with label-cleanup prereq for retry/rebuild triggers)
- OpenSpec leerlijn parts 1–2
- Claude Skills leerlijn parts 1–4
- `openwoo-community-meetings`

**Dutch translations** of EN-original posts:
- `deskdesk-tutorial-0-three-paths`
- `deskdesk-tutorial-5-advanced-manifest`
- `the-platform-moment`
- `spec-driven-development`

**Dutch copies** of the Dutch-sourced posts (now properly under `i18n/nl/`):
- All 12 Hydra/OpenSpec/Claude Skills posts

**Link localization sweep** (separate but co-located):
- `/academy/<slug>` → `/nl/academy/<slug>` in `href` attributes and markdown
  links across all 23 NL blog posts (61 occurrences). Authored absolute
  links don't auto-localize the way Docusaurus's `<Link>`/paginator do,
  so each NL page must point at `/nl/` explicitly. This also fixes the
  same latent bug in pre-existing NL files.
- Same fix in `i18n/nl/.../docusaurus-plugin-content-pages/connext.mdx`

**Theme i18n string** in `i18n/nl/code.json`:
- `theme.academy.seriesLabel.deskdesk` → "Bouw een Nextcloud-app"
  Matches the `translate()` call introduced in the BlogListPage swizzle
  on #38. Without this entry the Dutch series chip falls back to English.

## Dependency on #38

This branch was cut from `tutorial/openspec-introductie` after the locale-aware
`useBaseUrl()` theme fixes landed (commit `4e6bdc8e`). The link sweep on the
NL files relies on those theme fixes to make breadcrumbs and the "View all"
button locale-aware. Once #38 merges, this PR's diff narrows to just the
i18n content.

## Test plan
- [x] `npm run build` succeeds for both locales
- [x] `npm run serve` → `localhost:3000/academy/<slug>/` (EN) and
      `localhost:3000/nl/academy/<slug>/` (NL) both render
- [x] In any NL post, in-page links to other academy posts go to
      `/nl/academy/...` not `/academy/...`
- [x] Locale switcher (top-right) jumps to the EN/NL equivalent of the current page

🤖 Generated with [Claude Code](https://claude.com/claude-code)